### PR TITLE
[bcr-wallet-lib] refactor of Token

### DIFF
--- a/crates/bcr-wallet-core/src/wallet/api.rs
+++ b/crates/bcr-wallet-core/src/wallet/api.rs
@@ -1,14 +1,14 @@
 // ----- standard library imports
 use std::str::FromStr;
 // ----- extra library imports
-use cashu::{Amount, CheckStateRequest, CurrencyUnit, Proof, ProofsMethods, amount};
+use cashu::{Amount, CheckStateRequest, Proof, ProofsMethods, amount};
 use cdk::wallet::MintConnector;
 use tracing::{error, warn};
 // ----- local modules
 use super::types::SwapProofs;
 use super::{utils, wallet::*};
 use crate::db::{KeysetDatabase, WalletDatabase};
-use bcr_wallet_lib::wallet::{Token, TokenOperations};
+use bcr_wallet_lib::wallet::Token;
 
 // ----- end imports
 
@@ -187,13 +187,13 @@ where
         let token =
             Token::from_str(&token).map_err(|e| anyhow::anyhow!("Failed to parse token: {}", e))?;
 
-        if token.mint_url() == self.mint_url
-            && token.unit().to_string().to_lowercase() == "crsat"
-            && self.unit == CurrencyUnit::Sat
-        {
+        if token.mint_url() == self.mint_url && token.unit().as_ref() == Some(&self.unit) {
             // TODO Improve rules
             // Allow CRSAT -> SAT
-        } else if token.mint_url() != self.mint_url || token.unit() != self.unit {
+        } else if token.mint_url() != self.mint_url
+            || token.unit().is_none()
+            || token.unit().as_ref() != Some(&self.unit)
+        {
             tracing::error!( token_mint = ?token.mint_url(), token_unit = ?token.unit(),
                             wallet_mint = ?self.mint_url,
                             wallet_unit = ?self.unit,

--- a/crates/bcr-wallet-core/src/wallet/credit.rs
+++ b/crates/bcr-wallet-core/src/wallet/credit.rs
@@ -55,7 +55,7 @@ where
     Connector: cdk::wallet::MintConnector,
 {
     fn proofs_to_token(&self, proofs: Vec<Proof>, memo: Option<String>) -> Token {
-        Token::new_credit(self.mint_url.clone(), self.unit.clone(), memo, proofs)
+        Token::new_bitcr(self.mint_url.clone(), proofs, memo, self.unit.clone())
     }
     async fn swap_proofs_amount(
         &self,

--- a/crates/bcr-wallet-core/src/wallet/debit.rs
+++ b/crates/bcr-wallet-core/src/wallet/debit.rs
@@ -16,7 +16,7 @@ where
     Connector: cdk::wallet::MintConnector,
 {
     fn proofs_to_token(&self, proofs: Vec<Proof>, memo: Option<String>) -> Token {
-        Token::new_debit(self.mint_url.clone(), self.unit.clone(), memo, proofs)
+        Token::new_cashu(self.mint_url.clone(), proofs, memo, self.unit.clone())
     }
     async fn swap_proofs_amount(
         &self,


### PR DESCRIPTION
### **User description**
We very likely don't need to create BitcrV3 or support CashuV3 either, as they are reminiscence of previous version that have been superseeded by V4 and left in place only for backward compatibility with older mints

In our case we can ignore V3 and only use V4


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor Token implementation to remove V3 support

- Simplify token creation with new constructors

- Update token parsing to handle only V4 formats

- Improve unit validation in import functionality


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.rs</strong><dd><code>Update token import validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/wallet/api.rs

<li>Remove unused <code>CurrencyUnit</code> and <code>TokenOperations</code> imports<br> <li> Update token unit validation logic in <code>import_token</code> method<br> <li> Improve error handling for token unit comparison


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/37/files#diff-43133f18b5fc8e0991552622b70851c59c928ea4761f2980f4dc138ac8e46cbc">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>credit.rs</strong><dd><code>Update credit token creation method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/wallet/credit.rs

<li>Replace <code>Token::new_credit</code> with <code>Token::new_bitcr</code> constructor<br> <li> Update parameter order in token creation


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/37/files#diff-4970d9e85720db1648c5f39e303a7518bc25e07c52eedd0dec5ebaabaad3cca9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>debit.rs</strong><dd><code>Update debit token creation method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/wallet/debit.rs

<li>Replace <code>Token::new_debit</code> with <code>Token::new_cashu</code> constructor<br> <li> Update parameter order in token creation


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/37/files#diff-802ec7d6e05251579195e7305fca6a88d148a18380a48063831e1a4066c9dd0d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>token.rs</strong><dd><code>Complete token implementation refactor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-lib/src/wallet/token.rs

<li>Complete rewrite removing V3 token support<br> <li> Add separate <code>BitcrTokenV4</code> struct with custom serialization<br> <li> Implement new constructors <code>new_bitcr</code> and <code>new_cashu</code><br> <li> Simplify token parsing to handle only V4 formats


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/37/files#diff-2248b1537187a88e047f4516727c5ba41a84658c2cd12bc5258919fd7d4f294a">+231/-171</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>token.rs</strong><dd><code>Update tests for V4-only token support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-lib/tests/token.rs

<li>Update test cases to use V4 token strings<br> <li> Remove V3 to V4 conversion tests<br> <li> Add separate tests for BitcrV4 and CashuV4 tokens


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/37/files#diff-d4e78c8374d50116f14c661bb995d2d7787d7b62db698af0705b7d9fb3163d70">+45/-59</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>