### PR TITLE
[bcr-wallet-core] refactor of the payment APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ ciborium = "0.2"
 futures = {version = "0.3"}
 getrandom = {version = "0.3"}
 mockall = {version  = "0.13"}
+nostr-sdk = {version = "0.43", features = ["nip59"]}
 rand = {version = "0.9"}
+reqwest = {version = "0.12", features = ["json"]}
 rexie = { version = "0.6" }
 secp256k1 = { version = "0.29" }
 serde = { version = "1" }

--- a/crates/bcr-wallet-core/Cargo.toml
+++ b/crates/bcr-wallet-core/Cargo.toml
@@ -13,16 +13,20 @@ bitcoin.workspace = true
 cashu = { workspace = true, features = ["wallet"] }
 cdk = { workspace = true, features = ["wallet"] }
 futures = {workspace = true}
+nostr-sdk = {workspace =true}
+reqwest = {workspace = true}
 rexie.workspace = true
 secp256k1.workspace = true
 serde-wasm-bindgen.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tokio = {workspace = true}
 tracing-subscriber.workspace = true
 tracing-wasm.workspace = true
 tracing.workspace = true
 uuid = {workspace = true }
+url = {workspace = true}
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 

--- a/crates/bcr-wallet-core/src/app.rs
+++ b/crates/bcr-wallet-core/src/app.rs
@@ -7,20 +7,20 @@ use std::{
 };
 // ----- extra library imports
 use anyhow::Error as AnyError;
-use bcr_wallet_lib::wallet::Token;
 use bitcoin::{
     bip32 as btc32,
     hashes::{Hash, HashEngine, sha256},
     hex::DisplayHex,
 };
-use cashu::{CurrencyUnit, KeySetInfo, MintInfo, MintUrl};
+use cashu::{CurrencyUnit, KeySetInfo, MintInfo, MintUrl, nut18 as cdk18};
 use cdk::wallet::{
     MintConnector,
     types::{Transaction, TransactionId},
 };
+use nostr_sdk::nips::nip19::{FromBech32, Nip19Profile};
+use uuid::Uuid;
 // ----- local imports
 use crate::{
-    SendSummary,
     error::{Error, Result},
     types::{PaymentSummary, RedemptionSummary},
     wallet::{CreditPocket, Pocket, WalletBalance},
@@ -118,7 +118,11 @@ pub async fn initialize_api(network: String) {
         .await
         .expect("Failed to build app state DB");
 
-    let purse = ProductionPurse::new(pursedb);
+    let myself = Nip19Profile::from_bech32("nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p").expect("Nip19Profile");
+    let nostr = nostr_sdk::ClientBuilder::new().build();
+    let purse = ProductionPurse::new(pursedb, reqwest::Client::new(), nostr, myself)
+        .await
+        .expect("Purse::new");
     let mut appstate = AppState::new(net, Some(Arc::new(purse)));
     appstate
         .load_wallets()
@@ -133,6 +137,15 @@ fn get_wallet(idx: usize) -> Result<Arc<ProductionWallet>> {
             return Err(Error::Initialization);
         };
         purse.get_wallet(idx).ok_or(Error::WalletNotFound(idx))
+    })
+}
+
+fn get_purse() -> Result<Arc<ProductionPurse>> {
+    APP_STATE.with_borrow(|state| {
+        let Some(purse) = &state.purse else {
+            return Err(Error::Initialization);
+        };
+        Ok(Arc::clone(purse))
     })
 }
 
