### PR TITLE
Refactor to use fingerprints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", tag =
 bcr-wallet-lib = { path = "./crates/bcr-wallet-lib" }
 bip39 = {version = "2.1", features = ["rand"]}
 bitcoin = { version = "0.32" }
-cashu = { version = "0.13", default-features = false }
-cdk = { version = "0.13", default-features = false }
-cdk-common = { version = "0.13", default-features = false }
+cashu = { version = "=0.13.1", default-features = false }
+cdk = { version = "=0.13.1", default-features = false }
+cdk-common = { version = "=0.13.1", default-features = false }
 chrono = { version  = "0.4"}
 ciborium = "0.2"
 futures = {version = "0.3"}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# Wallet-Core
-Bitcredit wallet core in Rust/WASM 
+# Wallet Core
+Bitcredit wallet core in Rust/WASM

--- a/crates/bcr-wallet-core/main.js
+++ b/crates/bcr-wallet-core/main.js
@@ -5,7 +5,7 @@ async function run() {
   await wasmModule.initialize_api();
 
   let update_wallets = async () => {
-    let wallets = await wasmModule.get_wallets_names();
+    let wallets = wasmModule.get_wallets_names();
 
     document.getElementById("walletlist").innerHTML = wallets
       .map((name, idx) => `<option value="${idx}">${name}</option>`)
@@ -19,9 +19,9 @@ async function run() {
     if (wallet_idx < 0) {
       return;
     }
-    let wallet_name = await wasmModule.get_wallet_name(wallet_idx);
+    let wallet_name = wasmModule.get_wallet_name(wallet_idx);
     let wallet_balance = await wasmModule.get_wallet_balance(wallet_idx);
-    let wallet_unit = await wasmModule.get_wallet_currency_unit(wallet_idx);
+    let wallet_unit = wasmModule.get_wallet_currency_unit(wallet_idx);
     let wallet_redemptions = await wasmModule.wallet_list_redemptions(
       wallet_idx,
       172800,
@@ -89,7 +89,7 @@ async function run() {
   });
 
   document.getElementById("redeembtn").addEventListener("click", async () => {
-    let ids = await wasmModule.get_wallets_ids();
+    let ids = wasmModule.get_wallets_ids();
     let idx = Number(ids[document.getElementById("walletlist").selectedIndex]);
 
     let amount_redeemed = await wasmModule.wallet_redeem_credit(idx);
@@ -98,7 +98,7 @@ async function run() {
   });
 
   document.getElementById("requestbtn").addEventListener("click", async () => {
-    let ids = await wasmModule.get_wallets_ids();
+    let ids = wasmModule.get_wallets_ids();
     let idx = Number(ids[document.getElementById("walletlist").selectedIndex]);
     let amount = prompt("Enter import");
     let payment_request = await wasmModule.wallet_prepare_payment_request(
@@ -127,7 +127,7 @@ async function run() {
   });
 
   document.getElementById("sendbtn").addEventListener("click", async () => {
-    let ids = await wasmModule.get_wallets_ids();
+    let ids = wasmModule.get_wallets_ids();
     let idx = Number(ids[document.getElementById("walletlist").selectedIndex]);
     let input = prompt("Enter payment request");
     let summary = await wasmModule.wallet_prepare_payment(idx, input);

--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -74,7 +74,7 @@ pub enum Error {
     #[error("invalid token: {0}")]
     InvalidToken(String),
     #[error("Invalid Hash Lock on Beta Proofs, expected {0} got {1}")]
-    InvalidHashLock(Sha256, Sha256),
+    InvalidHashLock(Sha256, String),
     #[error("no active keyset")]
     NoActiveKeyset,
     #[error("unknown keyset ID")]

--- a/crates/bcr-wallet-core/src/mint.rs
+++ b/crates/bcr-wallet-core/src/mint.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::secp256k1::PublicKey;
-use cashu::{BlindSignature, Proof, ProofDleq};
+use cashu::{Proof, ProofDleq};
 use cdk::Error as CdkError;
 use serde::{Deserialize, Serialize};
 // ----- local imports
@@ -42,15 +42,18 @@ pub struct PublicKeyResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SecretlessProof {
-    pub signature: BlindSignature,
-    pub y: bitcoin::secp256k1::PublicKey,
-    pub dleq: ProofDleq,
+pub struct ProofFingerprint {
+    pub amount: cashu::Amount,
+    pub keyset_id: cashu::Id,
+    pub c: cashu::PublicKey,
+    pub y: cashu::PublicKey,
+    pub dleq: Option<ProofDleq>,
+    pub witness: Option<cashu::Witness>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubstituteExchangeRequest {
-    pub proofs: Vec<SecretlessProof>,
+    pub proofs: Vec<ProofFingerprint>,
     pub locks: Vec<Sha256>,
     pub wallet_pubkey: PublicKey,
 }
@@ -92,7 +95,7 @@ pub trait MintConnector: cdk::wallet::MintConnector + sync::SendSync {
 
     async fn post_exchange_substitute(
         &self,
-        proofs: Vec<SecretlessProof>,
+        proofs: Vec<ProofFingerprint>,
         locks: Vec<bitcoin::hashes::sha256::Hash>,
         wallet_pubkey: bitcoin::secp256k1::PublicKey,
     ) -> CdkResult<Vec<Proof>>;
@@ -280,7 +283,7 @@ impl MintConnector for HttpClientExt {
 
     async fn post_exchange_substitute(
         &self,
-        proofs: Vec<SecretlessProof>,
+        proofs: Vec<ProofFingerprint>,
         locks: Vec<bitcoin::hashes::sha256::Hash>,
         wallet_pubkey: bitcoin::secp256k1::PublicKey,
     ) -> CdkResult<Vec<Proof>> {

--- a/crates/bcr-wallet-core/src/purse.rs
+++ b/crates/bcr-wallet-core/src/purse.rs
@@ -35,6 +35,10 @@ pub trait Wallet: sync::SendSync {
     fn config(&self) -> WalletConfig;
     fn name(&self) -> String;
     fn mint_url(&self) -> MintUrl;
+    #[allow(dead_code)]
+    fn betas(&self) -> Vec<MintUrl>;
+    #[allow(dead_code)]
+    fn clowder_id(&self) -> bitcoin::secp256k1::PublicKey;
     fn mint_urls(&self) -> Vec<MintUrl>;
     async fn prepare_pay(&self, input: String, now: u64) -> Result<PaymentSummary>;
     async fn pay(

--- a/crates/bcr-wallet-core/src/utils.rs
+++ b/crates/bcr-wallet-core/src/utils.rs
@@ -1,67 +1,27 @@
 // ----- standard library imports
-use std::collections::HashMap;
 // ----- extra library imports
-use bitcoin::secp256k1::{PublicKey, SECP256K1};
-use cashu::{BlindSignature, Proof};
+use bitcoin::secp256k1::PublicKey;
+use cashu::Proof;
 use cdk::Error as CdkError;
 // ----- local imports
-use crate::mint::SecretlessProof;
+use crate::mint::ProofFingerprint;
 // ----- end imports
 
 type CdkResult<T> = std::result::Result<T, cdk::Error>;
 
-pub async fn proofs_to_secretless(
-    alpha_id: PublicKey,
-    substitute_client: &dyn crate::mint::MintConnector,
+pub fn proofs_to_fingerprints(
     proofs: Vec<Proof>,
-) -> CdkResult<(Vec<SecretlessProof>, Vec<cashu::secret::Secret>)> {
-    let alpha_keysets = substitute_client
-        .get_alpha_keysets(alpha_id)
-        .await
-        .map_err(|err| CdkError::HttpError(None, err.to_string()))?;
-
-    let keys: HashMap<cashu::Id, cashu::KeySet> = alpha_keysets
-        .iter()
-        .map(|keyset| (keyset.id, keyset.clone()))
-        .collect();
-
+) -> CdkResult<(Vec<ProofFingerprint>, Vec<cashu::secret::Secret>)> {
     let mut secrets = Vec::with_capacity(proofs.len());
-    let mut secret_less = Vec::with_capacity(proofs.len());
+    let mut fingerprints = Vec::with_capacity(proofs.len());
 
     for p in proofs.iter() {
-        let pubkey = keys
-            .get(&p.keyset_id)
-            .ok_or(CdkError::UnknownKeySet)?
-            .keys
-            .amount_key(p.amount)
-            .ok_or(CdkError::AmountKey)?;
-
-        let dleq = p.dleq.as_ref().ok_or(CdkError::DleqProofNotProvided)?;
-        let r = bitcoin::secp256k1::Scalar::from(*dleq.r);
-        let r_bigk: PublicKey = pubkey
-            .mul_tweak(SECP256K1, &r)
-            .map_err(|err| CdkError::Custom(err.to_string()))?;
-        let signature =
-            p.c.combine(&r_bigk)
-                .map_err(|err| CdkError::Custom(err.to_string()))?;
-
-        let dleq = p.dleq.clone().ok_or(CdkError::DleqProofNotProvided)?;
         secrets.push(p.secret.clone());
 
-        let signature = BlindSignature {
-            amount: p.amount,
-            keyset_id: p.keyset_id,
-            c: signature.into(),
-            dleq: None,
-        };
-        secret_less.push(SecretlessProof {
-            signature,
-            dleq,
-            y: *p.y()?,
-        });
+        fingerprints.push(p.clone().try_into()?);
     }
 
-    Ok((secret_less, secrets))
+    Ok((fingerprints, secrets))
 }
 
 pub fn validate_offline_conditions(
@@ -105,6 +65,21 @@ pub fn validate_offline_conditions(
     Ok(lock_time)
 }
 
+impl TryFrom<Proof> for ProofFingerprint {
+    type Error = CdkError;
+
+    fn try_from(proof: Proof) -> Result<Self, Self::Error> {
+        Ok(ProofFingerprint {
+            amount: proof.amount,
+            keyset_id: proof.keyset_id,
+            c: proof.c,
+            dleq: proof.dleq.clone(),
+            witness: proof.witness.clone(),
+            y: proof.y()?,
+        })
+    }
+}
+
 #[cfg(all(test, not(target_arch = "wasm32")))]
 pub mod tests {
     use async_trait::async_trait;
@@ -114,7 +89,7 @@ pub mod tests {
     };
     use cdk_common::Error as CDKError;
 
-    use crate::mint::SecretlessProof;
+    use crate::mint::ProofFingerprint;
     type CdkResult<T> = Result<T, CDKError>;
 
     mockall::mock! {
@@ -202,7 +177,7 @@ pub mod tests {
 
         async fn post_exchange_substitute(
             &self,
-            proofs: Vec<SecretlessProof>,
+            proofs: Vec<ProofFingerprint>,
             locks: Vec<bitcoin::hashes::sha256::Hash>,
             wallet_pubkey: bitcoin::secp256k1::PublicKey,
         ) -> CdkResult<Vec<cashu::Proof>>;

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -542,7 +542,7 @@ where
                 .and_then(|c| c.clone().try_into().ok())
                 .ok_or(Error::SpendingConditions)?;
 
-            if secret.secret_data().data().to_string() != h.to_string() {
+            if secret.secret_data().data() != h.to_string() {
                 return Err(Error::InvalidHashLock(
                     h,
                     secret.secret_data().data().to_string(),

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -1,7 +1,7 @@
 // ----- standard library imports
 use std::{collections::HashMap, str::FromStr, sync::Mutex};
 // ----- extra library imports
-use crate::utils::proofs_to_secretless;
+use crate::utils::proofs_to_fingerprints;
 use async_trait::async_trait;
 use bcr_wallet_lib::wallet::Token;
 use bitcoin::hashes::{Hash, sha256::Hash as Sha256};
@@ -145,6 +145,7 @@ pub struct Wallet<TxRepo, DebtPck> {
     mnemonic: bip39::Mnemonic,
     current_payment: Mutex<Option<PayReference>>,
     betas: Vec<cashu::MintUrl>,
+    clowder_id: bitcoin::secp256k1::PublicKey,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -164,6 +165,7 @@ impl<TxRepo, DebtPck> Wallet<TxRepo, DebtPck> {
         mnemonic: bip39::Mnemonic,
     ) -> Result<Self> {
         let betas = client.get_clowder_betas().await?;
+        let clowder_id = client.get_clowder_id().await?;
         Ok(Self {
             network,
             client,
@@ -175,6 +177,7 @@ impl<TxRepo, DebtPck> Wallet<TxRepo, DebtPck> {
             mnemonic,
             current_payment: Mutex::new(None),
             betas,
+            clowder_id,
         })
     }
 
@@ -392,7 +395,7 @@ where
             } else {
                 tracing::debug!("Offline exchange");
                 let substitute_proofs = self
-                    .offline_exchange(alpha_id, &substitute_client, proofs, tstamp)
+                    .offline_exchange(&substitute_client, proofs, tstamp)
                     .await?;
                 // Alpha proofs -> Beta proofs is done, so we only need the path from Beta to the Wallet Mint
                 let path = path.node_ids[1..].to_vec();
@@ -500,7 +503,6 @@ where
 
     async fn offline_exchange(
         &self,
-        alpha_id: bitcoin::secp256k1::PublicKey,
         substitute_client: &dyn MintConnector,
         proofs: Vec<Proof>,
         tstamp: u64,
@@ -508,15 +510,14 @@ where
         // Ephemeral P2PK secret
         let wallet_pk = cashu::SecretKey::generate();
 
-        let (secretless, secrets) =
-            proofs_to_secretless(alpha_id, substitute_client, proofs).await?;
+        let (fingerprints, secrets) = proofs_to_fingerprints(proofs)?;
         let hash_locks: Vec<Sha256> = secrets
             .iter()
             .map(|secret| Sha256::hash(&secret.to_bytes()))
             .collect();
         let mut beta_proofs = substitute_client
             .post_exchange_substitute(
-                secretless.clone(),
+                fingerprints.clone(),
                 hash_locks.clone(),
                 *wallet_pk.public_key(),
             )
@@ -955,5 +956,13 @@ where
         let mut urls = self.betas.clone();
         urls.push(self.client.mint_url());
         urls
+    }
+
+    fn betas(&self) -> Vec<cashu::MintUrl> {
+        self.betas.clone()
+    }
+
+    fn clowder_id(&self) -> bitcoin::secp256k1::PublicKey {
+        self.clowder_id
     }
 }

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -527,10 +527,10 @@ where
             let msg: Vec<u8> = p.secret.to_bytes();
 
             // Verify spending conditions
-            let hashed = Sha256::hash(&msg);
-            if hashed != h {
-                return Err(Error::InvalidHashLock(h, hashed));
-            }
+            // let hashed = Sha256::hash(&msg);
+            // if hashed != h {
+            //     return Err(Error::InvalidHashLock(h, hashed));
+            // }
             let secret: cashu::nuts::nut10::Secret = p
                 .secret
                 .clone()
@@ -541,6 +541,14 @@ where
                 .tags()
                 .and_then(|c| c.clone().try_into().ok())
                 .ok_or(Error::SpendingConditions)?;
+
+            if secret.secret_data().data().to_string() != h.to_string() {
+                return Err(Error::InvalidHashLock(
+                    h,
+                    secret.secret_data().data().to_string(),
+                ));
+            }
+
             crate::utils::validate_offline_conditions(
                 *wallet_pk.public_key(),
                 &conditions,

--- a/crates/bcr-wallet-core/tests/rexie.rs
+++ b/crates/bcr-wallet-core/tests/rexie.rs
@@ -258,7 +258,7 @@ async fn transaction_load_tx_nonexisting() {
 
 #[wasm_bindgen_test]
 async fn transaction_delete_tx() {
-    let transactiondb = create_transaction_db("transaction_load_tx").await;
+    let transactiondb = create_transaction_db("transaction_delete_tx").await;
 
     let ys = publics()[0..3].to_vec();
     let tx = Transaction {


### PR DESCRIPTION
Clowder updated to use fingerprints, these changes are to match the request format expected for the offline intermint exchange.