### PR TITLE
add SentinelClient

### DIFF
--- a/crates/bcr-wallet-core/Cargo.toml
+++ b/crates/bcr-wallet-core/Cargo.toml
@@ -17,6 +17,7 @@ cdk = { workspace = true, features = ["wallet"] }
 chrono = {workspace = true}
 futures = {workspace = true}
 nostr-sdk = {workspace =true, features = ["nip06"]}
+rand = {workspace = true}
 reqwest = {workspace = true}
 secp256k1.workspace = true
 serde.workspace = true

--- a/crates/bcr-wallet-core/src/app.rs
+++ b/crates/bcr-wallet-core/src/app.rs
@@ -1,5 +1,5 @@
-use crate::mint::MintConnector as MintCon;
 use crate::{
+    MintConnector as MintCon,
     config::{Config, SameMintSafeMode, Settings},
     error::{Error, Result},
     purse::Wallet,
@@ -506,7 +506,7 @@ async fn build_wallet(
 ) -> Result<ProductionWallet> {
     let seed = mnemonic.to_seed("");
     // retrieving mint details
-    let client = Box::new(ProductionConnector::new(mint_url.clone()));
+    let client = ProductionConnector::new(mint_url.clone());
     let keyset_infos = client.get_mint_keysets().await?.keysets;
     let (debit_unit, credit_unit) = find_currency_units(&keyset_infos)?;
     // building wallet dbs
@@ -538,11 +538,19 @@ async fn build_wallet(
 
     let mut beta_clients = HashMap::<cashu::MintUrl, Box<dyn MintCon>>::new();
 
-    for beta in client.as_ref().get_clowder_betas().await? {
-        let beta_client = crate::mint::HttpClientExt::new(beta.clone());
+    let betas_urls = client.get_clowder_betas().await?;
+    for beta in betas_urls.clone() {
+        let beta_client = ProductionConnector::new(beta.clone());
         beta_clients.insert(beta, Box::new(beta_client));
     }
-
+    // When same_mint_safe_mode is enabled, wrap the client with SentinelClient
+    // to send events to sentinel nodes for monitoring
+    let client = if matches!(same_mint_safe_mode, SameMintSafeMode::Disabled) {
+        Box::new(client) as Box<dyn MintCon>
+    } else {
+        let cl = crate::mint::SentinelClient::new(client, betas_urls);
+        Box::new(cl) as Box<dyn MintCon>
+    };
     let new_wallet: ProductionWallet = ProductionWallet::new(
         network,
         client,

--- a/crates/bcr-wallet-core/src/mint.rs
+++ b/crates/bcr-wallet-core/src/mint.rs
@@ -4,6 +4,7 @@ use bcr_common::wire::{clowder as wire_clowder, keys as wire_keys, swap as wire_
 use bitcoin::base64::prelude::*;
 use cashu::Proof;
 use cdk::Error as CdkError;
+use rand::seq::IndexedRandom;
 use std::str::FromStr;
 
 #[async_trait]
@@ -178,6 +179,430 @@ impl cdk::wallet::MintConnector for HttpClientExt {
 
 #[async_trait]
 impl MintConnector for HttpClientExt {
+    fn mint_url(&self) -> cashu::MintUrl {
+        cashu::MintUrl::from_str(self.url.as_str())
+            .expect("cashu::MintUrl is as good as reqwest::Url")
+    }
+
+    /// Active alpha keysets
+    async fn get_alpha_keysets(
+        &self,
+        alpha_id: bitcoin::secp256k1::PublicKey,
+    ) -> CdkResult<Vec<cashu::KeySet>> {
+        let url = self.url.join(&format!("v1/alpha/keysets/{alpha_id}"))?;
+        let response = self
+            .secondary
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        let response: cashu::nuts::KeysResponse = response
+            .json()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        Ok(response.keysets)
+    }
+
+    /// Is Alpha Offline
+    async fn get_alpha_offline(&self, alpha_id: bitcoin::secp256k1::PublicKey) -> CdkResult<bool> {
+        let url = self.url.join(&format!("v1/alpha/offline/{alpha_id}"))?;
+        let response = self
+            .secondary
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        let response: wire_clowder::OfflineResponse = response
+            .json()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        Ok(response.offline)
+    }
+
+    /// Determines the status of a mint from the view of the requested Beta
+    async fn get_alpha_status(
+        &self,
+        alpha_id: bitcoin::secp256k1::PublicKey,
+    ) -> CdkResult<wire_clowder::AlphaStateResponse> {
+        let url = self.url.join(&format!("v1/alpha/status/{alpha_id}"))?;
+        let response = self
+            .secondary
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        Ok(response
+            .json()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?)
+    }
+
+    /// Determines the substitute beta of an alpha mint
+    async fn get_alpha_substitute(
+        &self,
+        alpha_id: bitcoin::secp256k1::PublicKey,
+    ) -> CdkResult<wire_clowder::ConnectedMintResponse> {
+        let url = self.url.join(&format!("v1/alpha/substitute/{alpha_id}"))?;
+        let response = self
+            .secondary
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        Ok(response
+            .json()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?)
+    }
+
+    async fn get_clowder_betas(&self) -> CdkResult<Vec<cashu::MintUrl>> {
+        let url = self
+            .url
+            .join("v1/betas")
+            .expect("get_clowder_betas url error");
+        let response = self
+            .secondary
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        let response: wire_clowder::ConnectedMintsResponse = response
+            .json()
+            .await
+            .map_err(|e| CdkError::Custom(e.to_string()))?;
+        Ok(response.mints.into_iter().map(|m| m.mint).collect())
+    }
+
+    async fn post_exchange_substitute(
+        &self,
+        proofs: Vec<wire_keys::ProofFingerprint>,
+        locks: Vec<bitcoin::hashes::sha256::Hash>,
+        wallet_pubkey: bitcoin::secp256k1::PublicKey,
+    ) -> CdkResult<Vec<Proof>> {
+        let url = self.url.join("v1/exchange/substitute")?;
+        let request = wire_clowder::SubstituteExchangeRequest {
+            proofs,
+            locks,
+            wallet_pubkey,
+        };
+
+        let response = self
+            .secondary
+            .post(url)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        let response: wire_clowder::SubstituteExchangeResponse = response
+            .json()
+            .await
+            .map_err(|e| CdkError::Custom(e.to_string()))?;
+        Ok(response.outputs)
+    }
+
+    async fn post_exchange(
+        &self,
+        alpha_proofs: Vec<Proof>,
+        exchange_path: Vec<bitcoin::secp256k1::PublicKey>,
+    ) -> CdkResult<Vec<Proof>> {
+        let url = self
+            .url
+            .join("v1/exchange")
+            .expect("post_clowder_exchange url error");
+        let request = wire_clowder::ExchangeRequest {
+            exchange_path,
+            alpha_proofs,
+        };
+        let response = self
+            .secondary
+            .post(url)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        let response: wire_clowder::ExchangeResponse = response
+            .json()
+            .await
+            .map_err(|e| CdkError::Custom(e.to_string()))?;
+        Ok(response.beta_proofs)
+    }
+
+    async fn get_clowder_id(&self) -> CdkResult<bitcoin::secp256k1::PublicKey> {
+        let url = self.url.join("v1/id").expect("get_clowder_id url error");
+
+        let response = self
+            .secondary
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        let response: wire_clowder::PublicKeyResponse = response
+            .json()
+            .await
+            .map_err(|e| CdkError::Custom(e.to_string()))?;
+        Ok(response.public_key)
+    }
+
+    async fn post_clowder_path(
+        &self,
+        origin_mint_url: cashu::MintUrl,
+    ) -> CdkResult<wire_clowder::ConnectedMintsResponse> {
+        let url = self
+            .url
+            .join("v1/path")
+            .expect("post_clowder_path url error");
+        let request = wire_clowder::PathRequest { origin_mint_url };
+        let response = self
+            .secondary
+            .post(url)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| CdkError::HttpError(None, e.to_string()))?;
+        let response: wire_clowder::ConnectedMintsResponse = response
+            .json()
+            .await
+            .map_err(|e| CdkError::Custom(e.to_string()))?;
+        Ok(response)
+    }
+
+    async fn post_commitment(
+        &self,
+        inputs: Vec<cashu::Proof>,
+        outputs: Vec<cashu::BlindedMessage>,
+        expiration: chrono::TimeDelta,
+        alpha_pk: secp256k1::PublicKey,
+    ) -> Result<(
+        Vec<cashu::PublicKey>,
+        Vec<cashu::BlindedMessage>,
+        TStamp,
+        secp256k1::schnorr::Signature,
+    )> {
+        let url = self
+            .url
+            .join("v1/commitment")
+            .expect("post_commitment url error");
+        let inputs: Vec<_> = inputs
+            .into_iter()
+            .map(wire_keys::ProofFingerprint::try_from)
+            .collect::<std::result::Result<_, cashu::nut00::Error>>()?;
+        let now = chrono::Utc::now();
+        let payload = wire_swap::CommitmentContent {
+            inputs,
+            outputs,
+            expiration: now + expiration,
+        };
+        let borshed = borsh::to_vec(&payload)?;
+        let content = BASE64_STANDARD.encode(borshed);
+        let request = wire_swap::CommitmentRequest {
+            content: content.clone(),
+        };
+        let response = self.secondary.post(url).json(&request).send().await?;
+        let response: wire_swap::CommitmentResponse = response.json().await?;
+        bcr_common::core::signature::schnorr_verify_b64(
+            &content,
+            &response.commitment,
+            &alpha_pk.x_only_public_key().0,
+        )?;
+        let inputs: Vec<cashu::PublicKey> = payload.inputs.into_iter().map(|fp| fp.y).collect();
+        Ok((
+            inputs,
+            payload.outputs,
+            payload.expiration,
+            response.commitment,
+        ))
+    }
+}
+
+/// A client wrapper that forwards wallet events to sentinel nodes.
+///
+/// This client wraps the standard HTTP client and sends monitoring events
+/// to randomly selected sentinel nodes after performing mint, swap, and melt operations.
+#[derive(Debug, Clone)]
+pub struct SentinelClient {
+    main: cdk::wallet::HttpClient,
+    url: reqwest::Url,
+    secondary: reqwest::Client,
+    sentinels: Vec<reqwest::Url>,
+}
+
+impl SentinelClient {
+    pub fn new(client: HttpClientExt, sentinels: Vec<cashu::MintUrl>) -> Self {
+        let sentinels = sentinels
+            .iter()
+            .map(|url| {
+                reqwest::Url::parse(&url.to_string())
+                    .expect("cashu::MintUrl is as good as reqwest::Url")
+            })
+            .collect();
+
+        let HttpClientExt {
+            main,
+            url,
+            secondary,
+        } = client;
+        Self {
+            main,
+            url,
+            secondary,
+            sentinels,
+        }
+    }
+    /// Returns a randomly selected sentinel URL from the configured list, or `None` if no sentinels are configured.
+    fn random_sentinel(&self) -> Option<&reqwest::Url> {
+        self.sentinels.choose(&mut rand::rng())
+    }
+    /// Constructs the sentinel event endpoint URL from a base sentinel URL.
+    fn sentinel_ep(base_url: &reqwest::Url) -> reqwest::Url {
+        base_url
+            .join("v1/wallet/event")
+            .expect("wallet event url error")
+    }
+}
+
+#[async_trait]
+impl cdk::wallet::MintConnector for SentinelClient {
+    async fn get_mint_keys(&self) -> CdkResult<Vec<cashu::KeySet>> {
+        self.main.get_mint_keys().await
+    }
+    async fn post_restore(
+        &self,
+        request: cashu::RestoreRequest,
+    ) -> CdkResult<cashu::RestoreResponse> {
+        self.main.post_restore(request).await
+    }
+    async fn post_check_state(
+        &self,
+        request: cashu::CheckStateRequest,
+    ) -> CdkResult<cashu::CheckStateResponse> {
+        self.main.post_check_state(request).await
+    }
+    async fn get_mint_keyset(&self, keyset_id: cashu::Id) -> CdkResult<cashu::KeySet> {
+        self.main.get_mint_keyset(keyset_id).await
+    }
+    async fn get_mint_keysets(&self) -> CdkResult<cashu::KeysetResponse> {
+        self.main.get_mint_keysets().await
+    }
+    async fn get_mint_info(&self) -> CdkResult<cashu::MintInfo> {
+        self.main.get_mint_info().await
+    }
+
+    async fn post_swap(&self, request: cashu::SwapRequest) -> CdkResult<cashu::SwapResponse> {
+        let response = self.main.post_swap(request).await?;
+        let Some(sentinel_url) = self.random_sentinel() else {
+            return Ok(response);
+        };
+        let event_url = Self::sentinel_ep(sentinel_url);
+        let event = wire_clowder::WalletEvent::Swap {
+            minted: response.signatures.clone(),
+        };
+        let resp = self.secondary.post(event_url).json(&event).send().await;
+        if let Err(e) = resp {
+            tracing::error!("Failed to send swap event to sentinel {sentinel_url}: {e}");
+        }
+        Ok(response)
+    }
+
+    async fn post_mint(
+        &self,
+        request: cashu::MintRequest<String>,
+    ) -> CdkResult<cashu::MintResponse> {
+        let response = self.main.post_mint(request).await?;
+        let Some(sentinel_url) = self.random_sentinel() else {
+            return Ok(response);
+        };
+        let event_url = Self::sentinel_ep(sentinel_url);
+        let event = wire_clowder::WalletEvent::Mint {
+            minted: response.signatures.clone(),
+        };
+        let resp = self.secondary.post(event_url).json(&event).send().await;
+        if let Err(e) = resp {
+            tracing::error!("Failed to send mint event to sentinel {sentinel_url}: {e}");
+        }
+        Ok(response)
+    }
+    async fn post_mint_quote(
+        &self,
+        request: cashu::MintQuoteBolt11Request,
+    ) -> CdkResult<cashu::MintQuoteBolt11Response<String>> {
+        self.main.post_mint_quote(request).await
+    }
+
+    async fn post_melt(
+        &self,
+        request: cashu::MeltRequest<String>,
+    ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        let fps = request
+            .inputs()
+            .iter()
+            .map(|p| p.y())
+            .collect::<std::result::Result<Vec<_>, cashu::nut00::Error>>()?;
+        let qid = request.quote().clone();
+        let response = self.main.post_melt(request).await?;
+        let Some(sentinel_url) = self.random_sentinel() else {
+            return Ok(response);
+        };
+        let event_url = Self::sentinel_ep(sentinel_url);
+        let event = wire_clowder::WalletEvent::Melt { burned: fps, qid };
+        let resp = self.secondary.post(event_url).json(&event).send().await;
+        if let Err(e) = resp {
+            tracing::error!("Failed to send melt event to sentinel {sentinel_url}: {e}");
+        }
+        Ok(response)
+    }
+    async fn get_melt_quote_status(
+        &self,
+        quote_id: &str,
+    ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        self.main.get_melt_quote_status(quote_id).await
+    }
+    async fn post_melt_quote(
+        &self,
+        request: cashu::MeltQuoteBolt11Request,
+    ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        self.main.post_melt_quote(request).await
+    }
+    async fn get_mint_quote_status(
+        &self,
+        quote_id: &str,
+    ) -> CdkResult<cashu::MintQuoteBolt11Response<String>> {
+        self.main.get_mint_quote_status(quote_id).await
+    }
+
+    async fn post_mint_bolt12_quote(
+        &self,
+        request: cashu::MintQuoteBolt12Request,
+    ) -> CdkResult<cashu::MintQuoteBolt12Response<String>> {
+        self.main.post_mint_bolt12_quote(request).await
+    }
+    async fn get_mint_quote_bolt12_status(
+        &self,
+        quote_id: &str,
+    ) -> CdkResult<cashu::MintQuoteBolt12Response<String>> {
+        self.main.get_mint_quote_bolt12_status(quote_id).await
+    }
+    async fn post_melt_bolt12_quote(
+        &self,
+        request: cashu::MeltQuoteBolt12Request,
+    ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        self.main.post_melt_bolt12_quote(request).await
+    }
+    async fn get_melt_bolt12_quote_status(
+        &self,
+        quote_id: &str,
+    ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        self.main.get_melt_bolt12_quote_status(quote_id).await
+    }
+    async fn post_melt_bolt12(
+        &self,
+        request: cashu::MeltRequest<String>,
+    ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        self.main.post_melt_bolt12(request).await
+    }
+}
+
+#[async_trait]
+impl MintConnector for SentinelClient {
     fn mint_url(&self) -> cashu::MintUrl {
         cashu::MintUrl::from_str(self.url.as_str())
             .expect("cashu::MintUrl is as good as reqwest::Url")

--- a/crates/bcr-wallet-core/src/pocket/debit.rs
+++ b/crates/bcr-wallet-core/src/pocket/debit.rs
@@ -393,8 +393,8 @@ impl wallet::DebitPocket for Pocket {
                 .await?;
             return Err(Error::MeltUnpaid(response.quote));
         }
-        if let Some(premints) = &premints {
-            let change = unblind_proofs(&keyset, &response.change.unwrap_or(Vec::new()), premints);
+        if let Some(premints) = premints {
+            let change = unblind_proofs(&keyset, response.change.unwrap_or(Vec::new()), premints);
             for proof in change {
                 self.pdb.store_new(proof).await?;
             }
@@ -419,7 +419,7 @@ impl wallet::DebitPocket for Pocket {
                 }) => {
                     let premints = self.mdb.load_melt(mid.clone()).await?;
                     let keyset = client.get_mint_keyset(premints.keyset_id).await?;
-                    let proofs = unblind_proofs(&keyset, &signatures, &premints);
+                    let proofs = unblind_proofs(&keyset, signatures, premints);
                     for proof in proofs {
                         let amount = proof.amount;
                         match self.pdb.store_new(proof).await {

--- a/crates/bcr-wallet-core/src/pocket/mod.rs
+++ b/crates/bcr-wallet-core/src/pocket/mod.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 use async_trait::async_trait;
 use cashu::{
-    Amount, CurrencyUnit, KeySet, KeySetInfo, ProofDleq, amount::SplitTarget, nut00 as cdk00,
-    nut01 as cdk01, nut03 as cdk03, nut07 as cdk07,
+    Amount, CurrencyUnit, KeySet, KeySetInfo, amount::SplitTarget, nut00 as cdk00, nut01 as cdk01,
+    nut03 as cdk03, nut07 as cdk07,
 };
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
@@ -70,8 +70,8 @@ async fn clean_local_proofs(
 ///////////////////////////////////////////// unblind_proofs
 pub(crate) fn unblind_proofs(
     keyset: &KeySet,
-    signatures: &[cdk00::BlindSignature],
-    premint: &cdk00::PreMintSecrets,
+    signatures: Vec<cdk00::BlindSignature>,
+    premint: cdk00::PreMintSecrets,
 ) -> Vec<cdk00::Proof> {
     let mut proofs: Vec<cdk00::Proof> = Vec::new();
     if signatures.len() > premint.len() {
@@ -81,54 +81,23 @@ pub(crate) fn unblind_proofs(
             premint.len()
         )
     }
-    for (signature, secret) in signatures.iter().zip(premint.iter()) {
-        if signature.keyset_id != keyset.id || signature.keyset_id != premint.keyset_id {
-            tracing::error!(
-                "kid mismatch in signature: {}, {}, {}",
-                signature.keyset_id,
-                keyset.id,
-                premint.keyset_id,
-            );
-            continue;
+    for (signature, secret) in signatures.into_iter().zip(premint.iter()) {
+        let kid = signature.keyset_id;
+        let amount = signature.amount;
+        // WARNING: due to a bug in `into_iter()` in cashu 0.13.1 we need to `iter()` and clone the secret
+        // fixed in 0.14.0
+        match bcr_common::core::signature::unblind_ecash_signature(
+            keyset,
+            secret.clone(),
+            signature,
+        ) {
+            Ok(proof) => proofs.push(proof),
+            Err(e) => {
+                tracing::error!(
+                    "unblind_ecash_signature failed: kid: {kid}, amount: {amount}, error: {e}",
+                );
+            }
         }
-        if secret.amount != Amount::ZERO && signature.amount != secret.amount {
-            tracing::error!(
-                "amount mismatch in signature: {} != {}",
-                signature.amount,
-                secret.amount
-            );
-            continue;
-        }
-        let Some(key) = keyset.keys.get(&signature.amount) else {
-            tracing::error!(
-                "No mint key for amount: {} in kid: {}",
-                keyset.id,
-                signature.amount,
-            );
-            continue;
-        };
-        let result = cashu::dhke::unblind_message(&signature.c, &secret.r, key);
-        let Ok(c) = result else {
-            tracing::error!(
-                "unblind_message fail: kid: {}, amount {}",
-                keyset.id,
-                signature.amount,
-            );
-            continue;
-        };
-        let mut proof = cdk00::Proof::new(
-            signature.amount,
-            signature.keyset_id,
-            secret.secret.clone(),
-            c,
-        );
-
-        proof.dleq = signature
-            .dleq
-            .as_ref()
-            .map(|dleq| ProofDleq::new(dleq.e.clone(), dleq.s.clone(), secret.r.clone()));
-
-        proofs.push(proof);
     }
     proofs
 }
@@ -137,7 +106,7 @@ pub(crate) fn unblind_proofs(
 async fn swap(
     output_unit: CurrencyUnit,
     inputs: Vec<cdk00::Proof>,
-    premints: HashMap<cashu::Id, cdk00::PreMintSecrets>,
+    mut premints: HashMap<cashu::Id, cdk00::PreMintSecrets>,
     keysets: HashMap<cashu::Id, KeySet>,
     client: &dyn MintConnector,
     db: &dyn PocketRepository,
@@ -175,9 +144,9 @@ async fn swap(
             .or_insert_with(|| vec![signature]);
     }
     let mut total_cashed_in = Amount::ZERO;
-    for (kid, signatures) in signatures.iter() {
-        let premint = premints.get(kid).expect("premint should be here");
-        let keyset = keysets.get(kid).expect("keyset should be here");
+    for (kid, signatures) in signatures.into_iter() {
+        let premint = premints.remove(&kid).expect("premint should be here");
+        let keyset = keysets.get(&kid).expect("keyset should be here");
         let proofs = unblind_proofs(keyset, signatures, premint);
 
         for proof in proofs {
@@ -225,7 +194,7 @@ async fn swap_proof_to_target(
         .await?;
     let signatures = client.post_swap(request).await?.signatures;
     let mut on_target: HashMap<cdk01::PublicKey, cdk00::Proof> = HashMap::new();
-    let mut proofs = unblind_proofs(target_keyset, &signatures, &premint);
+    let mut proofs = unblind_proofs(target_keyset, signatures, premint);
     proofs.sort_by_key(|proof| std::cmp::Reverse(proof.amount));
     let mut current_amount = Amount::ZERO;
     for proof in proofs.into_iter() {
@@ -340,7 +309,7 @@ mod tests {
         assert!(premint.blinded_messages().len() == 1);
         let blind = premint.blinded_messages()[0].clone();
         let signature = signature::sign_ecash(&mintkeyset, &blind).unwrap();
-        let proofs = super::unblind_proofs(&keyset, &[signature], &premint);
+        let proofs = super::unblind_proofs(&keyset, vec![signature], premint);
         assert_eq!(proofs.len(), 1);
         signature::verify_ecash_proof(&mintkeyset, &proofs[0]).unwrap();
     }
@@ -357,7 +326,7 @@ mod tests {
             &mintkeyset,
             &[Amount::from(8u64), Amount::from(32u64)],
         );
-        let proofs = super::unblind_proofs(&keyset, &signatures, &premint);
+        let proofs = super::unblind_proofs(&keyset, signatures, premint);
         assert_eq!(proofs.len(), 1);
     }
 
@@ -373,7 +342,7 @@ mod tests {
             &mintkeyset,
             &[Amount::from(16u64), Amount::from(4u64)],
         );
-        let proofs = super::unblind_proofs(&keyset, &signatures, &premint);
+        let proofs = super::unblind_proofs(&keyset, signatures, premint);
         assert_eq!(proofs.len(), 0);
     }
 
@@ -386,7 +355,7 @@ mod tests {
             cdk00::PreMintSecrets::random(kid2, Amount::from(16u64), &SplitTarget::None).unwrap();
         assert_eq!(premint.blinded_messages().len(), 1);
         let signatures = core_tests::generate_ecash_signatures(&mintkeyset, &[Amount::from(16u64)]);
-        let proofs = super::unblind_proofs(&keyset, &signatures, &premint);
+        let proofs = super::unblind_proofs(&keyset, signatures, premint);
         assert_eq!(proofs.len(), 0);
     }
 

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -531,7 +531,7 @@ where
         let swap = client.post_swap(swap_request).await?;
 
         let keyset = client.get_mint_keyset(active_keyset_id).await?;
-        let proofs = crate::pocket::unblind_proofs(&keyset, &swap.signatures, &premints);
+        let proofs = crate::pocket::unblind_proofs(&keyset, swap.signatures, premints);
 
         Ok(proofs)
     }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `SentinelClient` wrapper for wallet event reporting to sentinel nodes

- Refactor `unblind_proofs` to use `bcr_common::core::signature::unblind_ecash_signature`

- Update function signatures to accept owned values instead of references

- Conditionally wrap main client with `SentinelClient` based on `SameMintSafeMode`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HttpClientExt"] -->|wrapped by| B["SentinelClient"]
  B -->|on swap/mint/melt| C["Random Sentinel"]
  C -->|POST wallet event| D["Sentinel Endpoint"]
  B -->|delegates other calls| A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mint.rs</strong><dd><code>Implement SentinelClient with event reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/mint.rs

<ul><li>Add new <code>SentinelClient</code> struct that wraps <code>HttpClientExt</code> and manages <br>sentinel URLs<br> <li> Implement <code>cdk::wallet::MintConnector</code> trait with event reporting on <br>swap/mint/melt operations<br> <li> Implement custom <code>MintConnector</code> trait delegating all clowder-specific <br>methods<br> <li> Add random sentinel selection via <code>random_sentinel()</code> helper method<br> <li> Send <code>WalletEvent</code> to randomly chosen sentinel after successful <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/109/files#diff-7eab6d3372222aa5e53932fef11d9369eb01d417f0536c5be1994dd751f47aad">+423/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app.rs</strong><dd><code>Integrate SentinelClient into wallet initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/app.rs

<ul><li>Remove <code>Box::new()</code> wrapper from <code>ProductionConnector</code> instantiation<br> <li> Change beta client creation to use <code>ProductionConnector</code> instead of <br><code>HttpClientExt</code><br> <li> Add conditional logic to wrap client with <code>SentinelClient</code> when <br><code>SameMintSafeMode</code> is enabled<br> <li> Store beta URLs before loop to avoid repeated async calls</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/109/files#diff-e720b0c2ecd74d4e7e02e6dededa253d5fad3026aacb07be25024bb8eeb4e586">+11/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Refactor unblind_proofs to use common signature utility</code>&nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/pocket/mod.rs

<ul><li>Refactor <code>unblind_proofs</code> to accept owned <code>Vec<BlindSignature></code> and <code>PreMintSecrets</code> instead <br>of references<br> <li> Replace manual unblinding logic with call to <br><code>bcr_common::core::signature::unblind_ecash_signature</code><br> <li> Simplify error handling by delegating to external function<br> <li> Update all call sites to pass owned values instead of references<br> <li> Remove <code>ProofDleq</code> import as it's now handled by external function</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/109/files#diff-75cb8e6a50ed45d750da38a0c0725794db0e7f0682a40c7a7446a0564b24fb5d">+29/-60</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>debit.rs</strong><dd><code>Update unblind_proofs call signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/pocket/debit.rs

<ul><li>Update <code>unblind_proofs</code> calls to pass owned values instead of references<br> <li> Remove unnecessary reference operators in two locations</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/109/files#diff-4e6f06900be2b435ce446adf18b2634ee588863817cfa96fd68972f5560659a5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wallet.rs</strong><dd><code>Update unblind_proofs call signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/src/wallet.rs

<ul><li>Update <code>unblind_proofs</code> call to pass owned values instead of references</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/109/files#diff-a728dbed0b385adf70434edb3f581a46a8ba286a76c7b6049469f1b36220caad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add rand dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bcr-wallet-core/Cargo.toml

- Add `rand` workspace dependency for random sentinel selection


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/Wallet-Core/pull/109/files#diff-663cb2a7378a6c3a4f5a754ee6cd1fd4f3e9add59e4080c64036662f5ee2e83d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

