### PR TITLE
Dont use type_changing_struct_update on stable rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 

--- a/crates/bcr-wallet-core/scripts/build_mac.sh
+++ b/crates/bcr-wallet-core/scripts/build_mac.sh
@@ -2,4 +2,4 @@
 export RUSTFLAGS='--cfg getrandom_backend="wasm_js"'
 export AR=/opt/homebrew/opt/llvm/bin/llvm-ar
 export CC=/opt/homebrew/opt/llvm/bin/clang
-wasm-pack build --target web --dev
+wasm-pack build --target web --release

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(type_changing_struct_update)]
 // TODO use async trait
 #![allow(async_fn_in_trait)]
 

--- a/crates/bcr-wallet-core/src/wallet/builder.rs
+++ b/crates/bcr-wallet-core/src/wallet/builder.rs
@@ -47,7 +47,9 @@ impl<T: WalletType, DB: WalletDatabase> WalletBuilder<UnitSet, T, DB> {
         WalletBuilder {
             mint_url: Some(mint_url),
             _marker: PhantomData,
-            ..self
+            database: self.database,
+            seed: self.seed,
+            unit: self.unit,
         }
     }
 }
@@ -57,7 +59,9 @@ impl<T: WalletType, DB: WalletDatabase> WalletBuilder<Unconfigured, T, DB> {
         WalletBuilder {
             unit: Some(unit),
             _marker: PhantomData,
-            ..self
+            seed: self.seed,
+            database: self.database,
+            mint_url: self.mint_url,
         }
     }
 }
@@ -67,7 +71,9 @@ impl<T: WalletType, DB: WalletDatabase> WalletBuilder<MintSet, T, DB> {
         WalletBuilder {
             database: Some(db),
             _marker: PhantomData,
-            ..self
+            unit: self.unit,
+            mint_url: self.mint_url,
+            seed: self.seed,
         }
     }
 }
@@ -77,7 +83,9 @@ impl<T: WalletType, DB: WalletDatabase> WalletBuilder<DatabaseSet, T, DB> {
         WalletBuilder {
             seed: Some(seed),
             _marker: PhantomData,
-            ..self
+            mint_url: self.mint_url,
+            database: self.database,
+            unit: self.unit,
         }
     }
 }


### PR DESCRIPTION
Resolves a build error

```
error[E0554]: `#![feature]` may not be used on the stable release channel

 --> crates/bcr-wallet-core/src/lib.rs:1:1
  |
1 | #![feature(type_changing_struct_update)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```