### PR TITLE
[bcr-wallet-core] finishing touch to wallet restore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cashu = { version = "0.11", default-features = false }
 cdk = { version = "0.11", default-features = false }
 cdk-common = { version = "0.11", default-features = false }
 ciborium = "0.2"
+futures = {version = "0.3"}
 getrandom = {version = "0.3"}
 mockall = {version  = "0.13"}
 rand = {version = "0.9"}

--- a/crates/bcr-wallet-core/Cargo.toml
+++ b/crates/bcr-wallet-core/Cargo.toml
@@ -12,6 +12,7 @@ bip39.workspace = true
 bitcoin.workspace = true
 cashu = { workspace = true, features = ["wallet"] }
 cdk = { workspace = true, features = ["wallet"] }
+futures = {workspace = true}
 rexie.workspace = true
 secp256k1.workspace = true
 serde-wasm-bindgen.workspace = true

--- a/crates/bcr-wallet-core/index.html
+++ b/crates/bcr-wallet-core/index.html
@@ -12,6 +12,7 @@
         </select>
         <button id="refreshbtn">Refresh</button>
         <button id="addbtn">Add wallet</button>
+        <button id="restorebtn">Restore wallet</button>
         <button id="removebtn">Remove wallet</button>
         <br></br>
         <button id="importbtn">Receive token</button>

--- a/crates/bcr-wallet-core/main.js
+++ b/crates/bcr-wallet-core/main.js
@@ -62,12 +62,21 @@ async function run() {
   }
 
   document.getElementById("addbtn").addEventListener("click", async () => {
-    //test
     let name = prompt("Enter wallet name");
     let mint_url = prompt("Enter mint url");
     let mnemonic = prompt("Enter mnemonic");
 
     await wasmModule.add_wallet(name, mint_url, mnemonic);
+    await update_wallets();
+    await format_past_txs();
+  });
+
+  document.getElementById("restorebtn").addEventListener("click", async () => {
+    let name = prompt("Enter wallet name");
+    let mint_url = prompt("Enter mint url");
+    let mnemonic = prompt("Enter mnemonic");
+
+    await wasmModule.restore_wallet(name, mint_url, mnemonic);
     await update_wallets();
     await format_past_txs();
   });


### PR DESCRIPTION
### **User description**
improve restore_keysetid to make it more testable
improve restore performances by running async functions in parallel with futures::JoinAll

add button in our test frontend


___

### **PR Type**
Enhancement


___

### **Description**
- Improve wallet restore performance with parallel async execution

- Make restore functions more testable with dependency injection

- Add restore button to test frontend interface

- Return count of restored proofs for better feedback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sequential Restore"] --> B["Parallel Restore"]
  B --> C["JoinAll Futures"]
  D["restore_keysetid"] --> E["inner_restore_keysetid"]
  E --> F["Testable Function"]
  G["Frontend"] --> H["Restore Button"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pocket.rs</strong><dd><code>Parallel restore execution with proof counting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/pocket.rs

<ul><li>Import <code>JoinAll</code> from futures crate<br> <li> Change <code>restore_local_proofs</code> return type from <code>()</code> to <code>usize</code><br> <li> Replace sequential loop with parallel execution using <code>JoinAll</code><br> <li> Return total count of recovered proofs</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/64/files#diff-b1722775b65e61e55f7824715ef33c11925055195895347d18c4e2bac85bb4a9">+21/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>restore.rs</strong><dd><code>Refactor restore logic for testability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/restore.rs

<ul><li>Extract <code>inner_restore_keysetid</code> for better testability<br> <li> Move counter management from <code>restore_batch</code> to caller<br> <li> Add comprehensive test suite for restore scenarios<br> <li> Improve function signatures with explicit parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/64/files#diff-13ea3cbbe5d3d917fcda5a83d8d10b45a635c81effd585b208db906620364097">+167/-42</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wallet.rs</strong><dd><code>Parallel wallet restore execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/wallet.rs

<ul><li>Update <code>restore_local_proofs</code> trait method return type to <code>usize</code><br> <li> Replace sequential await with <code>tokio::join!</code> for parallel execution</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/64/files#diff-a728dbed0b385adf70434edb3f581a46a8ba286a76c7b6049469f1b36220caad">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.js</strong><dd><code>Add restore wallet functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/main.js

<ul><li>Add event listener for restore button<br> <li> Remove test comment<br> <li> Call <code>restore_wallet</code> function with user inputs</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/64/files#diff-d6ecf7626504458e5f0177d1850f058aae84a8d346e5f6a7a3118f1006078b94">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add restore button to interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/index.html

- Add "Restore wallet" button to UI


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/64/files#diff-30b95db87952677f98e234017e752c3dbbda950c0e7040d72c528fd781c80421">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add futures dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

- Add `futures` dependency version 0.3


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/64/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add futures workspace dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/Cargo.toml

- Add `futures` workspace dependency


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/64/files#diff-663cb2a7378a6c3a4f5a754ee6cd1fd4f3e9add59e4080c64036662f5ee2e83d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

