### PR TITLE
Use new dev relay as default

### DIFF
--- a/crates/bcr-wallet-core/src/config.rs
+++ b/crates/bcr-wallet-core/src/config.rs
@@ -19,7 +19,7 @@ impl Default for Settings {
             network: bitcoin::Network::Testnet,
             mnemonic: bip39::Mnemonic::generate(12).expect("Failed to generate default mnemonic"),
             nostr_relays: vec![
-                RelayUrl::parse("wss://bitcr-cloud-run-05-550030097098.europe-west1.run.app")
+                RelayUrl::parse("wss://bcr-relay-dev.minibill.tech")
                     .expect("Invalid default relay URL"),
             ],
         }


### PR DESCRIPTION
### **User description**
Use the new dev relay


___

### **PR Type**
Other


___

### **Description**
- Update default Nostr relay URL to new development server


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oldRelay["Old Dev Relay<br/>bitcr-cloud-run-05-550030097098.europe-west1.run.app"] -- "replaced with" --> newRelay["New Dev Relay<br/>bcr-relay-dev.minibill.tech"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Update default relay URL configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/config.rs

<ul><li>Replace default Nostr relay URL from Google Cloud Run endpoint to new <br>minibill.tech domain</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/77/files#diff-71498585837598ae984b6f48bf3c8968bccc5d3c4c8163dddaeb83c5397e7d3e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

