### PR TITLE
[bcr-wallet-core] refactor of wallet

### DIFF
--- a/crates/bcr-wallet-core/Cargo.toml
+++ b/crates/bcr-wallet-core/Cargo.toml
@@ -18,6 +18,7 @@ js-sys = "0.3"
 rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 rexie.workspace = true
+secp256k1.workspace = true
 serde-wasm-bindgen.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -60,6 +60,8 @@ pub enum Error {
     InactiveKeyset(cashu::Id),
     #[error("transaction not found {0}")]
     TransactionNotFound(cdk::wallet::types::TransactionId),
+    #[error("Mint not supporting debit currency")]
+    NoDebitCurrencyInMint(Vec<cashu::CurrencyUnit>),
 
     #[error("internal error: {0}")]
     Internal(String),

--- a/crates/bcr-wallet-core/src/pocket.rs
+++ b/crates/bcr-wallet-core/src/pocket.rs
@@ -643,16 +643,6 @@ impl CreditPocket for DummyPocket {
         Ok(Vec::new())
     }
 }
-#[async_trait(?Send)]
-impl DebitPocket for DummyPocket {
-    async fn reclaim_proofs(
-        &self,
-        _keysets_info: &[KeySetInfo],
-        _client: &dyn MintConnector,
-    ) -> Result<Amount> {
-        Ok(Amount::ZERO)
-    }
-}
 
 ///////////////////////////////////////////// clean_local_proofs
 async fn clean_local_proofs(

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -1,6 +1,7 @@
 // ----- standard library imports
 // ----- extra library imports
-use cashu::{Amount, CurrencyUnit};
+use bitcoin::bip32 as btc32;
+use cashu::{Amount, CurrencyUnit, MintUrl};
 use uuid::Uuid;
 // ----- local imports
 
@@ -35,4 +36,15 @@ impl PocketSendSummary {
             ..Default::default()
         }
     }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct WalletConfig {
+    pub wallet_id: String,
+    pub name: String,
+
+    pub mint: MintUrl,
+    pub debit_unit: CurrencyUnit,
+    pub credit_unit: Option<CurrencyUnit>,
+    pub master: btc32::Xpriv,
 }


### PR DESCRIPTION
Wallets and their mints always must provide a debit currency unit.

This commit makes the Wallet generic over the debit pocket as there is no need to have it dynamic.
We also refactor the AppState::add_wallet with more free functions in preparation for the AppStateDB