### PR TITLE
Initial offline intermint

### DIFF
--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -1,6 +1,7 @@
 // ----- standard library imports
 // ----- extra library imports
 use anyhow::Error as AnyError;
+use bitcoin::hashes::sha256::Hash as Sha256;
 use thiserror::Error;
 // ----- local imports
 
@@ -72,6 +73,8 @@ pub enum Error {
     EmptyToken(String),
     #[error("invalid token: {0}")]
     InvalidToken(String),
+    #[error("Invalid Hash Lock on Beta Proofs, expected {0} got {1}")]
+    InvalidHashLock(Sha256, Sha256),
     #[error("no active keyset")]
     NoActiveKeyset,
     #[error("unknown keyset ID")]

--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -114,6 +114,8 @@ pub enum Error {
     MaxExchangeAttempts,
     #[error("Missing currency unit")]
     MissingCurrencyUnit,
+    #[error("Invalid Clowder Path for foreign eCash")]
+    InvalidClowderPath,
 
     #[error("internal error: {0}")]
     Internal(String),

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -12,7 +12,7 @@ pub mod pocket;
 mod purse;
 mod restore;
 mod types;
-mod utils;
+pub mod utils;
 pub mod wallet;
 
 // ----- end imports

--- a/crates/bcr-wallet-core/src/mint.rs
+++ b/crates/bcr-wallet-core/src/mint.rs
@@ -2,45 +2,68 @@
 use std::str::FromStr;
 // ----- extra library imports
 use async_trait::async_trait;
-use cashu::Proof;
+use bitcoin::hashes::sha256::Hash as Sha256;
+use bitcoin::secp256k1::PublicKey;
+use cashu::{BlindSignature, Proof, ProofDleq};
 use cdk::Error as CdkError;
+use serde::{Deserialize, Serialize};
 // ----- local imports
 use crate::sync;
 
 // ----- end imports
 
-//* Clowder Models, TODO - later obtain from shared library such
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+//* Clowder Models, TODO - later obtain from shared library
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConnectedMintsResponse {
     pub mint_urls: Vec<cashu::MintUrl>,
     pub clowder_urls: Vec<reqwest::Url>,
     pub node_ids: Vec<bitcoin::secp256k1::PublicKey>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PathRequest {
     pub origin_mint_url: cashu::MintUrl,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExchangeRequest {
     pub alpha_proofs: Vec<cashu::Proof>,
     pub exchange_path: Vec<bitcoin::secp256k1::PublicKey>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExchangeResponse {
     pub beta_proofs: Vec<cashu::Proof>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublicKeyResponse {
     pub public_key: bitcoin::secp256k1::PublicKey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct ClowderBetasResponse {
-    pub betas: Vec<cashu::MintUrl>,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecretlessProof {
+    pub signature: BlindSignature,
+    pub y: bitcoin::secp256k1::PublicKey,
+    pub dleq: ProofDleq,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubstituteExchangeRequest {
+    pub proofs: Vec<SecretlessProof>,
+    pub locks: Vec<Sha256>,
+    pub wallet_pubkey: PublicKey,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubstituteExchangeResponse {
+    pub outputs: Vec<Proof>,
+    pub signature: bitcoin::secp256k1::schnorr::Signature,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OfflineResponse {
+    pub offline: bool,
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -60,6 +83,19 @@ pub trait MintConnector: cdk::wallet::MintConnector + sync::SendSync {
         &self,
         origin_mint_url: cashu::MintUrl,
     ) -> CdkResult<ConnectedMintsResponse>;
+    async fn get_alpha_keysets(
+        &self,
+        alpha_id: bitcoin::secp256k1::PublicKey,
+    ) -> CdkResult<Vec<cashu::KeySet>>;
+
+    async fn get_alpha_offline(&self, alpha_id: bitcoin::secp256k1::PublicKey) -> CdkResult<bool>;
+
+    async fn post_exchange_substitute(
+        &self,
+        proofs: Vec<SecretlessProof>,
+        locks: Vec<bitcoin::hashes::sha256::Hash>,
+        wallet_pubkey: bitcoin::secp256k1::PublicKey,
+    ) -> CdkResult<Vec<Proof>>;
 }
 
 #[derive(Debug, Clone)]
@@ -189,6 +225,41 @@ impl MintConnector for HttpClientExt {
             .expect("cashu::MintUrl is as good as reqwest::Url")
     }
 
+    /// Active alpha keysets
+    async fn get_alpha_keysets(
+        &self,
+        alpha_id: bitcoin::secp256k1::PublicKey,
+    ) -> CdkResult<Vec<cashu::KeySet>> {
+        let url = self.url.join(&format!("v1/alpha/keysets/{alpha_id}"))?;
+        let response = self
+            .secondary
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        let response: cashu::nuts::KeysResponse = response
+            .json()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        Ok(response.keysets)
+    }
+
+    /// Is Alpha Offline
+    async fn get_alpha_offline(&self, alpha_id: bitcoin::secp256k1::PublicKey) -> CdkResult<bool> {
+        let url = self.url.join(&format!("v1/alpha/offline/{alpha_id}"))?;
+        let response = self
+            .secondary
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        let response: OfflineResponse = response
+            .json()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        Ok(response.offline)
+    }
+
     async fn get_clowder_betas(&self) -> CdkResult<Vec<cashu::MintUrl>> {
         let url = self
             .url
@@ -205,6 +276,33 @@ impl MintConnector for HttpClientExt {
             .await
             .map_err(|e| CdkError::Custom(e.to_string()))?;
         Ok(response.mint_urls)
+    }
+
+    async fn post_exchange_substitute(
+        &self,
+        proofs: Vec<SecretlessProof>,
+        locks: Vec<bitcoin::hashes::sha256::Hash>,
+        wallet_pubkey: bitcoin::secp256k1::PublicKey,
+    ) -> CdkResult<Vec<Proof>> {
+        let url = self.url.join("v1/exchange/substitute")?;
+        let request = SubstituteExchangeRequest {
+            proofs,
+            locks,
+            wallet_pubkey,
+        };
+
+        let response = self
+            .secondary
+            .post(url)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        let response: SubstituteExchangeResponse = response
+            .json()
+            .await
+            .map_err(|e| CdkError::Custom(e.to_string()))?;
+        Ok(response.outputs)
     }
 
     async fn post_exchange(

--- a/crates/bcr-wallet-core/src/pocket/credit.rs
+++ b/crates/bcr-wallet-core/src/pocket/credit.rs
@@ -147,6 +147,11 @@ impl wallet::Pocket for Pocket {
         keysets_info: &[KeySetInfo],
         inputs: Vec<cdk00::Proof>,
     ) -> Result<(Amount, Vec<cdk01::PublicKey>)> {
+        tracing::info!(
+            "Credit receive proofs keyset {:?} proofs {:?}",
+            keysets_info,
+            inputs
+        );
         self.validate_keysets(keysets_info, &inputs)?;
         // storing proofs in pending state
         let mut proofs: HashMap<cdk01::PublicKey, cdk00::Proof> =
@@ -155,6 +160,7 @@ impl wallet::Pocket for Pocket {
             let y = input.y()?;
             proofs.insert(y, input);
         }
+        tracing::info!("credit digest proofs");
         self.digest_proofs(client, proofs).await
     }
 

--- a/crates/bcr-wallet-core/src/utils.rs
+++ b/crates/bcr-wallet-core/src/utils.rs
@@ -5,7 +5,6 @@ use bitcoin::secp256k1::{PublicKey, SECP256K1};
 use cashu::{BlindSignature, Proof};
 use cdk::Error as CdkError;
 // ----- local imports
-use crate::mint::MintConnector;
 use crate::mint::SecretlessProof;
 // ----- end imports
 
@@ -63,6 +62,47 @@ pub async fn proofs_to_secretless(
     }
 
     Ok((secret_less, secrets))
+}
+
+pub fn validate_offline_conditions(
+    wallet_pubkey: PublicKey,
+    conditions: &cashu::Conditions,
+    tstamp: u64,
+) -> CdkResult<u64> {
+    tracing::info!("Verifying spending conditions {:?}", conditions);
+
+    let lock_time = conditions.locktime.ok_or(CdkError::LocktimeNotProvided)?;
+    let num_sigs = conditions.num_sigs.ok_or(CdkError::PubkeyRequired)?;
+    let pubkeys = conditions
+        .pubkeys
+        .as_ref()
+        .ok_or(CdkError::PubkeyRequired)?;
+    let refund_len = conditions
+        .refund_keys
+        .as_ref()
+        .map(|r| r.len())
+        .unwrap_or(0);
+
+    if pubkeys.len() != 1 || num_sigs != 1 {
+        return Err(CdkError::PubkeyRequired);
+    }
+    if refund_len != 0 {
+        return Err(CdkError::InvalidSpendConditions(
+            "Beta proofs refund not allowed".into(),
+        ));
+    }
+    if *pubkeys[0] != wallet_pubkey {
+        return Err(CdkError::InvalidSpendConditions(
+            "Pubkey must be wallet pubkey".into(),
+        ));
+    }
+    if lock_time < tstamp + crate::config::LOCK_REDUCTION_SECONDS_PER_HOP {
+        return Err(CdkError::InvalidSpendConditions(
+            "Lock time too short".into(),
+        ));
+    }
+
+    Ok(lock_time)
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/crates/bcr-wallet-core/src/utils.rs
+++ b/crates/bcr-wallet-core/src/utils.rs
@@ -1,11 +1,71 @@
-#![cfg(not(target_arch = "wasm32"))]
 // ----- standard library imports
+use std::collections::HashMap;
 // ----- extra library imports
+use bitcoin::secp256k1::{PublicKey, SECP256K1};
+use cashu::{BlindSignature, Proof};
+use cdk::Error as CdkError;
 // ----- local imports
-
+use crate::mint::MintConnector;
+use crate::mint::SecretlessProof;
 // ----- end imports
 
-#[cfg(test)]
+type CdkResult<T> = std::result::Result<T, cdk::Error>;
+
+pub async fn proofs_to_secretless(
+    alpha_id: PublicKey,
+    substitute_client: &dyn crate::mint::MintConnector,
+    proofs: Vec<Proof>,
+) -> CdkResult<(Vec<SecretlessProof>, Vec<cashu::secret::Secret>)> {
+    let alpha_keysets = substitute_client
+        .get_alpha_keysets(alpha_id)
+        .await
+        .map_err(|err| CdkError::HttpError(None, err.to_string()))?;
+
+    let keys: HashMap<cashu::Id, cashu::KeySet> = alpha_keysets
+        .iter()
+        .map(|keyset| (keyset.id, keyset.clone()))
+        .collect();
+
+    let mut secrets = Vec::with_capacity(proofs.len());
+    let mut secret_less = Vec::with_capacity(proofs.len());
+
+    for p in proofs.iter() {
+        let pubkey = keys
+            .get(&p.keyset_id)
+            .ok_or(CdkError::UnknownKeySet)?
+            .keys
+            .amount_key(p.amount)
+            .ok_or(CdkError::AmountKey)?;
+
+        let dleq = p.dleq.as_ref().ok_or(CdkError::DleqProofNotProvided)?;
+        let r = bitcoin::secp256k1::Scalar::from(*dleq.r);
+        let r_bigk: PublicKey = pubkey
+            .mul_tweak(SECP256K1, &r)
+            .map_err(|err| CdkError::Custom(err.to_string()))?;
+        let signature =
+            p.c.combine(&r_bigk)
+                .map_err(|err| CdkError::Custom(err.to_string()))?;
+
+        let dleq = p.dleq.clone().ok_or(CdkError::DleqProofNotProvided)?;
+        secrets.push(p.secret.clone());
+
+        let signature = BlindSignature {
+            amount: p.amount,
+            keyset_id: p.keyset_id,
+            c: signature.into(),
+            dleq: None,
+        };
+        secret_less.push(SecretlessProof {
+            signature,
+            dleq,
+            y: *p.y()?,
+        });
+    }
+
+    Ok((secret_less, secrets))
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
 pub mod tests {
     use async_trait::async_trait;
     use cashu::{
@@ -13,6 +73,8 @@ pub mod tests {
         nut07 as cdk07, nut09 as cdk09, nut23 as cdk23,
     };
     use cdk_common::Error as CDKError;
+
+    use crate::mint::SecretlessProof;
     type CdkResult<T> = Result<T, CDKError>;
 
     mockall::mock! {
@@ -91,6 +153,19 @@ pub mod tests {
             &self,
             origin_mint_url: cashu::MintUrl,
         ) -> CdkResult<crate::mint::ConnectedMintsResponse>;
+        async fn get_alpha_keysets(
+            &self,
+            alpha_id: bitcoin::secp256k1::PublicKey,
+        ) -> CdkResult<Vec<cashu::KeySet>>;
+
+        async fn get_alpha_offline(&self, alpha_id: bitcoin::secp256k1::PublicKey) -> CdkResult<bool>;
+
+        async fn post_exchange_substitute(
+            &self,
+            proofs: Vec<SecretlessProof>,
+            locks: Vec<bitcoin::hashes::sha256::Hash>,
+            wallet_pubkey: bitcoin::secp256k1::PublicKey,
+        ) -> CdkResult<Vec<cashu::Proof>>;
 
         }
     }

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -392,7 +392,7 @@ where
             } else {
                 tracing::debug!("Offline exchange");
                 let substitute_proofs = self
-                    .offline_exchange(alpha_id, &substitute_client, proofs)
+                    .offline_exchange(alpha_id, &substitute_client, proofs, tstamp)
                     .await?;
                 // Alpha proofs -> Beta proofs is done, so we only need the path from Beta to the Wallet Mint
                 let path = path.node_ids[1..].to_vec();
@@ -445,7 +445,7 @@ where
 
     async fn htlc_lock(
         unit: CurrencyUnit,
-        utc_now: u64,
+        tstamp: u64,
         client: &dyn MintConnector,
         is_credit: bool,
         proofs: Vec<cashu::Proof>,
@@ -461,7 +461,7 @@ where
 
         // total hops * time per hop + 2 hops buffer
         let lock_time =
-            utc_now + (key_locks.len() as u64 + 2) * crate::config::LOCK_REDUCTION_SECONDS_PER_HOP;
+            tstamp + (key_locks.len() as u64 + 2) * crate::config::LOCK_REDUCTION_SECONDS_PER_HOP;
 
         let infos = client.get_mint_keysets().await?.keysets;
 
@@ -503,6 +503,7 @@ where
         alpha_id: bitcoin::secp256k1::PublicKey,
         substitute_client: &dyn MintConnector,
         proofs: Vec<Proof>,
+        tstamp: u64,
     ) -> Result<Vec<Proof>> {
         // Ephemeral P2PK secret
         let wallet_pk = cashu::SecretKey::generate();
@@ -523,10 +524,28 @@ where
         // TODO - Verify Beta Proofs don't have additional locks preventing the wallet from using it
         for ((p, h), s) in beta_proofs.iter_mut().zip(hash_locks).zip(secrets) {
             let msg: Vec<u8> = p.secret.to_bytes();
+
+            // Verify spending conditions
             let hashed = Sha256::hash(&msg);
             if hashed != h {
                 return Err(Error::InvalidHashLock(h, hashed));
             }
+            let secret: cashu::nuts::nut10::Secret = p
+                .secret
+                .clone()
+                .try_into()
+                .map_err(|_| Error::SpendingConditions)?;
+            let conditions: cashu::Conditions = secret
+                .secret_data()
+                .tags()
+                .and_then(|c| c.clone().try_into().ok())
+                .ok_or(Error::SpendingConditions)?;
+            crate::utils::validate_offline_conditions(
+                *wallet_pk.public_key(),
+                &conditions,
+                tstamp,
+            )?;
+
             let signature: bitcoin::secp256k1::schnorr::Signature = wallet_pk.sign(&msg)?;
             let signatures = vec![signature.to_string()];
 

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -514,10 +514,19 @@ where
             .map(|secret| Sha256::hash(&secret.to_bytes()))
             .collect();
         let mut beta_proofs = substitute_client
-            .post_exchange_substitute(secretless.clone(), hash_locks, *wallet_pk.public_key())
+            .post_exchange_substitute(
+                secretless.clone(),
+                hash_locks.clone(),
+                *wallet_pk.public_key(),
+            )
             .await?;
-        for (p, s) in beta_proofs.iter_mut().zip(secrets) {
+        // TODO - Verify Beta Proofs don't have additional locks preventing the wallet from using it
+        for ((p, h), s) in beta_proofs.iter_mut().zip(hash_locks).zip(secrets) {
             let msg: Vec<u8> = p.secret.to_bytes();
+            let hashed = Sha256::hash(&msg);
+            if hashed != h {
+                return Err(Error::InvalidHashLock(h, hashed));
+            }
             let signature: bitcoin::secp256k1::schnorr::Signature = wallet_pk.sign(&msg)?;
             let signatures = vec![signature.to_string()];
 

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -1,14 +1,15 @@
 // ----- standard library imports
 use std::{collections::HashMap, str::FromStr, sync::Mutex};
 // ----- extra library imports
+use crate::utils::proofs_to_secretless;
 use async_trait::async_trait;
 use bcr_wallet_lib::wallet::Token;
-use bitcoin::hashes::Hash;
+use bitcoin::hashes::{Hash, sha256::Hash as Sha256};
 use cashu::{
     Amount, Bolt11Invoice, CurrencyUnit, KeySetInfo, MintUrl, Proof, nut00 as cdk00,
     nut01 as cdk01, nut07 as cdk07, nut18 as cdk18,
 };
-use cdk::wallet::MintConnector as _;
+// use cdk::wallet::MintConnector as _;
 use cdk::wallet::types::{Transaction, TransactionDirection, TransactionId};
 use nostr_sdk::nips::nip19::{FromBech32, Nip19Profile};
 use uuid::Uuid;
@@ -361,9 +362,51 @@ where
         if let Some(mint) = mint
             && mint != self.client.mint_url()
         {
-            proofs = self
-                .exchange_intermint_proofs(proofs, mint, unit.clone(), tstamp)
-                .await?;
+            // Determine path from current mint to origin
+            let path = self.client.post_clowder_path(mint.clone()).await?;
+            tracing::debug!("Receive intermint proofs path {:?}", path);
+            if path.node_ids.len() < 3 {
+                return Err(Error::InvalidClowderPath);
+            }
+            let alpha_id = path.node_ids[0];
+
+            let alpha_client = crate::mint::HttpClientExt::new(mint.clone());
+            // The path goes through the substitute Beta if the Alpha origin mint is offline
+            let beta_mint = path.mint_urls[1].clone();
+            let substitute_client = crate::mint::HttpClientExt::new(beta_mint);
+
+            let is_alpha_offline = substitute_client.get_alpha_offline(alpha_id).await?;
+
+            if !is_alpha_offline {
+                tracing::debug!("Online exchange");
+                proofs = self
+                    .online_exchange(
+                        proofs,
+                        mint,
+                        &alpha_client,
+                        path.node_ids,
+                        unit.clone(),
+                        tstamp,
+                    )
+                    .await?;
+            } else {
+                tracing::debug!("Offline exchange");
+                let substitute_proofs = self
+                    .offline_exchange(alpha_id, &substitute_client, proofs)
+                    .await?;
+                // Alpha proofs -> Beta proofs is done, so we only need the path from Beta to the Wallet Mint
+                let path = path.node_ids[1..].to_vec();
+                proofs = self
+                    .online_exchange(
+                        substitute_proofs,
+                        mint,
+                        &substitute_client,
+                        path,
+                        unit.clone(),
+                        tstamp,
+                    )
+                    .await?;
+            }
         }
 
         let received_amount = proofs
@@ -406,7 +449,7 @@ where
         client: &dyn MintConnector,
         is_credit: bool,
         proofs: Vec<cashu::Proof>,
-        hash_lock: bitcoin::hashes::sha256::Hash,
+        hash_lock: Sha256,
         key_locks: Vec<bitcoin::secp256k1::PublicKey>,
         wallet_pubkey: bitcoin::secp256k1::PublicKey,
     ) -> Result<Vec<cashu::Proof>> {
@@ -455,10 +498,43 @@ where
         Ok(proofs)
     }
 
-    pub async fn exchange_intermint_proofs(
+    async fn offline_exchange(
+        &self,
+        alpha_id: bitcoin::secp256k1::PublicKey,
+        substitute_client: &dyn MintConnector,
+        proofs: Vec<Proof>,
+    ) -> Result<Vec<Proof>> {
+        // Ephemeral P2PK secret
+        let wallet_pk = cashu::SecretKey::generate();
+
+        let (secretless, secrets) =
+            proofs_to_secretless(alpha_id, substitute_client, proofs).await?;
+        let hash_locks: Vec<Sha256> = secrets
+            .iter()
+            .map(|secret| Sha256::hash(&secret.to_bytes()))
+            .collect();
+        let mut beta_proofs = substitute_client
+            .post_exchange_substitute(secretless.clone(), hash_locks, *wallet_pk.public_key())
+            .await?;
+        for (p, s) in beta_proofs.iter_mut().zip(secrets) {
+            let msg: Vec<u8> = p.secret.to_bytes();
+            let signature: bitcoin::secp256k1::schnorr::Signature = wallet_pk.sign(&msg)?;
+            let signatures = vec![signature.to_string()];
+
+            p.witness = Some(cashu::Witness::HTLCWitness(cashu::HTLCWitness {
+                preimage: s.to_string(),
+                signatures: Some(signatures),
+            }));
+        }
+        Ok(beta_proofs)
+    }
+
+    pub async fn online_exchange(
         &self,
         alpha_proofs: Vec<cashu::Proof>,
         alpha_url: MintUrl,
+        alpha_client: &dyn MintConnector,
+        path: Vec<bitcoin::secp256k1::PublicKey>,
         unit: CurrencyUnit,
         tstamp: u64,
     ) -> Result<Vec<Proof>> {
@@ -468,16 +544,12 @@ where
         let wallet_pk = cashu::SecretKey::generate();
 
         // TODO make factory
-        let alpha_client = crate::mint::HttpClientExt::new(alpha_url.clone());
-
-        // Determine path from current mint to origin
-        let path = self.client.post_clowder_path(alpha_url.clone()).await?;
 
         // Require all intermediate mints to sign
         // Exclude alpha origin from p2pk lock as it doesn't need to sign its own eCash
-        tracing::debug!("Origin {}", path.node_ids[0]);
+        tracing::debug!("Origin {}", path[0]);
         let key_locks: Vec<bitcoin::secp256k1::PublicKey> =
-            path.node_ids.clone().into_iter().skip(1).collect();
+            path.clone().into_iter().skip(1).collect();
         tracing::debug!(
             "Key locks {}",
             key_locks
@@ -488,14 +560,14 @@ where
         );
 
         let preimage = format!("CLWDR {}", cashu::SecretKey::generate().to_secret_hex());
-        let hash_lock = bitcoin::hashes::sha256::Hash::hash(preimage.as_bytes());
+        let hash_lock = Sha256::hash(preimage.as_bytes());
 
         let is_credit = unit == self.credit.unit();
 
         let locked_alpha_proofs = Self::htlc_lock(
             unit,
             tstamp,
-            &alpha_client,
+            alpha_client,
             is_credit,
             alpha_proofs,
             hash_lock,
@@ -504,7 +576,7 @@ where
         )
         .await?;
 
-        let mut exchange_path = path.node_ids.clone();
+        let mut exchange_path = path.clone();
         // Include wallet pubkey as last to be p2pk
         exchange_path.push(*wallet_pk.public_key());
 
@@ -557,11 +629,35 @@ where
         let proofs = if token.mint_url() == self.client.mint_url() {
             token.proofs(&keysets_info)?
         } else {
-            let alpha_client = crate::mint::HttpClientExt::new(token.mint_url());
-            let alpha_infos = alpha_client.get_mint_keysets().await?.keysets;
-            let same_token = token.proofs(&alpha_infos)?;
-            tracing::debug!("Exchanged into same mint token {}", token);
-            same_token
+            let path = self.client.post_clowder_path(token.mint_url()).await?;
+            tracing::debug!("Receive intermint proofs path {:?}", path);
+            if path.node_ids.len() < 3 {
+                return Err(Error::InvalidClowderPath);
+            }
+            let alpha_id = path.node_ids[0];
+            // The path goes through the substitute Beta if the Alpha origin mint is offline
+            let beta_mint = path.mint_urls[1].clone();
+            // In the direct exchange case this is the same as the Wallet's mint
+            let substitute_client = crate::mint::HttpClientExt::new(beta_mint);
+
+            // In the offline case we can only ask the substitute, in the online case we can ask the mint
+            // The Beta mint (after Alpha in the path) should have it in any case
+            // This can be revised based on some criteria ?
+            let alpha_keysets = substitute_client.get_alpha_keysets(alpha_id).await?;
+
+            // The endpoint only returns active keysets and Clowder/Wildcat don't have fees
+            let alpha_infos: Vec<cashu::KeySetInfo> = alpha_keysets
+                .iter()
+                .map(|keyset| cashu::KeySetInfo {
+                    id: keyset.id,
+                    unit: keyset.unit.clone(),
+                    active: true,
+                    input_fee_ppk: 0,
+                    final_expiry: keyset.final_expiry,
+                })
+                .collect();
+
+            token.proofs(&alpha_infos)?
         };
         if proofs.is_empty() {
             return Err(Error::EmptyToken(token_teaser));


### PR DESCRIPTION
Offline intermint for wallet
Multihop case consists of first exchanging eCash for substitute beta eCash, and then doing atomic HTLC exchange from there to the wallet mint.