### PR TITLE
fix: dont fail run if private and no code security enabled

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: true
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add error handling to CodeQL SARIF upload step

- Prevent workflow failure when code security is disabled


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cargo deny check"] --> B["Upload SARIF to GitHub"]
  B --> C["Workflow continues on error"]
  B -.-> D["Code security disabled"] 
  D --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rust.yml</strong><dd><code>Add error handling to SARIF upload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/rust.yml

<ul><li>Added <code>continue-on-error: true</code> to CodeQL SARIF upload step<br> <li> Prevents workflow failure when GitHub code security features are <br>disabled</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/80/files#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

