### PR TITLE
Add jobs for migrate rabid and redeem, Add logging for requests, Small fixes, Remove unused Errors

### DIFF
--- a/crates/bcr-wallet-cli/alice.toml
+++ b/crates/bcr-wallet-cli/alice.toml
@@ -1,6 +1,7 @@
 ## Other mint URLs
 #mint_url = "http://localhost:4343"
-mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
+mint_url = "http://localhost:8080"
+# mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
 # mint_url = "https://mint.wildcat1.clowder1.minibill.tech"
 
 # mint_url = "https://wildcat-dev-docker.minibill.tech"

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -180,6 +180,11 @@ pub async fn cmd_send_payment(
     Ok(res)
 }
 
+pub async fn cmd_run_jobs(app_state: &AppState) -> Result<()> {
+    app_state.execute_jobs().await;
+    Ok(())
+}
+
 fn push_line(res: &mut String) {
     res.push_str("-----------------------\n");
 }

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -55,6 +55,8 @@ enum Commands {
     ReclaimFunds { id: usize },
     #[command(name = "migrate_rabid")]
     MigrateRabid,
+    #[command(name = "run_jobs")]
+    RunJobs,
     #[command(name = "gen_mnemonic")]
     GenMnemonic,
 }
@@ -158,6 +160,10 @@ async fn main() -> Result<()> {
         Commands::MigrateRabid => {
             info!("Migrate Rabid for {}", cli.wallet,);
             app_state.purse_migrate_rabid().await?
+        }
+        Commands::RunJobs => {
+            info!("RunJobs for {}:", cli.wallet);
+            command::cmd_run_jobs(&app_state).await?;
         }
     }
 

--- a/crates/bcr-wallet-core/src/db.rs
+++ b/crates/bcr-wallet-core/src/db.rs
@@ -43,3 +43,10 @@ pub async fn build_settingsdb(
 ) -> Result<prod::ProductionSettingsRepository> {
     prod::ProductionSettingsRepository::new(db)
 }
+
+pub async fn build_jobsdb(
+    _db_version: u32,
+    db: Arc<redb::Database>,
+) -> Result<prod::ProductionJobsRepository> {
+    prod::ProductionJobsRepository::new(db)
+}

