### PR TITLE
[bcr-wallet-core] remove duplicate code in receive_token

### DIFF
--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -40,6 +40,8 @@ pub enum Error {
     Any(AnyError),
     #[error("wallet at idx {0} not found")]
     WalletNotFound(usize),
+    #[error("empty token: {0}")]
+    EmptyToken(String),
     #[error("invalid token: {0}")]
     InvalidToken(String),
     #[error("no active keyset")]


### PR DESCRIPTION
### **User description**
move the logic that extracts proofs from token into the wallet


___

### **PR Type**
Enhancement


___

### **Description**
- Consolidate token processing logic into wallet layer

- Remove duplicate `receive_token` methods from pocket implementations

- Add empty token validation with new error type

- Centralize token type and currency unit validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Token Input"] --> B["Wallet receive_token()"]
  B --> C["Extract proofs from token"]
  C --> D["Validate token type & currency"]
  D --> E["Route to appropriate pocket"]
  E --> F["Pocket receive_proofs()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Add empty token error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/error.rs

- Add new `EmptyToken` error variant for tokens with no proofs


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/46/files#diff-41a47c543cd4184039a7149e812dd0ce9d9d9ed9e9c1925516401b1b502769f8">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pocket.rs</strong><dd><code>Remove duplicate token processing methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/pocket.rs

<ul><li>Remove <code>is_mine()</code> method from all pocket implementations<br> <li> Remove <code>receive_token()</code> method from CrPocket, DbPocket, and DummyPocket<br> <li> Update test names from <code>receive_token</code> to <code>receive_proofs</code><br> <li> Remove unused import <code>std::str::FromStr</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/46/files#diff-b1722775b65e61e55f7824715ef33c11925055195895347d18c4e2bac85bb4a9">+8/-64</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wallet.rs</strong><dd><code>Centralize token processing in wallet layer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/wallet.rs

<ul><li>Remove <code>is_mine()</code> and <code>receive_token()</code> from Pocket trait<br> <li> Refactor wallet's <code>receive_token()</code> to handle token parsing and <br>validation<br> <li> Add token type checking (CashuV4 vs BitcrV4) and currency unit <br>validation<br> <li> Route validated proofs to appropriate pocket's <code>receive_proofs()</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/46/files#diff-a728dbed0b385adf70434edb3f581a46a8ba286a76c7b6049469f1b36220caad">+26/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

