### PR TITLE
[bcr-wallet-core] make traits Send + Sync

### DIFF
--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -17,6 +17,20 @@ pub mod wallet;
 
 const TEASER_SIZE: usize = 25;
 
+#[cfg(target_arch = "wasm32")]
+mod sync {
+    pub trait SendSync {}
+    impl<T> SendSync for T where T: ?Sized {}
+}
+#[cfg(not(target_arch = "wasm32"))]
+mod sync {
+    pub trait SendSync: Send + Sync {}
+    impl<T> SendSync for T where T: Send + Sync {}
+}
+
+pub trait MintConnector: cdk::wallet::MintConnector + sync::SendSync {}
+impl<T> MintConnector for T where T: cdk::wallet::MintConnector + sync::SendSync {}
+
 // --------------------------------------------------------------- initialize_api
 #[wasm_bindgen]
 pub async fn initialize_api(network: String) {

--- a/crates/bcr-wallet-core/src/pocket/mod.rs
+++ b/crates/bcr-wallet-core/src/pocket/mod.rs
@@ -7,10 +7,13 @@ use cashu::{
     Amount, CurrencyUnit, KeySet, KeySetInfo, amount::SplitTarget, nut00 as cdk00, nut01 as cdk01,
     nut03 as cdk03, nut07 as cdk07,
 };
-use cdk::wallet::MintConnector;
 use uuid::Uuid;
 // ----- local imports
-use crate::error::{Error, Result};
+use crate::{
+    MintConnector,
+    error::{Error, Result},
+    sync,
+};
 // ----- local modules
 pub mod credit;
 pub mod debit;
@@ -29,7 +32,7 @@ struct SendReference {
 #[cfg_attr(test, mockall::automock)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait PocketRepository {
+pub trait PocketRepository: sync::SendSync {
     async fn store_new(&self, proof: cdk00::Proof) -> Result<cdk01::PublicKey>;
     async fn store_pendingspent(&self, proof: cdk00::Proof) -> Result<cdk01::PublicKey>;
     async fn load_proof(&self, y: cdk01::PublicKey) -> Result<(cdk00::Proof, cdk07::State)>;

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -6,15 +6,13 @@ use bcr_wallet_lib::wallet::Token;
 use cashu::{
     Amount, Bolt11Invoice, CurrencyUnit, KeySetInfo, nut00 as cdk00, nut01 as cdk01, nut18 as cdk18,
 };
-use cdk::wallet::{
-    MintConnector,
-    types::{Transaction, TransactionDirection, TransactionId},
-};
+use cdk::wallet::types::{Transaction, TransactionDirection, TransactionId};
 use uuid::Uuid;
 // ----- local imports
 use crate::{
+    MintConnector,
     error::{Error, Result},
-    purse,
+    purse, sync,
     types::{
         PaymentType, PocketMeltSummary, PocketSendSummary, RedemptionSummary, SendSummary,
         WalletConfig, WalletPaymentSummary, WalletSendSummary,
@@ -25,8 +23,9 @@ use crate::{
 
 /// trait that represents a single compartment in our wallet where we store proofs/tokens of the
 /// same currency emitted by the same mint
-#[async_trait(?Send)]
-pub trait Pocket {
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait Pocket: sync::SendSync {
     fn unit(&self) -> CurrencyUnit;
 
     async fn balance(&self) -> Result<Amount>;
@@ -58,7 +57,8 @@ pub trait Pocket {
     ) -> Result<usize>;
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait CreditPocket: Pocket {
     fn maybe_unit(&self) -> Option<CurrencyUnit>;
     /// returns the amount reclaimed and the proofs that can be redeemed (i.e. unspent proofs with
@@ -82,7 +82,8 @@ pub trait CreditPocket: Pocket {
     ) -> Result<Vec<RedemptionSummary>>;
 }
 
-#[async_trait(?Send)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait DebitPocket: Pocket {
     async fn reclaim_proofs(
         &self,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add conditional Send + Sync trait bounds for non-WASM targets

- Replace async_trait(?Send) with conditional compilation attributes

- Remove concurrent processing in favor of sequential execution

- Update trait definitions to include SendSync bounds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sync module"] --> B["SendSync trait"]
  B --> C["MintConnector trait"]
  B --> D["Repository traits"]
  E["async_trait macros"] --> F["Conditional compilation"]
  G["Concurrent processing"] --> H["Sequential execution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add conditional sync traits and MintConnector wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/lib.rs

<ul><li>Add conditional <code>sync</code> module with <code>SendSync</code> trait<br> <li> Define <code>SendSync</code> as empty trait for WASM, <code>Send + Sync</code> for native<br> <li> Create <code>MintConnector</code> trait wrapper with <code>SendSync</code> bounds</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/69/files#diff-215a37c66b7040a141c225630bd02045caf1cf1f20ec88624fb33bbc5491f701">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>credit.rs</strong><dd><code>Update async traits and remove concurrent processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/pocket/credit.rs

<ul><li>Replace <code>async_trait(?Send)</code> with conditional compilation attributes<br> <li> Change from <code>JoinAll</code> concurrent processing to sequential iteration<br> <li> Update import to use local <code>MintConnector</code> trait</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/69/files#diff-9cfcfae3ef6fe248d343086e2dee504085dbc81457ec5e6b98a6a1ccc7f93616">+13/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>debit.rs</strong><dd><code>Add SendSync bounds and update async processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/pocket/debit.rs

<ul><li>Add <code>SendSync</code> bound to <code>MintMeltRepository</code> trait<br> <li> Replace <code>async_trait(?Send)</code> with conditional compilation<br> <li> Remove concurrent <code>JoinAll</code> processing for sequential execution<br> <li> Update imports to use local <code>MintConnector</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/69/files#diff-4e6f06900be2b435ce446adf18b2634ee588863817cfa96fd68972f5560659a5">+10/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add SendSync bounds to repository traits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/pocket/mod.rs

<ul><li>Add <code>SendSync</code> bound to <code>PocketRepository</code> trait<br> <li> Update imports to include local <code>MintConnector</code> and <code>sync</code><br> <li> Replace <code>async_trait(?Send)</code> with conditional compilation</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/69/files#diff-75cb8e6a50ed45d750da38a0c0725794db0e7f0682a40c7a7446a0564b24fb5d">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>restore.rs</strong><dd><code>Simplify restore logic and remove generic abstractions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/restore.rs

<ul><li>Remove generic <code>inner_restore_keysetid</code> function and <code>AsyncFn</code> abstraction<br> <li> Simplify <code>restore_keysetid</code> to call <code>restore_batch</code> directly<br> <li> Update test expectations to match new sequential behavior<br> <li> Update imports to use local <code>MintConnector</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/69/files#diff-13ea3cbbe5d3d917fcda5a83d8d10b45a635c81effd585b208db906620364097">+185/-83</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wallet.rs</strong><dd><code>Add SendSync bounds to wallet traits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/wallet.rs

<ul><li>Add <code>SendSync</code> bounds to <code>Pocket</code>, <code>CreditPocket</code>, and <code>DebitPocket</code> traits<br> <li> Replace <code>async_trait(?Send)</code> with conditional compilation attributes<br> <li> Update imports to use local <code>MintConnector</code> and include <code>sync</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/69/files#diff-a728dbed0b385adf70434edb3f581a46a8ba286a76c7b6049469f1b36220caad">+10/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