@@ -202,7 +215,7 @@ pub fn wallet_name(idx: usize) -> Result<String> {
 pub fn wallet_mint_url(idx: usize) -> Result<String> {
     tracing::debug!("mint_url for wallet {idx}");
     let wallet = get_wallet(idx)?;
-    Ok(wallet.url.to_string())
+    Ok(wallet.mint_url.to_string())
 }
 
 pub struct WalletCurrencyUnit {
@@ -233,34 +246,6 @@ pub async fn wallet_receive(idx: usize, token: String, tstamp: u64) -> Result<Tr
     let wallet = get_wallet(idx)?;
     let tx_id = wallet.receive_token(token, tstamp).await?;
     Ok(tx_id)
-}
-
-pub async fn wallet_prepare_send(idx: usize, amount: u64, unit: String) -> Result<SendSummary> {
-    tracing::debug!("wallet_prepare_send({idx}, {amount}, {unit})");
-
-    let amount = cashu::Amount::from(amount);
-    let unit = if unit.is_empty() {
-        None
-    } else {
-        Some(cashu::CurrencyUnit::from_str(&unit)?)
-    };
-    let wallet = get_wallet(idx)?;
-    let summary = wallet.prepare_send(amount, unit).await?;
-    Ok(SendSummary::from(summary))
-}
-
-pub async fn wallet_send(
-    idx: usize,
-    request_id: String,
-    memo: Option<String>,
-    tstamp: u64,
-) -> Result<(Token, TransactionId)> {
-    tracing::debug!("wallet_send({idx}, {request_id}, {:?}, {tstamp})", memo);
-
-    let rid = uuid::Uuid::from_str(&request_id)?;
-    let wallet = get_wallet(idx)?;
-    let (token, tx_id) = wallet.send(rid, memo, tstamp).await?;
-    Ok((token, tx_id))
 }
 
 pub async fn wallet_reclaim_funds(idx: usize) -> Result<WalletBalance> {
@@ -318,20 +303,52 @@ pub async fn wallet_list_tx_ids(idx: usize) -> Result<Vec<TransactionId>> {
     Ok(tx_ids)
 }
 
-pub async fn wallet_prepare_payment(idx: usize, input: String) -> Result<PaymentSummary> {
+pub async fn wallet_prepare_payment(idx: usize, input: String, now: u64) -> Result<PaymentSummary> {
     tracing::debug!("wallet_prepare_payment({idx}, {input})");
 
-    let wallet = get_wallet(idx)?;
-    let summary = wallet.prepare_payment(input).await?;
+    let purse = get_purse()?;
+    let summary = purse.prepare_pay(idx, input, now).await?;
     Ok(summary)
 }
 
-pub async fn wallet_pay(idx: usize, rid: String, tstamp: u64) -> Result<TransactionId> {
-    tracing::debug!("wallet_pay({idx}, {rid}, {tstamp})");
+pub async fn wallet_pay(rid: String, tstamp: u64) -> Result<TransactionId> {
+    tracing::debug!("wallet_pay({rid}, {tstamp})");
 
-    let rid = uuid::Uuid::from_str(&rid)?;
-    let wallet = get_wallet(idx)?;
-    let tx_id = wallet.pay(rid, tstamp).await?;
+    let purse = get_purse()?;
+    let rid = Uuid::from_str(&rid)?;
+    let tx_id = purse.pay(rid, tstamp).await?;
+    Ok(tx_id)
+}
+
+pub async fn wallet_prepare_pay_request(
+    idx: usize,
+    amount: u64,
+    unit: String,
+    description: String,
+) -> Result<cdk18::PaymentRequest> {
+    tracing::debug!("wallet_prepare_pay_request({idx}, {amount}, {unit}, {description})");
+
+    let amount = cashu::Amount::from(amount);
+    let unit = if unit.trim().is_empty() {
+        None
+    } else {
+        cashu::CurrencyUnit::from_str(&unit).ok()
+    };
+    let description = if description.trim().is_empty() {
+        None
+    } else {
+        Some(description.trim().to_string())
+    };
+    let purse = get_purse()?;
+    let request = purse.prepare_pay_request(amount, unit, description)?;
+    Ok(request)
+}
+
+pub async fn wallet_check_received_payment(p_id: String, tstamp: u64) -> Result<TransactionId> {
+    tracing::debug!("wallet_check_received_payment({p_id}, {tstamp})");
+
+    let purse = get_purse()?;
+    let tx_id = purse.check_received_payment(&p_id, tstamp).await?;
     Ok(tx_id)
 }
 
@@ -571,13 +588,12 @@ async fn build_wallet(
         network,
         mnemonic,
         client,
-        url: mint_url,
+        mint_url,
         tx_repo,
         debit: debit_pocket,
         credit: credit_pocket,
         name,
         id: wallet_id,
-        current_send: Mutex::new(None),
         current_payment: Mutex::new(None),
     };
     Ok(new_wallet)

--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -27,6 +27,16 @@ pub enum Error {
     BtcBip32(#[from] bitcoin::bip32::Error),
     #[error("uuid:: {0}")]
     Uuid(#[from] uuid::Error),
+    #[error("nostr::nip19 {0}")]
+    Nip19(#[from] nostr_sdk::nips::nip19::Error),
+    #[error("nostr-sdk::client {0}")]
+    NostrClient(#[from] nostr_sdk::client::Error),
+    #[error("serde_json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("reqwest::Url {0}")]
+    Url(#[from] url::ParseError),
+    #[error("reqwest::Client {0}")]
+    ReqwestClient(#[from] reqwest::Error),
 
     #[error("insufficient funds")]
     InsufficientFunds,
@@ -70,18 +80,24 @@ pub enum Error {
     NoDebitCurrencyInMint(Vec<cashu::CurrencyUnit>),
     #[error("network mismatch, ours: {0}, theirs: {1}")]
     InvalidNetwork(bitcoin::Network, bitcoin::Network),
-    #[error("bolt11 invoice, missing amount")]
-    Bolt11MissingAmount,
+    #[error("payment request, missing amount")]
+    MissingAmount,
     #[error("payment request unknown {0}")]
     UnknownPaymentRequest(String),
-    #[error("payment {0} expired {1}")]
-    PaymentExpired(uuid::Uuid, u64),
+    #[error("payment expired")]
+    PaymentExpired,
     #[error("melt op unpaid")]
     MeltUnpaid(String),
     #[error("melt op not found: {0}")]
     MeltNotFound(String),
     #[error("missing initialization")]
     Initialization,
+    #[error("inter-mint payment not supported yet")]
+    InterMint,
+    #[error("spending conditions not supported yet")]
+    SpendingConditions,
+    #[error("NUT-18 request has no transport")]
+    NoTransport,
 
     #[error("internal error: {0}")]
     Internal(String),

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -178,71 +178,85 @@ pub async fn wallet_reclaim_funds(idx: usize) -> WalletBalance {
     }
 }
 
-// --------------------------------------------------------------- wallet_prepare_send
+// --------------------------------------------------------------- wallet_prepare_pay
 #[wasm_bindgen]
 #[derive(Default)]
-pub struct SendSummary {
+pub struct PaySummary {
     #[wasm_bindgen(getter_with_clone)]
     pub request_id: String,
     #[wasm_bindgen(getter_with_clone)]
     pub unit: String,
     #[wasm_bindgen(readonly)]
-    pub send_fees: u64,
-    #[wasm_bindgen(readonly)]
-    pub swap_fees: u64,
+    pub fees: u64,
 }
 
-impl std::convert::From<types::SendSummary> for SendSummary {
-    fn from(summary: types::SendSummary) -> Self {
+impl std::convert::From<types::PaymentSummary> for PaySummary {
+    fn from(summary: types::PaymentSummary) -> Self {
         Self {
             request_id: summary.request_id.to_string(),
             unit: summary.unit.to_string(),
-            send_fees: summary.send_fees.into(),
-            swap_fees: summary.swap_fees.into(),
+            fees: summary.fees.into(),
         }
     }
 }
 
 #[wasm_bindgen]
-pub async fn wallet_prepare_send(idx: usize, amount: u64, unit: String) -> SendSummary {
-    let returned = app::wallet_prepare_send(idx, amount, unit.clone()).await;
+pub async fn wallet_prepare_pay(idx: usize, input: String, now: u32) -> PaySummary {
+    let teaser = input.chars().take(TEASER_SIZE).collect::<String>();
+    let returned = app::wallet_prepare_payment(idx, input, now as u64).await;
     match returned {
-        Ok(summary) => summary,
+        Ok(summary) => PaySummary::from(summary),
         Err(e) => {
-            tracing::error!("wallet_prepare_send({idx}, {amount}, {unit}): {e}");
-            SendSummary::default()
+            tracing::error!("wallet_prepare_pay({idx}, {teaser}): {e}");
+            PaySummary::default()
         }
     }
 }
 
-// --------------------------------------------------------------- wallet_send
+// --------------------------------------------------------------- wallet_pay
 #[wasm_bindgen]
-#[derive(Default)]
-pub struct TokenTxId {
-    #[wasm_bindgen(getter_with_clone)]
-    pub token: String,
-    #[wasm_bindgen(getter_with_clone)]
-    pub tx_id: String,
-}
-#[wasm_bindgen]
-pub async fn wallet_send(
-    idx: usize,
-    request_id: String,
-    tstamp: u32,
-    memo: Option<String>,
-) -> TokenTxId {
-    let returned = app::wallet_send(idx, request_id.clone(), memo.clone(), tstamp as u64).await;
+pub async fn wallet_pay(request_id: String, tstamp: u32) -> String {
+    let returned = app::wallet_pay(request_id.clone(), tstamp as u64).await;
     match returned {
-        Ok((token, tx_id)) => TokenTxId {
-            token: token.to_string(),
-            tx_id: tx_id.to_string(),
-        },
+        Ok(tx_id) => tx_id.to_string(),
+        Err(e) => {
+            tracing::error!("wallet_pay({request_id}, {tstamp}): {e}",);
+            String::default()
+        }
+    }
+}
+
+// --------------------------------------------------------------- wallet_prepare_pay_request
+#[wasm_bindgen]
+pub async fn wallet_prepare_pay_request(
+    idx: usize,
+    amount: u32,
+    unit: String,
+    description: String,
+) -> String {
+    let returned =
+        app::wallet_prepare_pay_request(idx, amount as u64, unit.clone(), description.clone())
+            .await;
+    match returned {
+        Ok(request) => request.to_string(),
         Err(e) => {
             tracing::error!(
-                "wallet_send({idx}, {request_id}, {tstamp}, {:?}): {e}",
-                memo
+                "wallet_prepare_pay_request({idx}, {amount}, {unit}, {description}): {e}",
             );
-            TokenTxId::default()
+            String::default()
+        }
+    }
+}
+
+// --------------------------------------------------------------- wallet_check_received_payment
+#[wasm_bindgen]
+pub async fn wallet_check_received_payment(payment_id: String, tstamp: u32) -> String {
+    let returned = app::wallet_check_received_payment(payment_id.clone(), tstamp as u64).await;
+    match returned {
+        Ok(tx_id) => tx_id.to_string(),
+        Err(e) => {
+            tracing::error!("wallet_check_received_payment({payment_id}, {tstamp}): {e}",);
+            String::default()
         }
     }
 }
@@ -346,57 +360,6 @@ pub async fn wallet_load_tx(idx: usize, tx_id: String) -> Transaction {
         }
     }
 }
-// --------------------------------------------------------------- wallet_prepare_payment
-#[wasm_bindgen]
-#[derive(Default)]
-pub struct PaymentSummary {
-    #[wasm_bindgen(getter_with_clone)]
-    pub request_id: String,
-    #[wasm_bindgen(getter_with_clone)]
-    pub unit: String,
-    #[wasm_bindgen(readonly)]
-    pub fees: u64,
-    #[wasm_bindgen(readonly)]
-    pub reserved_fees: u64,
-    #[wasm_bindgen(readonly)]
-    pub expiry: u64,
-}
-impl std::convert::From<types::PaymentSummary> for PaymentSummary {
-    fn from(summary: types::PaymentSummary) -> Self {
-        Self {
-            request_id: summary.request_id.to_string(),
-            unit: summary.unit.to_string(),
-            fees: summary.fees.into(),
-            reserved_fees: summary.reserved_fees.into(),
-            expiry: summary.expiry,
-        }
-    }
-}
-#[wasm_bindgen]
-pub async fn wallet_prepare_payment(idx: usize, input: String) -> PaymentSummary {
-    let teaser = input.chars().take(TEASER_SIZE).collect::<String>();
-    let returned = app::wallet_prepare_payment(idx, input).await;
-    match returned {
-        Ok(summary) => PaymentSummary::from(summary),
-        Err(e) => {
-            tracing::error!("wallet_prepare_payment({idx}, {teaser}): {e}");
-            PaymentSummary::default()
-        }
-    }
-}
-
-// --------------------------------------------------------------- wallet_pay
-#[wasm_bindgen]
-pub async fn wallet_pay(idx: usize, request_id: String, tstamp: u32) -> String {
-    let returned = app::wallet_pay(idx, request_id.clone(), tstamp as u64).await;
-    match returned {
-        Ok(tx_id) => tx_id.to_string(),
-        Err(e) => {
-            tracing::error!("wallet_pay({idx}, {request_id}, {tstamp}): {e}",);
-            String::default()
-        }
-    }
-}
 
 // --------------------------------------------------------------- wallet_check_pending_melts
 #[wasm_bindgen]
@@ -429,7 +392,7 @@ pub async fn wallet_list_tx_ids(idx: usize) -> Vec<String> {
 pub fn get_wallets_ids() -> Vec<u32> {
     let returned = app::wallets_ids();
     match returned {
-        Ok(indexes) => indexes.into_iter().map(|i| i as u32).collect(),
+        Ok(indexes) => indexes.into_iter().collect(),
         Err(e) => {
             tracing::error!("get_wallets_ids: {e}");
             Vec::default()

--- a/crates/bcr-wallet-core/src/purse.rs
+++ b/crates/bcr-wallet-core/src/purse.rs
@@ -1,15 +1,29 @@
 // ----- standard library imports
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 // ----- extra library imports
 use async_trait::async_trait;
+use cashu::{Amount, CurrencyUnit, MintUrl, nut00 as cdk00, nut18 as cdk18};
+use cdk::wallet::types::TransactionId;
+use nostr_sdk::nips::{
+    nip19::{Nip19Profile, ToBech32},
+    nip59::UnwrappedGift,
+};
+use uuid::Uuid;
 // ----- local imports
-use crate::{error::Result, types::WalletConfig};
+use crate::{
+    error::{Error, Result},
+    sync,
+    types::{PaymentSummary, WalletConfig},
+};
 
 // ----- end imports
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait PurseRepository {
+pub trait PurseRepository: sync::SendSync {
     async fn store(&self, wallet: WalletConfig) -> Result<()>;
     async fn load(&self, wallet_id: &str) -> Result<WalletConfig>;
     #[allow(dead_code)]
@@ -19,21 +33,64 @@ pub trait PurseRepository {
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait Wallet {
+pub trait Wallet: sync::SendSync {
     fn config(&self) -> WalletConfig;
     fn name(&self) -> String;
+    fn mint_url(&self) -> MintUrl;
+    async fn prepare_pay(&self, input: String, now: u64) -> Result<PaymentSummary>;
+    async fn pay(
+        &self,
+        p_id: Uuid,
+        nostr_cl: &nostr_sdk::Client,
+        http_cl: &reqwest::Client,
+        tstamp: u64,
+    ) -> Result<TransactionId>;
+
+    async fn receive_proofs(
+        &self,
+        proofs: Vec<cdk00::Proof>,
+        unit: CurrencyUnit,
+        tstamp: u64,
+        memo: Option<String>,
+        metadata: HashMap<String, String>,
+    ) -> Result<TransactionId>;
+}
+
+struct PaymentReference {
+    payment_ref: Uuid,
+    wallet_idx: usize,
 }
 
 pub struct Purse<PurseRepo, Wlt> {
     pub repo: PurseRepo,
-    pub wallets: Mutex<Vec<Arc<Wlt>>>,
+    pub wallets: Arc<Mutex<Vec<Arc<Wlt>>>>,
+    nostr_cl: Arc<nostr_sdk::Client>,
+    nostr_subid: nostr_sdk::SubscriptionId,
+    myself: Nip19Profile,
+    http_cl: Arc<reqwest::Client>,
+    current_payment: Mutex<Option<PaymentReference>>,
 }
 impl<PurseRepo, Wlt> Purse<PurseRepo, Wlt> {
-    pub fn new(repo: PurseRepo) -> Self {
-        Self {
+    pub async fn new(
+        repo: PurseRepo,
+        http_cl: reqwest::Client,
+        nostr_cl: nostr_sdk::Client,
+        myself: Nip19Profile,
+    ) -> Result<Self> {
+        let filter = nostr_sdk::Filter::new()
+            .kind(nostr_sdk::Kind::GiftWrap)
+            .pubkey(myself.public_key);
+        let output = nostr_cl.subscribe(filter, None).await?;
+
+        Ok(Self {
             repo,
-            wallets: Mutex::new(Vec::default()),
-        }
+            wallets: Arc::new(Mutex::new(Vec::default())),
+            nostr_cl: Arc::new(nostr_cl),
+            nostr_subid: output.id().clone(),
+            myself,
+            http_cl: Arc::new(http_cl),
+            current_payment: Mutex::new(None),
+        })
     }
 }
 
@@ -79,5 +136,143 @@ where
         let mut wallets = self.wallets.lock().unwrap();
         wallets.push(Arc::new(wallet));
         Ok(wallets.len() - 1)
+    }
+
+    pub async fn prepare_pay(&self, idx: usize, input: String, now: u64) -> Result<PaymentSummary> {
+        let Some(wlt) = self.wallets.lock().unwrap().get(idx).cloned() else {
+            return Err(Error::WalletNotFound(idx));
+        };
+        let summary = wlt.prepare_pay(input, now).await?;
+        let pref = PaymentReference {
+            payment_ref: summary.request_id,
+            wallet_idx: idx,
+        };
+        *self.current_payment.lock().unwrap() = Some(pref);
+        Ok(summary)
+    }
+
+    pub async fn pay(&self, p_id: Uuid, tstamp: u64) -> Result<TransactionId> {
+        let p_ref = self.current_payment.lock().unwrap().take();
+        let Some(pref) = p_ref else {
+            return Err(Error::NoPrepareRef(p_id));
+        };
+        if pref.payment_ref != p_id {
+            return Err(Error::NoPrepareRef(p_id));
+        }
+        let Some(wlt) = self.wallets.lock().unwrap().get(pref.wallet_idx).cloned() else {
+            return Err(Error::Internal(String::from(
+                "Wallet not found for payment",
+            )));
+        };
+        let txid = wlt.pay(p_id, &self.nostr_cl, &self.http_cl, tstamp).await?;
+        Ok(txid)
+    }
+
+    pub fn prepare_pay_request(
+        &self,
+        amount: Amount,
+        unit: Option<CurrencyUnit>,
+        description: Option<String>,
+    ) -> Result<cdk18::PaymentRequest> {
+        let mints = {
+            let wlts = self.wallets.lock().unwrap();
+            let mut mints = Vec::with_capacity(wlts.len());
+            for wlt in wlts.iter() {
+                mints.push(wlt.mint_url());
+            }
+            mints
+        };
+        let nostr_transport = cdk18::Transport {
+            _type: cdk18::TransportType::Nostr,
+            target: self.myself.to_bech32()?,
+            tags: Some(vec![vec![String::from("n"), String::from("17")]]),
+        };
+        let request = cdk18::PaymentRequest {
+            payment_id: Some(Uuid::new_v4().to_string()),
+            amount: Some(amount),
+            mints: Some(mints),
+            unit,
+            single_use: Some(true),
+            description,
+            nut10: None,
+            transports: Some(vec![nostr_transport]),
+        };
+        Ok(request)
+    }
+
+    pub async fn check_received_payment(&self, p_id: &str, now: u64) -> Result<TransactionId> {
+        let wlts = Arc::clone(&self.wallets);
+        let sub_id = self.nostr_subid.clone();
+        let cl = Arc::clone(&self.nostr_cl);
+        self.nostr_cl
+            .handle_notifications(|notif| async {
+                let cloned = Arc::clone(&wlts);
+                let ok = handle_notification(notif, &cl, &sub_id, cloned, p_id, now).await?;
+                Ok(ok)
+            })
+            .await?;
+        todo!()
+    }
+}
+
+async fn handle_notification(
+    notif: nostr_sdk::RelayPoolNotification,
+    cl: &nostr_sdk::Client,
+    sub_id: &nostr_sdk::SubscriptionId,
+    wlts: Arc<Mutex<Vec<Arc<impl Wallet>>>>,
+    payment_id: &str,
+    now: u64,
+) -> std::result::Result<bool, nostr_sdk::client::Error> {
+    let nostr_sdk::RelayPoolNotification::Event {
+        subscription_id,
+        event,
+        ..
+    } = notif
+    else {
+        return Ok(false);
+    };
+    if subscription_id != *sub_id {
+        return Ok(false);
+    }
+    if event.kind != nostr_sdk::Kind::GiftWrap {
+        return Ok(false);
+    }
+    let UnwrappedGift { rumor, sender } = cl.unwrap_gift_wrap(&event).await?;
+    if rumor.kind != nostr_sdk::Kind::PrivateDirectMessage {
+        return Ok(false);
+    }
+    let Ok(payload) = serde_json::from_str::<cdk18::PaymentRequestPayload>(rumor.content.as_str())
+    else {
+        return Ok(false);
+    };
+    let cdk18::PaymentRequestPayload {
+        id,
+        mint,
+        proofs,
+        unit,
+        memo,
+    } = payload;
+    if id.unwrap_or_default() != payment_id {
+        return Ok(false);
+    }
+    let wlt = {
+        let locked = wlts.lock().unwrap();
+        let found = locked.iter().find(|w| w.mint_url() == mint).cloned();
+        if found.is_none() {
+            return Ok(false);
+        }
+        found.unwrap()
+    };
+    let meta = HashMap::from([
+        (String::from("sender"), sender.to_string()),
+        (String::from("payment_id"), payment_id.to_string()),
+    ]);
+    let response = wlt.receive_proofs(proofs, unit, now, memo, meta).await;
+    match response {
+        Ok(txid) => Ok(true),
+        Err(e) => {
+            tracing::error!("Error receiving proofs: {}", e);
+            Ok(false)
+        }
     }
 }

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -1,6 +1,6 @@
 // ----- standard library imports
 // ----- extra library imports
-use cashu::{Amount, CurrencyUnit, MintUrl, nut18 as cdk18};
+use cashu::{Amount, CurrencyUnit, MintUrl};
 use uuid::Uuid;
 // ----- local imports
 
@@ -44,6 +44,7 @@ pub struct WalletConfig {
 pub struct MeltSummary {
     pub request_id: Uuid,
     pub amount: Amount,
+    pub unit: CurrencyUnit,
     pub fees: Amount,
     pub reserved_fees: Amount,
     pub expiry: u64,
@@ -58,19 +59,6 @@ impl MeltSummary {
     }
 }
 
-pub enum PaymentType {
-    Cdk18(cdk18::PaymentRequest),
-    Bolt11(cashu::Bolt11Invoice),
-}
-impl PaymentType {
-    pub fn memo(&self) -> Option<String> {
-        match self {
-            PaymentType::Cdk18(req) => req.description.clone(),
-            PaymentType::Bolt11(invoice) => Some(invoice.description().to_string()),
-        }
-    }
-}
-
 pub struct PaymentSummary {
     pub request_id: Uuid,
     pub unit: CurrencyUnit,
@@ -78,6 +66,30 @@ pub struct PaymentSummary {
     pub fees: Amount,
     pub reserved_fees: Amount,
     pub expiry: u64,
-    pub internal_rid: Uuid,
-    pub details: PaymentType,
+}
+
+impl std::convert::From<SendSummary> for PaymentSummary {
+    fn from(value: SendSummary) -> Self {
+        Self {
+            request_id: value.request_id,
+            unit: value.unit,
+            amount: value.amount,
+            fees: value.send_fees + value.swap_fees,
+            reserved_fees: Amount::ZERO,
+            expiry: 0,
+        }
+    }
+}
+
+impl std::convert::From<MeltSummary> for PaymentSummary {
+    fn from(value: MeltSummary) -> Self {
+        Self {
+            request_id: value.request_id,
+            unit: value.unit,
+            amount: value.amount,
+            fees: value.fees,
+            reserved_fees: value.reserved_fees,
+            expiry: value.expiry,
+        }
+    }
 }

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -7,15 +7,14 @@ use cashu::{
     Amount, Bolt11Invoice, CurrencyUnit, KeySetInfo, nut00 as cdk00, nut01 as cdk01, nut18 as cdk18,
 };
 use cdk::wallet::types::{Transaction, TransactionDirection, TransactionId};
+use nostr_sdk::{FromBech32, nips::nip19::Nip19Profile};
 use uuid::Uuid;
 // ----- local imports
 use crate::{
     MintConnector,
     error::{Error, Result},
     purse, sync,
-    types::{
-        MeltSummary, PaymentSummary, PaymentType, RedemptionSummary, SendSummary, WalletConfig,
-    },
+    types::{MeltSummary, PaymentSummary, RedemptionSummary, SendSummary, WalletConfig},
 };
 
 // ----- end imports
@@ -26,28 +25,22 @@ use crate::{
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait Pocket: sync::SendSync {
     fn unit(&self) -> CurrencyUnit;
-
     async fn balance(&self) -> Result<Amount>;
-
     async fn receive_proofs(
         &self,
         client: &dyn MintConnector,
         keysets_info: &[KeySetInfo],
         proofs: Vec<cdk00::Proof>,
     ) -> Result<(Amount, Vec<cdk01::PublicKey>)>;
-
     async fn prepare_send(&self, amount: Amount, infos: &[KeySetInfo]) -> Result<SendSummary>;
-
     async fn send_proofs(
         &self,
         rid: Uuid,
         keysets_info: &[KeySetInfo],
         client: &dyn MintConnector,
     ) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>>;
-
     async fn clean_local_proofs(&self, client: &dyn MintConnector)
     -> Result<Vec<cdk01::PublicKey>>;
-
     async fn restore_local_proofs(
         &self,
         keysets_info: &[KeySetInfo],
@@ -66,13 +59,11 @@ pub trait CreditPocket: Pocket {
         keysets_info: &[KeySetInfo],
         client: &dyn MintConnector,
     ) -> Result<(Amount, Vec<cdk00::Proof>)>;
-
     async fn get_redeemable_proofs(
         &self,
         keysets_info: &[KeySetInfo],
         client: &dyn MintConnector,
     ) -> Result<Vec<cdk00::Proof>>;
-
     async fn list_redemptions(
         &self,
         keysets_info: &[KeySetInfo],
@@ -88,27 +79,24 @@ pub trait DebitPocket: Pocket {
         keysets_info: &[KeySetInfo],
         client: &dyn MintConnector,
     ) -> Result<Amount>;
-
     async fn prepare_melt(
         &self,
         invoice: Bolt11Invoice,
         keysets_info: &[KeySetInfo],
         client: &dyn MintConnector,
     ) -> Result<MeltSummary>;
-
     async fn pay_melt(
         &self,
         rid: Uuid,
         keysets_info: &[KeySetInfo],
         client: &dyn MintConnector,
-    ) -> Result<Vec<cdk01::PublicKey>>;
-
+    ) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>>;
     async fn check_pending_melts(&self, client: &dyn MintConnector) -> Result<Amount>;
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait TransactionRepository {
+pub trait TransactionRepository: sync::SendSync {
     async fn store_tx(&self, tx: Transaction) -> Result<TransactionId>;
     async fn load_tx(&self, tx_id: TransactionId) -> Result<Transaction>;
     #[allow(dead_code)]
@@ -118,30 +106,34 @@ pub trait TransactionRepository {
 
 pub struct SendReference {
     pub request_id: Uuid,
-    pub internal_rid: Uuid,
     pub amount: Amount,
     pub unit: CurrencyUnit,
 }
+pub enum PaymentType {
+    Cdk18 {
+        transport: cdk18::Transport,
+        id: Option<String>,
+    },
+    Bolt11,
+}
 pub struct PayReference {
-    pub request_id: Uuid,
-    pub internal_rid: Uuid,
-    pub amount: Amount,
-    pub unit: CurrencyUnit,
-    pub fees: Amount,
-    pub expiry: u64,
-    pub details: PaymentType,
+    request_id: Uuid,
+    unit: CurrencyUnit,
+    fees: Amount,
+    ptype: PaymentType,
+    memo: Option<String>,
 }
 pub struct Wallet<Conn, TxRepo, DebtPck> {
     pub network: bitcoin::Network,
     pub client: Conn,
     pub tx_repo: TxRepo,
-    pub url: cashu::MintUrl,
+    pub mint_url: cashu::MintUrl,
     pub debit: DebtPck,
     pub credit: Box<dyn CreditPocket>,
     pub name: String,
     pub id: String,
     pub mnemonic: bip39::Mnemonic,
-    pub current_send: Mutex<Option<SendReference>>,
+    // pub current_send: Mutex<Option<SendReference>>,
     pub current_payment: Mutex<Option<PayReference>>,
 }
 
@@ -160,26 +152,58 @@ where
         let credit = self.credit.balance().await?;
         Ok(WalletBalance { debit, credit })
     }
-    async fn prepare_send_with_pocket(
-        amount: Amount,
-        keysets_info: &[KeySetInfo],
-        pocket: &dyn Pocket,
-    ) -> Result<(SendReference, SendSummary)> {
-        let pocket_summary = pocket.prepare_send(amount, keysets_info).await?;
-        let reference = SendReference {
-            request_id: Uuid::new_v4(),
-            amount,
-            unit: pocket.unit(),
-            internal_rid: pocket_summary.request_id,
+
+    async fn check_nut18_request(
+        &self,
+        req: &cdk18::PaymentRequest,
+    ) -> Result<(Amount, CurrencyUnit, cdk18::Transport)> {
+        if let Some(mints) = &req.mints {
+            if !mints.contains(&self.mint_url) {
+                return Err(Error::InterMint);
+            }
+        }
+        if req.nut10.is_some() {
+            return Err(Error::SpendingConditions);
+        }
+        let Some(amount) = req.amount else {
+            return Err(Error::MissingAmount);
         };
-        let summary = SendSummary {
-            request_id: reference.request_id,
-            amount,
-            unit: pocket.unit(),
-            send_fees: pocket_summary.send_fees,
-            swap_fees: pocket_summary.swap_fees,
+        let unit = if let Some(unit) = &req.unit {
+            if *unit != self.debit.unit() && *unit != self.credit.unit() {
+                return Err(Error::CurrencyUnitMismatch(self.debit.unit(), unit.clone()));
+            }
+            unit.clone()
+        } else if amount <= self.credit.balance().await? {
+            self.credit.unit()
+        } else {
+            self.debit.unit()
         };
-        Ok((reference, summary))
+        let empty = vec![];
+        let transports = req.transports.as_ref().unwrap_or(&empty);
+        let (nostrs, https): (Vec<_>, Vec<_>) = transports
+            .iter()
+            .partition(|t| matches!(t._type, cdk18::TransportType::Nostr));
+        if !https.is_empty() {
+            Ok((amount, unit, https[0].clone()))
+        } else if !nostrs.is_empty() {
+            Ok((amount, unit, nostrs[0].clone()))
+        } else {
+            Err(Error::NoTransport)
+        }
+    }
+
+    fn check_bolt11_invoice(&self, invoice: &Bolt11Invoice, now: u64) -> Result<()> {
+        if invoice.network() != self.network {
+            return Err(Error::InvalidNetwork(self.network, invoice.network()));
+        }
+        let now = std::time::Duration::from_secs(now);
+        if now > invoice.duration_since_epoch() + invoice.expiry_time() {
+            return Err(Error::PaymentExpired);
+        }
+        if invoice.amount_milli_satoshis().is_none() {
+            return Err(Error::MissingAmount);
+        };
+        Ok(())
     }
 }
 
@@ -203,50 +227,6 @@ where
     Conn: MintConnector,
     DebtPck: DebitPocket,
 {
-    pub async fn prepare_send(
-        &self,
-        amount: Amount,
-        unit: Option<CurrencyUnit>,
-    ) -> Result<SendSummary> {
-        let keysets_info = self.client.get_mint_keysets().await?.keysets;
-        match unit {
-            Some(unit) if unit == self.credit.unit() => {
-                let (refer, summary) =
-                    Self::prepare_send_with_pocket(amount, &keysets_info, self.credit.as_ref())
-                        .await?;
-                *self.current_send.lock().unwrap() = Some(refer);
-                Ok(summary)
-            }
-            Some(unit) if unit == self.debit.unit() => {
-                let (refer, summary) =
-                    Self::prepare_send_with_pocket(amount, &keysets_info, &self.debit).await?;
-                *self.current_send.lock().unwrap() = Some(refer);
-                Ok(summary)
-            }
-            Some(unit) => Err(Error::UnknownCurrencyUnit(unit)),
-            None => {
-                // first we try to pay with credit
-                let credit_balance = self.credit.balance().await?;
-                if credit_balance >= amount {
-                    let (refer, summary) =
-                        Self::prepare_send_with_pocket(amount, &keysets_info, self.credit.as_ref())
-                            .await?;
-                    *self.current_send.lock().unwrap() = Some(refer);
-                    return Ok(summary);
-                }
-                // and then fall back to debit
-                let debit_balance = self.debit.balance().await?;
-                if debit_balance >= amount {
-                    let (refer, summary) =
-                        Self::prepare_send_with_pocket(amount, &keysets_info, &self.debit).await?;
-                    *self.current_send.lock().unwrap() = Some(refer);
-                    return Ok(summary);
-                }
-                Err(Error::InsufficientFunds)
-            }
-        }
-    }
-
     pub async fn reclaim_funds(&self) -> Result<WalletBalance> {
         let keysets_info = self.client.get_mint_keysets().await?.keysets;
         let debit_reclaimed = self
@@ -327,22 +307,60 @@ where
     TxRepo: TransactionRepository,
     DebtPck: DebitPocket,
 {
+    async fn _receive_proofs(
+        &self,
+        keysets_info: &[KeySetInfo],
+        proofs: Vec<cdk00::Proof>,
+        unit: CurrencyUnit,
+        tstamp: u64,
+        memo: Option<String>,
+        metadata: HashMap<String, String>,
+    ) -> Result<TransactionId> {
+        let received_amount = proofs
+            .iter()
+            .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
+        let (stored_amount, ys) = if unit == self.debit.unit() {
+            tracing::debug!("receive into debit pocket");
+            self.debit
+                .receive_proofs(&self.client, keysets_info, proofs)
+                .await?
+        } else if unit == self.credit.unit() {
+            tracing::debug!("receive into credit pocket");
+            self.credit
+                .receive_proofs(&self.client, keysets_info, proofs)
+                .await?
+        } else {
+            return Err(Error::CurrencyUnitMismatch(self.debit.unit(), unit));
+        };
+        let tx = Transaction {
+            mint_url: self.mint_url.clone(),
+            direction: TransactionDirection::Incoming,
+            fee: received_amount
+                .checked_sub(stored_amount)
+                .expect("fee cannot be negative"),
+            amount: received_amount,
+            memo,
+            metadata,
+            timestamp: tstamp,
+            unit,
+            ys,
+        };
+        let txid = self.tx_repo.store_tx(tx).await?;
+        Ok(txid)
+    }
+
     pub async fn receive_token(&self, token: Token, tstamp: u64) -> Result<TransactionId> {
         let token_teaser = token.to_string().chars().take(20).collect::<String>();
-        if token.mint_url() != self.url {
+        if token.mint_url() != self.mint_url {
             return Err(Error::InvalidToken(token_teaser));
         }
         let keysets_info = self.client.get_mint_keysets().await?.keysets;
         let proofs = token.proofs(&keysets_info)?;
-        let received_amount = proofs
-            .iter()
-            .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
-
         if proofs.is_empty() {
             return Err(Error::EmptyToken(token_teaser));
         }
 
-        let (stored_amount, unit, ys) = if matches!(token, Token::CashuV4(..)) {
+        let tx_id = if matches!(token, Token::CashuV4(..)) {
             tracing::debug!("import debit token");
             if token.unit().is_some() && token.unit() != Some(self.debit.unit()) {
                 return Err(Error::CurrencyUnitMismatch(
@@ -350,11 +368,15 @@ where
                     self.debit.unit(),
                 ));
             }
-            let (amount, ys) = self
-                .debit
-                .receive_proofs(&self.client, &keysets_info, proofs)
-                .await?;
-            (amount, self.debit.unit(), ys)
+            self._receive_proofs(
+                &keysets_info,
+                proofs,
+                self.debit.unit(),
+                tstamp,
+                token.memo().clone(),
+                HashMap::default(),
+            )
+            .await?
         } else if matches!(token, Token::BitcrV4(..)) {
             tracing::debug!("import credit token");
             if token.unit().is_some() && token.unit() != Some(self.credit.unit()) {
@@ -363,169 +385,66 @@ where
                     self.credit.unit(),
                 ));
             }
-            let (amount, ys) = self
-                .credit
-                .receive_proofs(&self.client, &keysets_info, proofs)
-                .await?;
-            (amount, self.credit.unit(), ys)
+
+            self._receive_proofs(
+                &keysets_info,
+                proofs,
+                self.credit.unit(),
+                tstamp,
+                token.memo().clone(),
+                HashMap::default(),
+            )
+            .await?
+            // let (amount, ys) = self
+            //     .credit
+            //     .receive_proofs(&self.client, &keysets_info, proofs)
+            //     .await?;
+            // (amount, self.credit.unit(), ys)
         } else {
             return Err(Error::InvalidToken(token_teaser));
         };
-        let tx = Transaction {
-            mint_url: self.url.clone(),
-            direction: TransactionDirection::Incoming,
-            fee: received_amount
-                .checked_sub(stored_amount)
-                .expect("fee cannot be negative"),
-            amount: received_amount,
-            memo: token.memo().clone(),
-            metadata: HashMap::new(),
-            timestamp: tstamp,
-            unit,
-            ys,
-        };
-        let txid = self.tx_repo.store_tx(tx).await?;
-        Ok(txid)
+        Ok(tx_id)
     }
 
-    pub async fn send(
+    async fn pay_nut18(
         &self,
-        rid: Uuid,
-        memo: Option<String>,
-        tstamp: u64,
-    ) -> Result<(Token, TransactionId)> {
-        let current_send = self.current_send.lock().unwrap().take();
-        if current_send.is_none() {
-            return Err(Error::NoPrepareRef(rid));
+        proofs: Vec<cdk00::Proof>,
+        nostr_cl: &nostr_sdk::Client,
+        http_cl: &reqwest::Client,
+        transport: cdk18::Transport,
+        p_id: Option<String>,
+        mut partial_tx: Transaction,
+    ) -> Result<TransactionId> {
+        let payload = cdk18::PaymentRequestPayload {
+            id: p_id,
+            memo: partial_tx.memo.clone(),
+            unit: partial_tx.unit.clone(),
+            mint: self.mint_url.clone(),
+            proofs,
         };
-        let current_ref = current_send.unwrap();
-        if current_ref.request_id != rid {
-            return Err(Error::NoPrepareRef(rid));
+        match transport._type {
+            cdk18::TransportType::HttpPost => {
+                let url = reqwest::Url::from_str(&transport.target)?;
+                let response = http_cl.post(url).json(&payload).send().await?;
+                response.error_for_status()?;
+            }
+            cdk18::TransportType::Nostr => {
+                let payload = serde_json::to_string(&payload)?;
+                let receiver = Nip19Profile::from_bech32(&transport.target)?;
+                let output = nostr_cl
+                    .send_private_msg_to(
+                        receiver.relays,
+                        receiver.public_key,
+                        payload,
+                        std::iter::empty(),
+                    )
+                    .await?;
+                partial_tx
+                    .metadata
+                    .insert(String::from("nostr::event_id"), output.id().to_string());
+            }
         }
-
-        let keysets_info = self.client.get_mint_keysets().await?.keysets;
-
-        let (token, sent_amount, unit, ys) = if current_ref.unit == self.credit.unit() {
-            let proofs_map = self
-                .credit
-                .send_proofs(current_ref.internal_rid, &keysets_info, &self.client)
-                .await?;
-            let (ys, proofs): (Vec<cdk01::PublicKey>, Vec<cdk00::Proof>) =
-                proofs_map.into_iter().unzip();
-            let sent_amount = proofs
-                .iter()
-                .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
-            let token =
-                Token::new_bitcr(self.url.clone(), proofs, memo.clone(), self.credit.unit());
-            (token, sent_amount, self.credit.unit(), ys)
-        } else if current_ref.unit == self.debit.unit() {
-            let proofs_map = self
-                .debit
-                .send_proofs(current_ref.internal_rid, &keysets_info, &self.client)
-                .await?;
-            let (ys, proofs): (Vec<cdk01::PublicKey>, Vec<cdk00::Proof>) =
-                proofs_map.into_iter().unzip();
-            let sent_amount = proofs
-                .iter()
-                .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
-            let token = Token::new_cashu(self.url.clone(), proofs, memo.clone(), self.debit.unit());
-            (token, sent_amount, self.debit.unit(), ys)
-        } else {
-            return Err(Error::UnknownCurrencyUnit(current_ref.unit));
-        };
-
-        let tx = Transaction {
-            mint_url: self.url.clone(),
-            amount: current_ref.amount,
-            fee: sent_amount
-                .checked_sub(current_ref.amount)
-                .expect("fee cannot be negative"),
-            direction: TransactionDirection::Outgoing,
-            memo,
-            ys,
-            unit,
-            timestamp: tstamp,
-            metadata: HashMap::new(),
-        };
-        let tx_id = self.tx_repo.store_tx(tx).await?;
-        Ok((token, tx_id))
-    }
-
-    async fn prepare_nut18_payment(
-        &self,
-        _request: cdk18::PaymentRequest,
-    ) -> Result<PaymentSummary> {
-        todo!()
-    }
-
-    async fn prepare_bolt11_payment(&self, invoice: Bolt11Invoice) -> Result<PaymentSummary> {
-        // preliminary checks
-        if invoice.network() != self.network {
-            return Err(Error::InvalidNetwork(self.network, invoice.network()));
-        }
-        if invoice.amount_milli_satoshis().is_none() {
-            return Err(Error::Bolt11MissingAmount);
-        }
-        let keysets_info = self.client.get_mint_keysets().await?.keysets;
-        let pkt_summary = self
-            .debit
-            .prepare_melt(invoice.clone(), &keysets_info, &self.client)
-            .await?;
-        let pay_summary = PaymentSummary {
-            request_id: Uuid::new_v4(),
-            amount: pkt_summary.amount,
-            fees: pkt_summary.fees,
-            reserved_fees: pkt_summary.reserved_fees,
-            unit: self.debit.unit(),
-            expiry: pkt_summary.expiry,
-            internal_rid: pkt_summary.request_id,
-            details: PaymentType::Bolt11(invoice),
-        };
-        Ok(pay_summary)
-    }
-
-    pub async fn prepare_payment(&self, input: String) -> Result<PaymentSummary> {
-        if let Ok(request) = cdk18::PaymentRequest::from_str(&input) {
-            return self.prepare_nut18_payment(request).await;
-        }
-        if let Ok(invoice) = Bolt11Invoice::from_str(&input) {
-            return self.prepare_bolt11_payment(invoice).await;
-        }
-        Err(Error::UnknownPaymentRequest(input))
-    }
-
-    pub async fn pay(&self, rid: Uuid, tstamp: u64) -> Result<TransactionId> {
-        let current_payment = self.current_payment.lock().unwrap().take();
-        let current_payment = current_payment.ok_or(Error::NoPrepareRef(rid))?;
-        if current_payment.request_id != rid {
-            return Err(Error::NoPrepareRef(rid));
-        }
-        if tstamp > current_payment.expiry {
-            return Err(Error::PaymentExpired(
-                current_payment.request_id,
-                current_payment.expiry,
-            ));
-        }
-
-        let keysets_info = self.client.get_mint_keysets().await?.keysets;
-        let ys = self
-            .debit
-            .pay_melt(current_payment.internal_rid, &keysets_info, &self.client)
-            .await?;
-
-        let tx = Transaction {
-            amount: current_payment.amount,
-            fee: current_payment.fees,
-            mint_url: self.url.clone(),
-            direction: TransactionDirection::Outgoing,
-            memo: current_payment.details.memo(),
-            metadata: HashMap::new(),
-            timestamp: tstamp,
-            unit: self.debit.unit(),
-            ys,
-        };
-
-        let txid = self.tx_repo.store_tx(tx).await?;
+        let txid = self.tx_repo.store_tx(partial_tx).await?;
         Ok(txid)
     }
 }
@@ -534,6 +453,8 @@ where
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<Conn, TxRepo, DebtPck> purse::Wallet for Wallet<Conn, TxRepo, DebtPck>
 where
+    TxRepo: TransactionRepository,
+    Conn: MintConnector,
     DebtPck: DebitPocket,
 {
     fn config(&self) -> WalletConfig {
@@ -543,11 +464,153 @@ where
             network: self.network,
             debit: self.debit.unit(),
             credit: self.credit.maybe_unit(),
-            mint: self.url.clone(),
+            mint: self.mint_url.clone(),
             mnemonic: self.mnemonic.clone(),
         }
     }
     fn name(&self) -> String {
         self.name.clone()
+    }
+    fn mint_url(&self) -> cashu::MintUrl {
+        self.mint_url.clone()
+    }
+    async fn prepare_pay(&self, input: String, now: u64) -> Result<PaymentSummary> {
+        let infos = self.client.get_mint_keysets().await?.keysets;
+        if let Ok(request) = cdk18::PaymentRequest::from_str(&input) {
+            let (amount, unit, transport) = self.check_nut18_request(&request).await?;
+            let s_summary = if self.credit.unit() == unit {
+                self.credit.prepare_send(amount, &infos).await?
+            } else if self.debit.unit() == unit {
+                self.debit.prepare_send(amount, &infos).await?
+            } else {
+                return Err(Error::CurrencyUnitMismatch(self.debit.unit(), unit));
+            };
+            let summary = PaymentSummary::from(s_summary);
+            let pref = PayReference {
+                request_id: summary.request_id,
+                unit: summary.unit.clone(),
+                fees: summary.fees,
+                ptype: PaymentType::Cdk18 {
+                    transport,
+                    id: request.payment_id,
+                },
+                memo: request.description,
+            };
+            *self.current_payment.lock().unwrap() = Some(pref);
+            Ok(summary)
+        } else if let Ok(invoice) = Bolt11Invoice::from_str(&input) {
+            self.check_bolt11_invoice(&invoice, now)?;
+            let m_summary = self
+                .debit
+                .prepare_melt(invoice.clone(), &infos, &self.client)
+                .await?;
+            let summary = PaymentSummary::from(m_summary);
+            let pref = PayReference {
+                request_id: summary.request_id,
+                unit: summary.unit.clone(),
+                fees: summary.fees,
+                ptype: PaymentType::Bolt11,
+                memo: Some(invoice.description().to_string()),
+            };
+            *self.current_payment.lock().unwrap() = Some(pref);
+            Ok(summary)
+        } else {
+            Err(Error::UnknownPaymentRequest(input))
+        }
+    }
+    async fn pay(
+        &self,
+        p_id: Uuid,
+        nostr_cl: &nostr_sdk::Client,
+        http_cl: &reqwest::Client,
+        now: u64,
+    ) -> Result<TransactionId> {
+        let p_ref = self.current_payment.lock().unwrap().take();
+        let Some(p_ref) = p_ref else {
+            return Err(Error::NoPrepareRef(p_id));
+        };
+        if p_ref.request_id != p_id {
+            return Err(Error::NoPrepareRef(p_id));
+        }
+        let infos = self.client.get_mint_keysets().await?.keysets;
+        let PayReference {
+            request_id,
+            unit,
+            fees,
+            ptype,
+            memo,
+        } = p_ref;
+        match ptype {
+            PaymentType::Cdk18 { transport, id } => {
+                let proofs = if unit == self.credit.unit() {
+                    self.credit
+                        .send_proofs(request_id, &infos, &self.client)
+                        .await?
+                } else if unit == self.debit.unit() {
+                    self.debit
+                        .send_proofs(request_id, &infos, &self.client)
+                        .await?
+                } else {
+                    return Err(Error::Internal(String::from("currency unit mismatch")));
+                };
+                let (ys, proofs): (Vec<cdk01::PublicKey>, Vec<cdk00::Proof>) =
+                    proofs.into_iter().unzip();
+                let amount = proofs
+                    .iter()
+                    .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
+                let partial_tx = Transaction {
+                    mint_url: self.mint_url.clone(),
+                    fee: fees,
+                    direction: TransactionDirection::Outgoing,
+                    memo,
+                    timestamp: now,
+                    unit: unit.clone(),
+                    ys,
+                    amount,
+                    // payments might need to fill some extra metadata later
+                    metadata: HashMap::default(),
+                };
+                let tx_id = self
+                    .pay_nut18(proofs, nostr_cl, http_cl, transport, id, partial_tx)
+                    .await?;
+                return Ok(tx_id);
+            }
+            PaymentType::Bolt11 => {
+                let proofs = self
+                    .debit
+                    .pay_melt(request_id, &infos, &self.client)
+                    .await?;
+                let (ys, proofs): (Vec<cdk01::PublicKey>, Vec<cdk00::Proof>) =
+                    proofs.into_iter().unzip();
+                let amount = proofs
+                    .iter()
+                    .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
+                let partial_tx = Transaction {
+                    mint_url: self.mint_url.clone(),
+                    fee: fees,
+                    direction: TransactionDirection::Outgoing,
+                    memo,
+                    timestamp: now,
+                    unit: unit.clone(),
+                    ys,
+                    amount,
+                    metadata: HashMap::default(),
+                };
+                let tx_id = self.tx_repo.store_tx(partial_tx).await?;
+                return Ok(tx_id);
+            }
+        }
+    }
+    async fn receive_proofs(
+        &self,
+        proofs: Vec<cdk00::Proof>,
+        unit: CurrencyUnit,
+        tstamp: u64,
+        memo: Option<String>,
+        metadata: HashMap<String, String>,
+    ) -> Result<TransactionId> {
+        let keysets_info = self.client.get_mint_keysets().await?.keysets;
+        self._receive_proofs(&keysets_info, proofs, unit, tstamp, memo, metadata)
+            .await
     }
 }


### PR DESCRIPTION
- remove prepare_send and sed functions
- add prepare_payment and pay that allow nut18 and bolt11 payments

- add prepare_payment_request and check_received_payment for nut18 PaymentRequest