--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -64,16 +64,6 @@ pub enum Error {
     RedbStorage(#[from] redb::StorageError),
     #[error("Database Join error: {0}")]
     RedbTokioSpawn(#[from] tokio::task::JoinError),
-    #[error("local pocket DB not initialized correctly")]
-    BadPocketDB,
-    #[error("local purse DB not initialized correctly")]
-    BadPurseDB,
-    #[error("local transaction DB not initialized correctly")]
-    BadTransactionDB,
-    #[error("local mint/melt DB not initialized correctly")]
-    BadMintMeltDB,
-    #[error("local settings DB not initialized correctly")]
-    BadSettingsDB,
     #[error("proof in local DB not found: {0}")]
     ProofNotFound(cashu::PublicKey),
     #[error("proof not in desired state: {0}")]
@@ -82,8 +72,6 @@ pub enum Error {
     CounterKidMismatch,
     #[error("counter in local DB not found: {0}")]
     CounterNotFound(cdk02::Id),
-    #[error("internal, generic: {0}")]
-    Any(AnyError),
     #[error("wallet id {0} not found")]
     WalletIdNotFound(String),
     #[error("wallet at idx {0} not found")]
@@ -124,8 +112,6 @@ pub enum Error {
     MeltUnpaid(String),
     #[error("melt op not found: {0}")]
     MeltNotFound(String),
-    #[error("missing initialization")]
-    Initialization,
     #[error("inter-mint payment not supported yet")]
     InterMint,
     #[error("spending conditions not supported yet")]
@@ -134,8 +120,6 @@ pub enum Error {
     NoTransport,
     #[error("Maximum Exchange attempts reached")]
     MaxExchangeAttempts,
-    #[error("Missing currency unit")]
-    MissingCurrencyUnit,
     #[error("Invalid Clowder Path for foreign eCash")]
     InvalidClowderPath,
     #[error("Beta not found")]
@@ -145,4 +129,6 @@ pub enum Error {
 
     #[error("internal error: {0}")]
     Internal(String),
+    #[error("internal, generic: {0}")]
+    Any(AnyError),
 }

--- a/crates/bcr-wallet-core/src/job.rs
+++ b/crates/bcr-wallet-core/src/job.rs
@@ -1,0 +1,6 @@
+use crate::TStamp;
+
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct JobState {
+    pub last_run: TStamp,
+}

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -1,3 +1,4 @@
+use crate::job::JobState;
 use crate::mint::MintConnector;
 use crate::{
     config::{Config, SameMintSafeMode, Settings},
@@ -11,6 +12,7 @@ use bitcoin::{
 };
 use cashu::{CurrencyUnit, KeySetInfo, MintInfo, MintUrl};
 use cdk::wallet::{MintConnector as MintCon, types::TransactionId};
+use chrono::Utc;
 use error::{Error, Result};
 use std::{
     collections::{HashMap, HashSet},
@@ -18,13 +20,13 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::RwLock;
-use tracing::info;
 use uuid::Uuid;
 
 mod clowder_models;
 pub mod config;
 mod db;
 pub mod error;
+mod job;
 mod mint;
 pub mod persistence;
 pub mod pocket;
@@ -42,6 +44,7 @@ mod prod {
     pub type ProductionPurseRepository = crate::persistence::redb::PurseDB;
     pub type ProductionTransactionRepository = crate::persistence::redb::TransactionDB;
     pub type ProductionSettingsRepository = crate::persistence::redb::SettingsDB;
+    pub type ProductionJobsRepository = crate::persistence::redb::JobsDB;
 }
 
 type ProductionConnector = crate::mint::HttpClientExt;
@@ -63,6 +66,7 @@ pub enum LocalDB {
 pub struct AppState {
     purse: Arc<ProductionPurse>,
     settings: Arc<prod::ProductionSettingsRepository>,
+    jobs: Arc<prod::ProductionJobsRepository>,
     db: Arc<redb::Database>,
 }
 
@@ -72,11 +76,12 @@ impl AppState {
     pub async fn initialize(db_path: &str) -> Result<Self> {
         tracing::debug!("Initializing API");
 
-        // Open Datbase file - only allowed to do once!
+        // Open Database file - only allowed to do once!
         let db = Arc::new(redb::Database::create(db_path)?);
 
         let pursedb = db::build_pursedb(AppState::DB_VERSION, db.clone()).await?;
         let settingsdb = Arc::new(db::build_settingsdb(AppState::DB_VERSION, db.clone()).await?);
+        let jobsdb = Arc::new(db::build_jobsdb(AppState::DB_VERSION, db.clone()).await?);
         let settings = settingsdb.clone().load().await?;
         let config = Config::new(settings)?;
         let nostr_cl = nostr_sdk::Client::new(config.nostr_signer);
@@ -86,7 +91,7 @@ impl AppState {
         nostr_cl.connect().await;
         let http_cl = reqwest::Client::new();
         let purse = ProductionPurse::new(pursedb, http_cl, nostr_cl, config.nprofile).await?;
-        let mut appstate = AppState::new(Arc::new(purse), settingsdb, db);
+        let mut appstate = AppState::new(Arc::new(purse), settingsdb, jobsdb, db);
         appstate.load_wallets().await?;
         Ok(appstate)
     }
@@ -94,12 +99,14 @@ impl AppState {
     fn new(
         purse: Arc<ProductionPurse>,
         settings: Arc<prod::ProductionSettingsRepository>,
+        jobs: Arc<prod::ProductionJobsRepository>,
         db: Arc<redb::Database>,
     ) -> Self {
         tracing::debug!("Creating new AppState");
         Self {
             purse,
             settings,
+            jobs,
             db,
         }
     }
@@ -156,6 +163,10 @@ impl AppState {
 
     fn get_settingsdb(&self) -> Arc<prod::ProductionSettingsRepository> {
         self.settings.clone()
+    }
+
+    fn get_jobsdb(&self) -> Arc<prod::ProductionJobsRepository> {
+        self.jobs.clone()
     }
 
     fn get_db(&self) -> Arc<redb::Database> {
@@ -245,7 +256,6 @@ impl AppState {
         tracing::debug!("wallet_balance({idx})");
 
         let wallet = self.get_wallet(idx).await?;
-        // TODO: fix this, lock held across await, issue #92
         wallet.read().await.balance().await
     }
 
@@ -405,7 +415,7 @@ impl AppState {
 
     pub fn generate_random_mnemonic(&self, mnemonic_len: u32) -> String {
         let mnemonic_len = if mnemonic_len == 0 { 12 } else { mnemonic_len };
-        info!("Generate random {}-word mnemonic", mnemonic_len);
+        tracing::info!("Generate random {}-word mnemonic", mnemonic_len);
 
         const VALID_MNEMONIC_LENGTHS: [u32; 5] = [12, 15, 18, 21, 24];
         assert!(
@@ -421,6 +431,63 @@ impl AppState {
                 String::default()
             }
         }
+    }
+
+    /// Checks when the jobs were run the last time and if it's greater than 1 day
+    /// then it runs the jobs.
+    /// This should be called in an interval and on app initialization
+    pub async fn run_jobs(&self) -> Result<()> {
+        tracing::info!("Run Jobs triggered");
+        let last_run_ts = self.get_jobsdb().load().await?.last_run;
+        let now = Utc::now();
+
+        let diff = now.signed_duration_since(last_run_ts);
+
+        if diff.num_days() < 1 {
+            tracing::info!("Run Jobs called, but not yet 1 day since last job run.");
+            return Ok(());
+        }
+
+        if self.execute_jobs().await {
+            tracing::info!("Run Jobs executed successfully");
+            self.get_jobsdb().store(JobState { last_run: now }).await?;
+        } else {
+            tracing::info!(
+                "Run Jobs executed with some errors - will run again at the next interval."
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Actually runs the jobs - gets called via `run_jobs` for creating a
+    /// regular job interval, but calling this directly forces a job run right now
+    /// Returns a boolean indicating if all jobs ran to success
+    pub async fn execute_jobs(&self) -> bool {
+        let mut job_failed = false;
+        if let Err(e) = self.purse_migrate_rabid().await {
+            job_failed = true;
+            tracing::error!("Error running purse_migrate_rabid job: {e}");
+        }
+
+        let wallet_ids = self.get_purse().ids().await;
+        for wallet_id in wallet_ids.iter() {
+            match self.wallet_redeem_credit(*wallet_id as usize).await {
+                Ok(amount) => {
+                    tracing::info!(
+                        "Redeemed credit for wallet {wallet_id}. Amount redeemed: {amount}"
+                    );
+                }
+                Err(e) => {
+                    job_failed = true;
+                    tracing::error!(
+                        "Error running wallet_redeem_credit job for wallet {wallet_id}: {e}"
+                    );
+                }
+            };
+        }
+        // successful = true
+        !job_failed
     }
 }
 

--- a/crates/bcr-wallet-core/src/mint.rs
+++ b/crates/bcr-wallet-core/src/mint.rs
@@ -9,6 +9,7 @@ use cashu::Proof;
 use cdk::Error as CdkError;
 use rand::seq::IndexedRandom;
 use std::str::FromStr;
+use tracing::debug;
 
 #[async_trait]
 pub trait MintConnector: cdk::wallet::MintConnector + sync::SendSync {
@@ -85,66 +86,79 @@ type CdkResult<T> = std::result::Result<T, cdk::Error>;
 #[async_trait]
 impl cdk::wallet::MintConnector for HttpClientExt {
     async fn get_mint_keys(&self) -> CdkResult<Vec<cashu::KeySet>> {
+        debug!("HTTP call to get_mint_keys");
         self.main.get_mint_keys().await
     }
     async fn post_restore(
         &self,
         request: cashu::RestoreRequest,
     ) -> CdkResult<cashu::RestoreResponse> {
+        debug!("HTTP call to post_restore");
         self.main.post_restore(request).await
     }
     async fn post_check_state(
         &self,
         request: cashu::CheckStateRequest,
     ) -> CdkResult<cashu::CheckStateResponse> {
+        debug!("HTTP call to post_check_state");
         self.main.post_check_state(request).await
     }
     async fn get_mint_keyset(&self, keyset_id: cashu::Id) -> CdkResult<cashu::KeySet> {
+        debug!("HTTP call to get_mint_keyset");
         self.main.get_mint_keyset(keyset_id).await
     }
     async fn get_mint_keysets(&self) -> CdkResult<cashu::KeysetResponse> {
+        debug!("HTTP call to get_mint_keysets");
         self.main.get_mint_keysets().await
     }
     async fn get_mint_info(&self) -> CdkResult<cashu::MintInfo> {
+        debug!("HTTP call to get_mint_info");
         self.main.get_mint_info().await
     }
     async fn post_swap(&self, request: cashu::SwapRequest) -> CdkResult<cashu::SwapResponse> {
+        debug!("HTTP call to post_swap");
         self.main.post_swap(request).await
     }
     async fn post_mint(
         &self,
         request: cashu::MintRequest<String>,
     ) -> CdkResult<cashu::MintResponse> {
+        debug!("HTTP call to post_mint");
         self.main.post_mint(request).await
     }
     async fn post_mint_quote(
         &self,
         request: cashu::MintQuoteBolt11Request,
     ) -> CdkResult<cashu::MintQuoteBolt11Response<String>> {
+        debug!("HTTP call to post_mint_quote");
         self.main.post_mint_quote(request).await
     }
     async fn post_melt(
         &self,
         request: cashu::MeltRequest<String>,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to post_melt");
         self.main.post_melt(request).await
     }
     async fn get_melt_quote_status(
         &self,
         quote_id: &str,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to get_melt_quote_status");
         self.main.get_melt_quote_status(quote_id).await
     }
     async fn post_melt_quote(
         &self,
         request: cashu::MeltQuoteBolt11Request,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to post_melt_quote");
         self.main.post_melt_quote(request).await
     }
     async fn get_mint_quote_status(
         &self,
         quote_id: &str,
     ) -> CdkResult<cashu::MintQuoteBolt11Response<String>> {
+        debug!("HTTP call to get_mint_quote_status");
         self.main.get_mint_quote_status(quote_id).await
     }
 
@@ -152,30 +166,35 @@ impl cdk::wallet::MintConnector for HttpClientExt {
         &self,
         request: cashu::MintQuoteBolt12Request,
     ) -> CdkResult<cashu::MintQuoteBolt12Response<String>> {
+        debug!("HTTP call to post_mint_bolt12_quote");
         self.main.post_mint_bolt12_quote(request).await
     }
     async fn get_mint_quote_bolt12_status(
         &self,
         quote_id: &str,
     ) -> CdkResult<cashu::MintQuoteBolt12Response<String>> {
+        debug!("HTTP call to get_mint_quote_bolt12_status");
         self.main.get_mint_quote_bolt12_status(quote_id).await
     }
     async fn post_melt_bolt12_quote(
         &self,
         request: cashu::MeltQuoteBolt12Request,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to post_melt_bolt12_quote");
         self.main.post_melt_bolt12_quote(request).await
     }
     async fn get_melt_bolt12_quote_status(
         &self,
         quote_id: &str,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to get_melt_bolt12_quote_status");
         self.main.get_melt_bolt12_quote_status(quote_id).await
     }
     async fn post_melt_bolt12(
         &self,
         request: cashu::MeltRequest<String>,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to post_melt_bolt12");
         self.main.post_melt_bolt12(request).await
     }
 }
@@ -193,6 +212,7 @@ impl MintConnector for HttpClientExt {
         alpha_id: bitcoin::secp256k1::PublicKey,
     ) -> CdkResult<Vec<cashu::KeySet>> {
         let url = self.url.join(&format!("v1/alpha/keysets/{alpha_id}"))?;
+        debug!("HTTP call to get_alpha_keysets on {url}");
         let response = self
             .secondary
             .get(url)
@@ -209,6 +229,7 @@ impl MintConnector for HttpClientExt {
     /// Is Alpha Offline
     async fn get_alpha_offline(&self, alpha_id: bitcoin::secp256k1::PublicKey) -> CdkResult<bool> {
         let url = self.url.join(&format!("v1/alpha/offline/{alpha_id}"))?;
+        debug!("HTTP call to get_alpha_offline on {url}");
         let response = self
             .secondary
             .get(url)
@@ -228,6 +249,7 @@ impl MintConnector for HttpClientExt {
         alpha_id: bitcoin::secp256k1::PublicKey,
     ) -> CdkResult<wire_clowder::AlphaStateResponse> {
         let url = self.url.join(&format!("v1/alpha/status/{alpha_id}"))?;
+        debug!("HTTP call to get_alpha_status on {url}");
         let response = self
             .secondary
             .get(url)
@@ -246,6 +268,7 @@ impl MintConnector for HttpClientExt {
         alpha_id: bitcoin::secp256k1::PublicKey,
     ) -> CdkResult<wire_clowder::ConnectedMintResponse> {
         let url = self.url.join(&format!("v1/alpha/substitute/{alpha_id}"))?;
+        debug!("HTTP call to get_alpha_substitute on {url}");
         let response = self
             .secondary
             .get(url)
@@ -263,6 +286,7 @@ impl MintConnector for HttpClientExt {
             .url
             .join("v1/betas")
             .expect("get_clowder_betas url error");
+        debug!("HTTP call to get_clowder_betas on {url}");
         let response = self
             .secondary
             .get(url)
@@ -283,6 +307,7 @@ impl MintConnector for HttpClientExt {
         wallet_pubkey: bitcoin::secp256k1::PublicKey,
     ) -> CdkResult<Vec<Proof>> {
         let url = self.url.join("v1/exchange/substitute")?;
+        debug!("HTTP call to post_exchange_substitute on {url}");
         let request = wire_clowder::SubstituteExchangeRequest {
             proofs,
             locks,
@@ -312,6 +337,7 @@ impl MintConnector for HttpClientExt {
             .url
             .join("v1/exchange")
             .expect("post_clowder_exchange url error");
+        debug!("HTTP call to post_exchange on {url}");
         let request = wire_clowder::ExchangeRequest {
             exchange_path,
             alpha_proofs,
@@ -332,6 +358,7 @@ impl MintConnector for HttpClientExt {
 
     async fn get_clowder_id(&self) -> CdkResult<bitcoin::secp256k1::PublicKey> {
         let url = self.url.join("v1/id").expect("get_clowder_id url error");
+        debug!("HTTP call to get_clowder_id on {url}");
 
         let response = self
             .secondary
@@ -354,6 +381,7 @@ impl MintConnector for HttpClientExt {
             .url
             .join("v1/path")
             .expect("post_clowder_path url error");
+        debug!("HTTP call to post_clowder_path on {url}");
         let request = wire_clowder::PathRequest { origin_mint_url };
         let response = self
             .secondary
@@ -385,6 +413,7 @@ impl MintConnector for HttpClientExt {
             .url
             .join("v1/commitment")
             .expect("post_commitment url error");
+        debug!("HTTP call to post_commitment on {url}");
         let inputs: Vec<_> = inputs
             .into_iter()
             .map(wire_keys::ProofFingerprint::try_from)
@@ -466,31 +495,38 @@ impl SentinelClient {
 #[async_trait]
 impl cdk::wallet::MintConnector for SentinelClient {
     async fn get_mint_keys(&self) -> CdkResult<Vec<cashu::KeySet>> {
+        debug!("HTTP call to get_mint_keys on sentinel");
         self.main.get_mint_keys().await
     }
     async fn post_restore(
         &self,
         request: cashu::RestoreRequest,
     ) -> CdkResult<cashu::RestoreResponse> {
+        debug!("HTTP call to post_restore on sentinel");
         self.main.post_restore(request).await
     }
     async fn post_check_state(
         &self,
         request: cashu::CheckStateRequest,
     ) -> CdkResult<cashu::CheckStateResponse> {
+        debug!("HTTP call to post_check_state on sentinel");
         self.main.post_check_state(request).await
     }
     async fn get_mint_keyset(&self, keyset_id: cashu::Id) -> CdkResult<cashu::KeySet> {
+        debug!("HTTP call to get_mint_keyset on sentinel");
         self.main.get_mint_keyset(keyset_id).await
     }
     async fn get_mint_keysets(&self) -> CdkResult<cashu::KeysetResponse> {
+        debug!("HTTP call to get_mint_keysets on sentinel");
         self.main.get_mint_keysets().await
     }
     async fn get_mint_info(&self) -> CdkResult<cashu::MintInfo> {
+        debug!("HTTP call to get_mint_info on sentinel");
         self.main.get_mint_info().await
     }
 
     async fn post_swap(&self, request: cashu::SwapRequest) -> CdkResult<cashu::SwapResponse> {
+        debug!("HTTP call to post_swap on sentinel");
         let response = self.main.post_swap(request).await?;
         let Some(sentinel_url) = self.random_sentinel() else {
             return Ok(response);
@@ -510,6 +546,7 @@ impl cdk::wallet::MintConnector for SentinelClient {
         &self,
         request: cashu::MintRequest<String>,
     ) -> CdkResult<cashu::MintResponse> {
+        debug!("HTTP call to post_mint on sentinel");
         let response = self.main.post_mint(request).await?;
         let Some(sentinel_url) = self.random_sentinel() else {
             return Ok(response);
@@ -528,6 +565,7 @@ impl cdk::wallet::MintConnector for SentinelClient {
         &self,
         request: cashu::MintQuoteBolt11Request,
     ) -> CdkResult<cashu::MintQuoteBolt11Response<String>> {
+        debug!("HTTP call to post_mint_quote on sentinel");
         self.main.post_mint_quote(request).await
     }
 
@@ -535,6 +573,7 @@ impl cdk::wallet::MintConnector for SentinelClient {
         &self,
         request: cashu::MeltRequest<String>,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to post_melt on sentinel");
         let fps = request
             .inputs()
             .iter()
@@ -557,18 +596,21 @@ impl cdk::wallet::MintConnector for SentinelClient {
         &self,
         quote_id: &str,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to get_melt_quote_status on sentinel");
         self.main.get_melt_quote_status(quote_id).await
     }
     async fn post_melt_quote(
         &self,
         request: cashu::MeltQuoteBolt11Request,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to post_melt_quote on sentinel");
         self.main.post_melt_quote(request).await
     }
     async fn get_mint_quote_status(
         &self,
         quote_id: &str,
     ) -> CdkResult<cashu::MintQuoteBolt11Response<String>> {
+        debug!("HTTP call to get_mint_quote_status on sentinel");
         self.main.get_mint_quote_status(quote_id).await
     }
 
@@ -576,30 +618,35 @@ impl cdk::wallet::MintConnector for SentinelClient {
         &self,
         request: cashu::MintQuoteBolt12Request,
     ) -> CdkResult<cashu::MintQuoteBolt12Response<String>> {
+        debug!("HTTP call to post_mint_bolt12_quote on sentinel");
         self.main.post_mint_bolt12_quote(request).await
     }
     async fn get_mint_quote_bolt12_status(
         &self,
         quote_id: &str,
     ) -> CdkResult<cashu::MintQuoteBolt12Response<String>> {
+        debug!("HTTP call to get_mint_quote_bolt12_status on sentinel");
         self.main.get_mint_quote_bolt12_status(quote_id).await
     }
     async fn post_melt_bolt12_quote(
         &self,
         request: cashu::MeltQuoteBolt12Request,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to post_melt_bolt12_quote on sentinel");
         self.main.post_melt_bolt12_quote(request).await
     }
     async fn get_melt_bolt12_quote_status(
         &self,
         quote_id: &str,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to get_melt_bolt12_quote_status on sentinel");
         self.main.get_melt_bolt12_quote_status(quote_id).await
     }
     async fn post_melt_bolt12(
         &self,
         request: cashu::MeltRequest<String>,
     ) -> CdkResult<cashu::MeltQuoteBolt11Response<String>> {
+        debug!("HTTP call to post_melt_bolt12 on sentinel");
         self.main.post_melt_bolt12(request).await
     }
 }

--- a/crates/bcr-wallet-core/src/persistence/redb.rs
+++ b/crates/bcr-wallet-core/src/persistence/redb.rs
@@ -2,6 +2,7 @@ use crate::{
     TStamp,
     config::Settings,
     error::{Error, Result},
+    job::JobState,
     persistence::Commitment,
     pocket::{PocketRepository, debit::MintMeltRepository},
     purse::PurseRepository,
@@ -1124,6 +1125,64 @@ impl SettingsDB {
     }
 
     pub async fn load(self: Arc<Self>) -> Result<Settings> {
+        spawn_blocking(move || self.load_sync()).await?
+    }
+}
+
+///////////////////////////////////////////// JobState
+const JOBS_TABLE: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new("jobs");
+
+///////////////////////////////////////////// JobsDB
+pub struct JobsDB {
+    db: Arc<Database>,
+}
+
+impl JobsDB {
+    const JOBS_MAIN_ID: &'static str = "main";
+
+    pub fn new(db: Arc<Database>) -> Result<Self> {
+        Ok(Self { db })
+    }
+
+    fn store_sync(&self, job_state: JobState) -> Result<()> {
+        let write_txn = self.db.begin_write()?;
+
+        {
+            let mut table = write_txn.open_table(JOBS_TABLE)?;
+
+            let mut serialized = Vec::new();
+            ciborium::into_writer(&job_state, &mut serialized)?;
+            table.insert(Self::JOBS_MAIN_ID.as_bytes(), serialized)?;
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    fn load_sync(&self) -> Result<JobState> {
+        let read_txn = self.db.begin_read()?;
+
+        match read_txn.open_table(JOBS_TABLE) {
+            Ok(table) => {
+                let entry = table.get(Self::JOBS_MAIN_ID.as_bytes())?;
+                match entry {
+                    Some(e) => {
+                        let job_state: JobState = ciborium::from_reader(e.value().as_slice())?;
+                        Ok(job_state)
+                    }
+                    None => Ok(JobState::default()),
+                }
+            }
+            Err(TableError::TableDoesNotExist(_)) => Ok(JobState::default()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub async fn store(self: Arc<Self>, job_state: JobState) -> Result<()> {
+        spawn_blocking(move || self.store_sync(job_state)).await?
+    }
+
+    pub async fn load(self: Arc<Self>) -> Result<JobState> {
         spawn_blocking(move || self.load_sync()).await?
     }
 }


### PR DESCRIPTION
* Adds a simple jobs infra for running migrate_rabid and redeem in the background once a day
* Adds a way to force-execute the jobs as well (for CLI and testing, mostly)
* Remove unused Errors
* Debug logging for all different requests to improve debugging