### PR TITLE
ci: add internal wasm package release (Github npm pkgs)

### DIFF
--- a/.github/workflows/wasm_release.yml
+++ b/.github/workflows/wasm_release.yml
@@ -10,17 +10,18 @@ env:
 
 jobs:
   release:
+    environment: release-npmjs
     name: WASM Release and Publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Create Github App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         with:
           app-id: ${{ vars.PRIVATE_REPO_ACCESS_APP_ID }}
           private-key: ${{ secrets.PRIVATE_REPO_ACCESS_APP_PRIVATE_KEY }}
@@ -39,7 +40,7 @@ jobs:
         run: rustup update
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/wasm_release_internal.yml
+++ b/.github/workflows/wasm_release_internal.yml
@@ -1,0 +1,73 @@
+name: wasm release internal
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+    #test workflow
+    branches: ["**"]
+
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
+jobs:
+  release:
+    environment: release-github
+    name: WASM Release and Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Create Github App token
+        id: app-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.PRIVATE_REPO_ACCESS_APP_ID }}
+          private-key: ${{ secrets.PRIVATE_REPO_ACCESS_APP_PRIVATE_KEY }}
+          owner: BitcreditProtocol
+
+      - name: Git auth with app token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+      - name: Switch rust version
+        run: rustup default stable
+
+      - name: Update rust
+        run: rustup update
+
+      - name: Install Node.js and setup registry
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 20
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@bitcreditprotocol"
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
+      - name: Build with wasm-pack
+        env:
+          RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
+        run: |
+          cd crates/bcr-wallet-core
+          wasm-pack build --target web --scope bitcreditprotocol --out-name index
+
+      - name: Copy LICENSE into pkg/
+        run: |
+          cp LICENSE crates/bcr-wallet-core/pkg/
+
+      - name: Publish to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd crates/bcr-wallet-core/pkg
+          npm publish

--- a/.github/workflows/wasm_release_internal.yml
+++ b/.github/workflows/wasm_release_internal.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "v*.*.*"
-    #test workflow
-    branches: ["**"]
 
 env:
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"


### PR DESCRIPTION
- add internal wasm package release (https://github.com/BitcreditProtocol/Wallet-Core/pkgs/npm/bcr-wallet-core)
- gate public npmjs release with environment protection rule

closes BitcreditProtocol/infrastructure#13