### PR TITLE
Pay by Token and Fix Payment and Transaction Status

### DIFF
--- a/crates/bcr-wallet-cli/alice.toml
+++ b/crates/bcr-wallet-cli/alice.toml
@@ -1,10 +1,10 @@
 ## Other mint URLs
 #mint_url = "http://localhost:4343"
 # mint_url = "http://localhost:8080"
-mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
+# mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
 # mint_url = "https://mint.wildcat1.clowder1.minibill.tech"
 
-# mint_url = "https://wildcat-dev-docker.minibill.tech"
-mnemonic = "fiscal live easy coffee monitor proof myself double cycle flat stay cycle"
+mint_url = "https://wildcat-dev-docker.minibill.tech"
+mnemonic = "royal scheme canoe flame sell jewel valve citizen deal patch stereo walk"
 log_level = "DEBUG"
 db_path = "./alice.db"

--- a/crates/bcr-wallet-cli/bob.toml
+++ b/crates/bcr-wallet-cli/bob.toml
@@ -1,4 +1,5 @@
-mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
-mnemonic = "quit install damage when glove pipe lucky update high lock child police"
+# mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
+mint_url = "https://wildcat-dev-docker.minibill.tech"
+mnemonic = "trip piano round arrest seven kangaroo used critic museum decline erupt horse"
 log_level = "DEBUG"
 db_path = "./bob.db"

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use bcr_wallet_core::AppState;
+use chrono::{DateTime, Utc};
 use tracing::info;
 
 use crate::WalletSettings;
