### PR TITLE
[dependencies] upgrade cdk to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ async-trait = { version = "0.1" }
 bcr-wallet-lib = { path = "./crates/bcr-wallet-lib" }
 bip39 = "2.1"
 bitcoin = { version = "0.32" }
-cashu = { version = "0.9", default-features = false }
-cdk = { version = "0.9", default-features = false }
+cashu = { version = "0.11", default-features = false }
+cdk = { version = "0.11", default-features = false }
 chrono = { version = "0.4" }
 ciborium = "0.2"
 rand = { version = "0.8" }

--- a/crates/bcr-wallet-core/src/wallet/api.rs
+++ b/crates/bcr-wallet-core/src/wallet/api.rs
@@ -202,8 +202,9 @@ where
                 "Token mint_url or unit does not match wallet"
             ));
         }
-
-        self.import_proofs(token.proofs()).await?;
+        let keysets = self.connector.get_mint_keysets().await?.keysets;
+        let proofs = token.proofs(&keysets)?;
+        self.import_proofs(proofs).await?;
         Ok(())
     }
 

--- a/crates/bcr-wallet-lib/src/wallet/token.rs
+++ b/crates/bcr-wallet-lib/src/wallet/token.rs
@@ -6,8 +6,9 @@ use std::str::FromStr;
 use bitcoin::base64::engine::{GeneralPurpose, general_purpose};
 use bitcoin::base64::{Engine as _, alphabet};
 use cashu::{
-    Amount, CurrencyUnit, MintUrl, Proof, Proofs,
-    nut00::{Error, ProofsMethods, token::TokenV4Token},
+    Amount, CurrencyUnit, KeySetInfo, MintUrl, Proof, Proofs,
+    nut00::{Error, ProofV4, token::TokenV4Token},
+    nuts::Id,
 };
 use serde::{Deserialize, Serialize};
 // ----- local modules
@@ -80,10 +81,10 @@ impl Token {
         })
     }
     /// Proofs in [`Token`]
-    pub fn proofs(&self) -> Proofs {
+    pub fn proofs(&self, mint_keysets: &[KeySetInfo]) -> Result<Proofs, Error> {
         match self {
-            Self::BitcrV4(token) => token.proofs(),
-            Self::CashuV4(token) => token.proofs(),
+            Self::BitcrV4(token) => token.proofs(mint_keysets),
+            Self::CashuV4(token) => token.proofs(mint_keysets),
         }
     }
 
@@ -173,17 +174,19 @@ pub struct BitcrTokenV4 {
 
 impl BitcrTokenV4 {
     /// Proofs from token
-    pub fn proofs(&self) -> Proofs {
-        self.token
-            .iter()
-            .flat_map(|token| token.proofs.iter().map(|p| p.into_proof(&token.keyset_id)))
-            .collect()
+    pub fn proofs(&self, mint_keysets: &[KeySetInfo]) -> Result<Proofs, Error> {
+        let mut proofs: Proofs = vec![];
+        for t in self.token.iter() {
+            let long_id = Id::from_short_keyset_id(&t.keyset_id, mint_keysets)?;
+            proofs.extend(t.proofs.iter().map(|p| p.into_proof(&long_id)));
+        }
+        Ok(proofs)
     }
 
     /// Value - errors if duplicate proofs are found
     #[inline]
     pub fn value(&self) -> Result<Amount, Error> {
-        let proofs = self.proofs();
+        let proofs: Vec<&ProofV4> = self.token.iter().flat_map(|t| &t.proofs).collect();
         let unique_count = proofs
             .iter()
             .collect::<std::collections::HashSet<_>>()
@@ -194,9 +197,13 @@ impl BitcrTokenV4 {
             return Err(Error::DuplicateProofs);
         }
 
-        proofs.total_amount()
+        Ok(Amount::try_sum(
+            self.token
+                .iter()
+                .map(|t| Amount::try_sum(t.proofs.iter().map(|p| p.amount)))
+                .collect::<Result<Vec<Amount>, _>>()?,
+        )?)
     }
-
     /// Memo
     #[inline]
     pub fn memo(&self) -> &Option<String> {

--- a/crates/bcr-wallet-lib/tests/token.rs
+++ b/crates/bcr-wallet-lib/tests/token.rs
@@ -1,4 +1,5 @@
 use bcr_wallet_lib::wallet::*;
+use cashu::nut02 as cdk02;
 use std::str::FromStr;
 
 #[test]
@@ -17,7 +18,7 @@ fn test_token_str_round_trip_1() {
     //
     assert_eq!(
         inner.token[0].keyset_id,
-        cashu::Id::from_str("00ad268c4d1f5826").unwrap()
+        cdk02::ShortKeysetId::from_str("00ad268c4d1f5826").unwrap()
     );
     assert_eq!(inner.unit.clone(), cashu::CurrencyUnit::Sat);
 
@@ -44,7 +45,7 @@ fn test_token_str_round_trip_2() {
     //
     assert_eq!(
         inner.token[0].keyset_id,
-        cashu::Id::from_str("00ad268c4d1f5826").unwrap()
+        cdk02::ShortKeysetId::from_str("00ad268c4d1f5826").unwrap()
     );
     assert_eq!(
         inner.unit.clone(),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgrade CDK dependencies from 0.9 to 0.11

- Update token proof handling to use keyset validation

- Modify proof extraction to require mint keysets

- Fix keyset ID type changes in tests


___

### **Changes diagram**

```mermaid
flowchart LR
  A["CDK 0.9"] --> B["CDK 0.11"]
  C["Token.proofs()"] --> D["Token.proofs(keysets)"]
  E["Direct proof access"] --> F["Keyset-validated proofs"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update CDK dependencies to version 0.11</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<li>Upgrade <code>cashu</code> dependency from 0.9 to 0.11<br> <li> Upgrade <code>cdk</code> dependency from 0.9 to 0.11


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/38/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.rs</strong><dd><code>Add keyset validation for token proof import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/wallet/api.rs

<li>Fetch mint keysets before importing token proofs<br> <li> Pass keysets to <code>token.proofs()</code> method call<br> <li> Update proof extraction to use keyset validation


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/38/files#diff-43133f18b5fc8e0991552622b70851c59c928ea4761f2980f4dc138ac8e46cbc">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>token.rs</strong><dd><code>Update token proof handling with keyset validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-lib/src/wallet/token.rs

<li>Add <code>KeySetInfo</code> and <code>Id</code> imports from cashu<br> <li> Change <code>proofs()</code> method to require mint keysets parameter<br> <li> Update proof conversion to use long keyset IDs<br> <li> Modify value calculation to handle new proof structure


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/38/files#diff-2248b1537187a88e047f4516727c5ba41a84658c2cd12bc5258919fd7d4f294a">+20/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>token.rs</strong><dd><code>Fix keyset ID types in token tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-lib/tests/token.rs

<li>Add <code>cashu::nut02</code> import for <code>ShortKeysetId</code><br> <li> Update keyset ID type from <code>Id</code> to <code>ShortKeysetId</code>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/38/files#diff-d4e78c8374d50116f14c661bb995d2d7787d7b62db698af0705b7d9fb3163d70">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>