@@ -41,15 +42,23 @@ pub async fn cmd_info(app_state: &AppState) -> Result<String> {
             for r in redemptions.iter() {
                 res.push_str(&format!("\t\t{} - {}", r.tstamp, r.amount));
             }
+            push_break(&mut res);
         }
         if !transactions.is_empty() {
             res.push_str("Transactions:");
             push_break(&mut res);
+            let mut txs = Vec::with_capacity(transactions.len());
             for t in transactions.iter() {
                 let tx = app_state.wallet_load_tx(*id, &t.to_string()).await?;
+                txs.push(tx);
+            }
+
+            txs.sort_by(|a, b| b.tstamp.cmp(&a.tstamp)); // sort by timestamp desc
+
+            for tx in txs.iter() {
                 res.push_str(&format!(
-                    "\t\tAmount: {}\t Fees: {}\tDesc: {}\tStatus: {:?}\tTstamp: {}\tDir: {:?}\tPayment Type: {:?}",
-                    tx.amount, tx.fees, tx.memo, tx.status, tx.tstamp, tx.direction, tx.ptype
+                    "\t\tAmount: {} {} \t Fees: {}  \t Status: {:?} \t {} \tType: {:<10} \t {:?} \t Memo: {}",
+                    tx.amount, tx.unit, tx.fees,  tx.status, format_timestamp(tx.tstamp), &format!("{:?}", tx.ptype), tx.direction,tx.memo
                 ));
                 push_break(&mut res);
             }
@@ -138,10 +147,11 @@ pub async fn cmd_request_payment(
     amount: u64,
     unit: &str,
     id: usize,
+    description: Option<String>,
 ) -> Result<String> {
     let mut res = String::new();
     let req = app_state
-        .wallet_prepare_payment_request(id, amount, unit.to_string(), String::default())
+        .wallet_prepare_payment_request(id, amount, unit.to_string(), description)
         .await?;
 
     info!("Payment Request: {}, {}", &req.request, &req.p_id);
@@ -168,6 +178,45 @@ pub async fn cmd_request_payment(
     Ok(res)
 }
 
+pub async fn cmd_pay_by_token(
+    app_state: &AppState,
+    name: &str,
+    id: usize,
+    amount: u64,
+    unit: &str,
+    description: Option<String>,
+) -> Result<String> {
+    let mut res = String::new();
+    let payment_summary = app_state
+        .wallet_prepare_pay_by_token(id, amount, unit.to_string(), description)
+        .await?;
+
+    info!(
+        "Payment Summary: Amount: {}, Unit: {}",
+        &payment_summary.amount, &payment_summary.unit,
+    );
+    let result = app_state
+        .wallet_pay_by_token(payment_summary.request_id.to_string())
+        .await?;
+
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!("Pay by Token for {name}, Wallet ID: {id}.\n"));
+    push_break(&mut res);
+    res.push_str(&format!("Payment Summary: {}", &payment_summary.request_id));
+    res.push_str(&format!(
+        "Unit: {}, Amount: {}",
+        &payment_summary.unit, &payment_summary.amount
+    ));
+    push_break(&mut res);
+    res.push_str(&format!("Transaction ID: {}", result.tx_id));
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!("Token: {}", result.token));
+
+    Ok(res)
+}
+
 pub async fn cmd_send_payment(
     app_state: &AppState,
     name: &str,
@@ -180,11 +229,8 @@ pub async fn cmd_send_payment(
         .await?;
 
     info!(
-        "Payment Summary: Amount: {}, Unit: {}, Fees: {}, Reserved Fees: {}",
-        &payment_summary.amount,
-        &payment_summary.unit,
-        &payment_summary.fees,
-        &payment_summary.reserved_fees
+        "Payment Summary: Amount: {}, Unit: {}",
+        &payment_summary.amount, &payment_summary.unit,
     );
 
     let tx_id = app_state
@@ -219,4 +265,10 @@ fn push_line(res: &mut String) {
 
 fn push_break(res: &mut String) {
     res.push('\n');
+}
+
+fn format_timestamp(ts: u64) -> String {
+    let datetime: DateTime<Utc> = DateTime::from_timestamp(ts as i64, 0).expect("valid timestamp");
+
+    datetime.format("%Y-%m-%d %H:%M:%S").to_string()
 }

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -50,9 +50,17 @@ enum Commands {
         id: usize,
         amount: u64,
         unit: String,
+        description: Option<String>,
     },
     #[command(name = "send_payment")]
     SendPayment { id: usize, input: String },
+    #[command(name = "pay_by_token")]
+    PayByToken {
+        id: usize,
+        amount: u64,
+        unit: String,
+        description: Option<String>,
+    },
     #[command(name = "recover")]
     Recover { id: usize },
     #[command(name = "reclaim_funds")]
@@ -138,11 +146,24 @@ async fn main() -> Result<()> {
                 command::cmd_restore_wallet(&app_state, &settings, &cli.wallet).await?
             );
         }
-        Commands::RequestPayment { id, amount, unit } => {
+        Commands::RequestPayment {
+            id,
+            amount,
+            unit,
+            description,
+        } => {
             info!(
-                "Requesting Payment for {}: {}, Amount: {amount}",
+                "Requesting Payment for {}: {}, Amount: {amount}, Unit: {unit}, Description: {description:?}",
                 cli.wallet,
-                command::cmd_request_payment(&app_state, &cli.wallet, amount, &unit, id).await?
+                command::cmd_request_payment(
+                    &app_state,
+                    &cli.wallet,
+                    amount,
+                    &unit,
+                    id,
+                    description.clone()
+                )
+                .await?
             );
         }
         Commands::SendPayment { id, input } => {
@@ -150,6 +171,26 @@ async fn main() -> Result<()> {
                 "Sending Payment for {}: {}, Input: {input}",
                 cli.wallet,
                 command::cmd_send_payment(&app_state, &cli.wallet, &input, id).await?
+            );
+        }
+        Commands::PayByToken {
+            id,
+            amount,
+            unit,
+            description,
+        } => {
+            info!(
+                "Payment by Token for {}: {}, Amount: {amount}, Unit: {unit}, Description: {description:?}",
+                cli.wallet,
+                command::cmd_pay_by_token(
+                    &app_state,
+                    &cli.wallet,
+                    id,
+                    amount,
+                    &unit,
+                    description.clone()
+                )
+                .await?
             );
         }
         Commands::GenMnemonic => {

--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -86,8 +86,8 @@ pub enum Error {
     NoActiveKeyset,
     #[error("unknown keyset ID")]
     UnknownKeysetId(cashu::Id),
-    #[error("unknown currency unit: {0}")]
-    UnknownCurrencyUnit(cashu::CurrencyUnit),
+    #[error("invalid currency unit: {0}")]
+    InvalidCurrencyUnit(String),
     #[error("unknown mint: {0}")]
     UnknownMint(cashu::MintUrl),
     #[error("currency unit mismatch: mine {0}, his {1}")]

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -6,6 +6,7 @@ use crate::{
     types::{PaymentSummary, RedemptionSummary},
     wallet::{CreditPocket, WalletBalance},
 };
+use bcr_wallet_lib::wallet::Token;
 use bitcoin::{
     hashes::{Hash, HashEngine, sha256},
     hex::DisplayHex,
@@ -319,6 +320,33 @@ impl AppState {
         Ok(Transaction::from(tx))
     }
 
+    pub async fn wallet_prepare_pay_by_token(
+        &self,
+        idx: usize,
+        amount: u64,
+        unit: String,
+        description: Option<String>,
+    ) -> Result<PaymentSummary> {
+        tracing::debug!("wallet_prepare_pay_by_token({idx}, {amount}, {unit}, {description:?})");
+        let amount = cashu::Amount::from(amount);
+        let unit = cashu::CurrencyUnit::from_str(&unit)
+            .map_err(|_| Error::InvalidCurrencyUnit(unit.clone()))?;
+        let purse = self.get_purse();
+        let summary = purse
+            .prepare_pay_by_token(idx, amount, unit, description)
+            .await?;
+        Ok(summary)
+    }
+
+    pub async fn wallet_pay_by_token(&self, rid: String) -> Result<CreatedToken> {
+        let tstamp = chrono::Utc::now().timestamp() as u64;
+        tracing::debug!("wallet_pay_by_token({rid}, {tstamp})");
+        let rid = Uuid::from_str(&rid)?;
+        let purse = self.get_purse();
+        let (tx_id, token) = purse.pay_by_token(rid, tstamp).await?;
+        Ok(CreatedToken { tx_id, token })
+    }
+
     pub async fn wallet_prepare_payment(
         &self,
         idx: usize,
@@ -347,20 +375,15 @@ impl AppState {
         idx: usize,
         amount: u64,
         unit: String,
-        description: String,
+        description: Option<String>,
     ) -> Result<PaymentRequest> {
-        tracing::debug!("wallet_prepare_pay_request({idx}, {amount}, {unit}, {description})");
+        tracing::debug!("wallet_prepare_pay_request({idx}, {amount}, {unit}, {description:?})");
 
         let amount = cashu::Amount::from(amount);
         let unit = if unit.trim().is_empty() {
             None
         } else {
             cashu::CurrencyUnit::from_str(&unit).ok()
-        };
-        let description = if description.trim().is_empty() {
-            None
-        } else {
-            Some(description.trim().to_string())
         };
         let purse = self.get_purse();
         let request = purse
@@ -493,12 +516,13 @@ impl AppState {
 
 // FFI types
 
-#[derive(Default)]
+#[derive(Default, Clone, Debug)]
 pub struct PaymentRequest {
     pub request: String,
     pub p_id: String,
 }
 
+#[derive(Default, Clone, Debug)]
 pub struct WalletCurrencyUnit {
     pub credit: String,
     pub debit: String,
@@ -526,6 +550,7 @@ pub enum PaymentType {
     Cdk18,
     Lightning,
 }
+
 impl std::convert::From<types::PaymentType> for PaymentType {
     fn from(ptype: types::PaymentType) -> Self {
         match ptype {
@@ -536,6 +561,7 @@ impl std::convert::From<types::PaymentType> for PaymentType {
         }
     }
 }
+
 #[derive(Debug, Clone, Copy, Default)]
 pub enum TransactionStatus {
     #[default]
@@ -544,6 +570,7 @@ pub enum TransactionStatus {
     CashedIn,
     Canceled,
 }
+
 impl std::convert::From<types::TransactionStatus> for TransactionStatus {
     fn from(status: types::TransactionStatus) -> Self {
         match status {
@@ -554,7 +581,8 @@ impl std::convert::From<types::TransactionStatus> for TransactionStatus {
         }
     }
 }
-#[derive(Default, Debug)]
+
+#[derive(Default, Clone, Debug)]
 pub struct Transaction {
     pub amount: u64,
     pub fees: u64,
@@ -581,6 +609,12 @@ impl std::convert::From<cdk::wallet::types::Transaction> for Transaction {
             status,
         }
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct CreatedToken {
+    pub tx_id: TransactionId,
+    pub token: Token,
 }
 
 // Wallet Initialization

--- a/crates/bcr-wallet-core/src/pocket/credit.rs
+++ b/crates/bcr-wallet-core/src/pocket/credit.rs
@@ -192,7 +192,9 @@ impl wallet::Pocket for Pocket {
             }
         }
         let mut current_amount = Amount::ZERO;
-        let summary = SendSummary::new();
+        let mut summary = SendSummary::new();
+        summary.unit = self.unit.clone();
+        summary.amount = target;
         let mut send_ref = SendReference {
             rid: summary.request_id,
             ..Default::default()

--- a/crates/bcr-wallet-core/src/pocket/debit.rs
+++ b/crates/bcr-wallet-core/src/pocket/debit.rs
@@ -141,7 +141,9 @@ impl Pocket {
             }
         }
         let mut current_amount = Amount::ZERO;
-        let pocket_summary = SendSummary::new();
+        let mut pocket_summary = SendSummary::new();
+        pocket_summary.amount = target;
+        pocket_summary.unit = self.unit.clone();
         let mut send_ref = SendReference {
             rid: pocket_summary.request_id,
             ..Default::default()

--- a/crates/bcr-wallet-core/src/purse.rs
+++ b/crates/bcr-wallet-core/src/purse.rs
@@ -3,9 +3,13 @@ use crate::{
     error::{Error, Result},
     persistence::redb::PurseDB,
     sync,
-    types::{PaymentSummary, WalletConfig},
+    types::{
+        self, PAYMENT_TYPE_METADATA_KEY, PaymentSummary, TRANSACTION_STATUS_METADATA_KEY,
+        WalletConfig,
+    },
 };
 use async_trait::async_trait;
+use bcr_wallet_lib::wallet::Token;
 use cashu::{Amount, CurrencyUnit, MintUrl, PaymentRequest, nut00 as cdk00, nut18 as cdk18};
 use cdk::wallet::types::TransactionId;
 use nostr::{nips::nip59::UnwrappedGift, signer::NostrSigner};
@@ -45,7 +49,7 @@ pub trait Wallet: sync::SendSync {
         nostr_cl: &nostr_sdk::Client,
         http_cl: &reqwest::Client,
         tstamp: u64,
-    ) -> Result<TransactionId>;
+    ) -> Result<(TransactionId, Option<Token>)>;
 
     async fn migrate_pockets_substitute(
         &mut self,
@@ -63,6 +67,13 @@ pub trait Wallet: sync::SendSync {
         metadata: HashMap<String, String>,
         quote_id: Option<String>,
     ) -> Result<TransactionId>;
+
+    async fn prepare_pay_by_token(
+        &self,
+        amount: Amount,
+        unit: CurrencyUnit,
+        description: Option<String>,
+    ) -> Result<PaymentSummary>;
 }
 
 struct PaymentReference {
@@ -175,7 +186,7 @@ where
                 "Wallet not found for payment",
             )));
         };
-        let txid = wlt
+        let (txid, _) = wlt
             .read()
             .await
             .pay(p_id, &self.nostr_cl, &self.http_cl, tstamp)
@@ -294,6 +305,65 @@ where
 
         Ok(())
     }
+
+    pub async fn prepare_pay_by_token(
+        &self,
+        idx: usize,
+        amount: Amount,
+        unit: CurrencyUnit,
+        description: Option<String>,
+    ) -> Result<PaymentSummary> {
+        let Some(wlt) = self.wallets.lock().await.get(idx).cloned() else {
+            return Err(Error::WalletNotFound(idx));
+        };
+
+        let summary = wlt
+            .read()
+            .await
+            .prepare_pay_by_token(amount, unit, description)
+            .await?;
+
+        let pref = PaymentReference {
+            payment_ref: summary.request_id,
+            wallet_idx: idx,
+        };
+
+        *self.current_payment.lock().await = Some(pref);
+
+        Ok(summary)
+    }
+
+    pub async fn pay_by_token(&self, p_id: Uuid, tstamp: u64) -> Result<(TransactionId, Token)> {
+        let p_ref = self.current_payment.lock().await.take();
+
+        let Some(pref) = p_ref else {
+            tracing::error!("No current payment reference found");
+            return Err(Error::NoPrepareRef(p_id));
+        };
+
+        if pref.payment_ref != p_id {
+            tracing::error!(
+                "Payment reference ID mismatch: expected {}, got {}",
+                pref.payment_ref,
+                p_id
+            );
+            return Err(Error::NoPrepareRef(p_id));
+        }
+
+        let Some(wlt) = self.wallets.lock().await.get(pref.wallet_idx).cloned() else {
+            return Err(Error::Internal(String::from(
+                "Wallet not found for payment",
+            )));
+        };
+
+        let (tx_id, token) = wlt
+            .read()
+            .await
+            .pay(p_id, &self.nostr_cl, &self.http_cl, tstamp)
+            .await?;
+
+        Ok((tx_id, token.expect("pay by token returns a token")))
+    }
 }
 
 async fn handle_event<T>(
@@ -373,6 +443,14 @@ where
         (String::from("sender"), event.pubkey.to_string()),
         (String::from("payment_id"), payment_id.to_string()),
         (String::from("nostr_event_id"), event.id.to_string()),
+        (
+            String::from(PAYMENT_TYPE_METADATA_KEY),
+            types::PaymentType::Cdk18.to_string(),
+        ),
+        (
+            String::from(TRANSACTION_STATUS_METADATA_KEY),
+            types::TransactionStatus::CashedIn.to_string(),
+        ),
     ]);
     let response = wlt
         .read()

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -2,12 +2,13 @@ use cashu::{Amount, CurrencyUnit, MintUrl};
 use std::{collections::HashMap, str::FromStr};
 use uuid::Uuid;
 
+#[derive(Default, Debug, Clone)]
 pub struct RedemptionSummary {
     pub tstamp: u64,
     pub amount: Amount,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 pub struct SendSummary {
     pub request_id: Uuid,
     pub amount: Amount,
@@ -36,7 +37,7 @@ pub struct WalletConfig {
     pub mnemonic: bip39::Mnemonic,
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct MeltSummary {
     pub request_id: Uuid,
     pub amount: Amount,
@@ -55,7 +56,7 @@ impl MeltSummary {
     }
 }
 
-#[derive(strum::EnumString, strum::Display)]
+#[derive(strum::EnumString, strum::Display, Debug, Clone)]
 pub enum PaymentType {
     NotApplicable,
     Token,
@@ -63,6 +64,7 @@ pub enum PaymentType {
     Lightning,
 }
 
+#[derive(Debug, Clone)]
 pub struct PaymentSummary {
     pub request_id: Uuid,
     pub unit: CurrencyUnit,

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -4,7 +4,10 @@ use crate::{
     error::{Error, Result},
     purse::{self},
     sync,
-    types::{self, MeltSummary, PaymentSummary, RedemptionSummary, SendSummary, WalletConfig},
+    types::{
+        self, MeltSummary, PAYMENT_TYPE_METADATA_KEY, PaymentSummary, RedemptionSummary,
+        SendSummary, TRANSACTION_STATUS_METADATA_KEY, WalletConfig,
+    },
 };
 use async_trait::async_trait;
 use bcr_common::wire::{clowder as wire_clowder, keys as wire_keys};
@@ -133,13 +136,16 @@ pub struct SendReference {
     pub amount: Amount,
     pub unit: CurrencyUnit,
 }
+
 pub enum PaymentType {
     Cdk18 {
         transport: cashu::Transport,
         id: Option<String>,
     },
     Bolt11,
+    Token,
 }
+
 pub struct PayReference {
     request_id: Uuid,
     unit: CurrencyUnit,
@@ -147,6 +153,7 @@ pub struct PayReference {
     ptype: PaymentType,
     memo: Option<String>,
 }
+
 pub struct Wallet<DebtPck> {
     network: bitcoin::Network,
     client: Box<dyn MintConnector>,
@@ -229,6 +236,7 @@ where
     pub fn debit_unit(&self) -> CurrencyUnit {
         self.debit.unit()
     }
+
     pub async fn balance(&self) -> Result<WalletBalance> {
         let debit = self.debit.balance().await?;
         let credit = self.credit.balance().await?;
@@ -741,6 +749,16 @@ where
             return Err(Error::EmptyToken(token_teaser));
         }
 
+        let mut metadata = HashMap::default();
+        metadata.insert(
+            PAYMENT_TYPE_METADATA_KEY.to_owned(),
+            types::PaymentType::Token.to_string(),
+        );
+        metadata.insert(
+            TRANSACTION_STATUS_METADATA_KEY.to_owned(),
+            types::TransactionStatus::CashedIn.to_string(),
+        );
+
         let tx_id = if token.unit().is_some() && token.unit() == Some(self.debit.unit()) {
             tracing::debug!("import debit token");
 
@@ -751,7 +769,7 @@ where
                 Some(token.mint_url()),
                 tstamp,
                 token.memo().clone(),
-                HashMap::default(),
+                metadata,
                 None,
             )
             .await?
@@ -765,7 +783,7 @@ where
                 Some(token.mint_url()),
                 tstamp,
                 token.memo().clone(),
-                HashMap::default(),
+                metadata,
                 None,
             )
             .await?
@@ -855,7 +873,8 @@ where
             } else {
                 return Err(Error::CurrencyUnitMismatch(self.debit.unit(), unit));
             };
-            let summary = PaymentSummary::from(s_summary);
+            let mut summary = PaymentSummary::from(s_summary);
+            summary.ptype = types::PaymentType::Cdk18;
             let pref = PayReference {
                 request_id: summary.request_id,
                 unit: summary.unit.clone(),
@@ -895,7 +914,7 @@ where
         nostr_cl: &nostr_sdk::Client,
         http_cl: &reqwest::Client,
         now: u64,
-    ) -> Result<TransactionId> {
+    ) -> Result<(TransactionId, Option<Token>)> {
         let p_ref = self.current_payment.lock().unwrap().take();
         let Some(p_ref) = p_ref else {
             tracing::error!("wallet: No current payment reference found");
@@ -945,6 +964,16 @@ where
                 let amount = proofs
                     .iter()
                     .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
+                let mut metadata = HashMap::default();
+                metadata.insert(
+                    PAYMENT_TYPE_METADATA_KEY.to_owned(),
+                    types::PaymentType::Cdk18.to_string(),
+                );
+                metadata.insert(
+                    TRANSACTION_STATUS_METADATA_KEY.to_owned(),
+                    types::TransactionStatus::Pending.to_string(),
+                );
+
                 let partial_tx = Transaction {
                     mint_url: self.client.mint_url(),
                     fee: fees,
@@ -955,13 +984,13 @@ where
                     ys,
                     amount,
                     // payments might need to fill some extra metadata later
-                    metadata: HashMap::default(),
+                    metadata,
                     quote_id: None,
                 };
                 let tx_id = self
                     .pay_nut18(proofs, nostr_cl, http_cl, transport, id, partial_tx)
                     .await?;
-                return Ok(tx_id);
+                Ok((tx_id, None))
             }
             PaymentType::Bolt11 => {
                 let proofs = self
@@ -978,6 +1007,16 @@ where
                 let amount = proofs
                     .iter()
                     .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
+                let mut metadata = HashMap::default();
+                metadata.insert(
+                    PAYMENT_TYPE_METADATA_KEY.to_owned(),
+                    types::PaymentType::Lightning.to_string(),
+                );
+                metadata.insert(
+                    TRANSACTION_STATUS_METADATA_KEY.to_owned(),
+                    types::TransactionStatus::Pending.to_string(),
+                );
+
                 let partial_tx = Transaction {
                     mint_url: self.client.mint_url(),
                     fee: fees,
@@ -987,11 +1026,83 @@ where
                     unit: unit.clone(),
                     ys,
                     amount,
-                    metadata: HashMap::default(),
+                    metadata,
                     quote_id: None,
                 };
                 let tx_id = self.tx_repo.store_tx(partial_tx).await?;
-                return Ok(tx_id);
+                Ok((tx_id, None))
+            }
+            PaymentType::Token => {
+                let (proofs, token) = if unit == self.credit.unit() {
+                    let p = self
+                        .credit
+                        .send_proofs(
+                            request_id,
+                            &infos,
+                            self.client.as_ref(),
+                            SafeMode::new(self.safe_mode, self.clowder_id),
+                        )
+                        .await?;
+                    (
+                        p.clone(),
+                        Token::new_bitcr(
+                            self.client.mint_url(),
+                            p.into_values().collect(),
+                            memo.clone(),
+                            self.credit.unit(),
+                        ),
+                    )
+                } else if unit == self.debit.unit() {
+                    let p = self
+                        .debit
+                        .send_proofs(
+                            request_id,
+                            &infos,
+                            self.client.as_ref(),
+                            SafeMode::new(self.safe_mode, self.clowder_id),
+                        )
+                        .await?;
+                    (
+                        p.clone(),
+                        Token::new_cashu(
+                            self.client.mint_url(),
+                            p.into_values().collect(),
+                            memo.clone(),
+                            self.debit.unit(),
+                        ),
+                    )
+                } else {
+                    return Err(Error::CurrencyUnitMismatch(self.debit.unit(), unit));
+                };
+                let (ys, proofs): (Vec<cashu::PublicKey>, Vec<cashu::Proof>) =
+                    proofs.into_iter().unzip();
+                let amount = proofs
+                    .iter()
+                    .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
+                let mut metadata = HashMap::default();
+                metadata.insert(
+                    PAYMENT_TYPE_METADATA_KEY.to_owned(),
+                    types::PaymentType::Token.to_string(),
+                );
+                metadata.insert(
+                    TRANSACTION_STATUS_METADATA_KEY.to_owned(),
+                    types::TransactionStatus::CashedIn.to_string(),
+                );
+
+                let partial_tx = Transaction {
+                    mint_url: self.client.mint_url(),
+                    fee: fees,
+                    direction: TransactionDirection::Outgoing,
+                    memo,
+                    timestamp: now,
+                    unit: unit.clone(),
+                    ys,
+                    amount,
+                    metadata,
+                    quote_id: None,
+                };
+                let tx_id = self.tx_repo.store_tx(partial_tx).await?;
+                Ok((tx_id, Some(token)))
             }
         }
     }
@@ -1142,5 +1253,32 @@ where
         );
 
         Ok(())
+    }
+
+    async fn prepare_pay_by_token(
+        &self,
+        amount: Amount,
+        unit: CurrencyUnit,
+        description: Option<String>,
+    ) -> Result<PaymentSummary> {
+        let infos = self.client.get_mint_keysets().await?.keysets;
+
+        let s_summary = if self.credit.unit() == unit {
+            self.credit.prepare_send(amount, &infos).await?
+        } else if self.debit.unit() == unit {
+            self.debit.prepare_send(amount, &infos).await?
+        } else {
+            return Err(Error::CurrencyUnitMismatch(self.debit.unit(), unit));
+        };
+        let summary = PaymentSummary::from(s_summary);
+        let pref = PayReference {
+            request_id: summary.request_id,
+            unit: summary.unit.clone(),
+            fees: summary.fees,
+            ptype: PaymentType::Token,
+            memo: description,
+        };
+        *self.current_payment.lock().unwrap() = Some(pref);
+        Ok(summary)
     }
 }


### PR DESCRIPTION
* Add `Pay by Token`, which creates and returns a debit, or credit token to be sent via QR code
* Fix PaymentStatus and TransactionStatus for the different payment methods
* Set unit and amount in payment preparation (they were missing/wrong in the summary)
* Fix/Clean up CLI display of transactions