### PR TITLE
List Transactions, Remove SettingsDB, Restructure App State Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Add jobs for migrate_rabid and redeeming
 * Remove Settings DB and replace with AppStateConfig
 * Add an endpoint `wallet_list_txs` that returns all transactions for a wallet, sorted by timestamp descending
+* Use mint_url, mnemonic, network from config and fail if wallet doesn't match
+* Remove `get_wallets_names` endpoint
 
 # 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 * Remove WASM
 * Replace rexie (IndexedDB) with redb for persistence
 * Add CLI client
+* Add Pay by Token
+* Fixed Nostr payment
+* Add jobs for migrate_rabid and redeeming
+* Remove Settings DB and replace with AppStateConfig
+* Add an endpoint `wallet_list_txs` that returns all transactions for a wallet, sorted by timestamp descending
 
 # 0.1.0
 

--- a/crates/bcr-wallet-cli/Cargo.toml
+++ b/crates/bcr-wallet-cli/Cargo.toml
@@ -7,11 +7,13 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 bcr-wallet-core = {path = "../bcr-wallet-core"}
+bip39.workspace = true
 bitcoin.workspace = true
 cashu.workspace = true
 chrono.workspace = true
 clap = {version = "4.0", features = ["derive"]}
 config = {version="0.15"}
+nostr-sdk = {workspace = true, features = ["nip06"]}
 serde.workspace = true
 tokio.workspace = true
 toml = "0.8"

--- a/crates/bcr-wallet-cli/alice.toml
+++ b/crates/bcr-wallet-cli/alice.toml
@@ -1,10 +1,12 @@
 ## Other mint URLs
 #mint_url = "http://localhost:4343"
 # mint_url = "http://localhost:8080"
-# mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
+mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
 # mint_url = "https://mint.wildcat1.clowder1.minibill.tech"
 
-mint_url = "https://wildcat-dev-docker.minibill.tech"
+# mint_url = "https://wildcat-dev-docker.minibill.tech"
 mnemonic = "royal scheme canoe flame sell jewel valve citizen deal patch stereo walk"
 log_level = "DEBUG"
 db_path = "./alice.db"
+network = "testnet"
+nostr_relays = ["wss://bcr-relay-dev.minibill.tech"]

--- a/crates/bcr-wallet-cli/bob.toml
+++ b/crates/bcr-wallet-cli/bob.toml
@@ -3,3 +3,5 @@ mint_url = "https://wildcat-dev-docker.minibill.tech"
 mnemonic = "trip piano round arrest seven kangaroo used critic museum decline erupt horse"
 log_level = "DEBUG"
 db_path = "./bob.db"
+network = "testnet"
+nostr_relays = ["wss://bcr-relay-dev.minibill.tech"]

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -24,7 +24,7 @@ pub async fn cmd_info(app_state: &AppState) -> Result<String> {
             .wallet_list_redemptions(*id, std::time::Duration::from_hours(48))
             .await?;
 
-        let transactions = app_state.wallet_list_tx_ids(*id).await?;
+        let transactions = app_state.wallet_list_txs(*id).await?;
 
         res.push_str(&format!("Name: {name}\n"));
         res.push_str(&format!("Wallet ID: {id}\n"));
@@ -47,15 +47,8 @@ pub async fn cmd_info(app_state: &AppState) -> Result<String> {
         if !transactions.is_empty() {
             res.push_str("Transactions:");
             push_break(&mut res);
-            let mut txs = Vec::with_capacity(transactions.len());
-            for t in transactions.iter() {
-                let tx = app_state.wallet_load_tx(*id, &t.to_string()).await?;
-                txs.push(tx);
-            }
 
-            txs.sort_by(|a, b| b.tstamp.cmp(&a.tstamp)); // sort by timestamp desc
-
-            for tx in txs.iter() {
+            for tx in transactions.iter() {
                 res.push_str(&format!(
                     "\t\tAmount: {} {} \t Fees: {}  \t Status: {:?} \t {} \tType: {:<10} \t {:?} \t Memo: {}",
                     tx.amount, tx.unit, tx.fees,  tx.status, format_timestamp(tx.tstamp), &format!("{:?}", tx.ptype), tx.direction,tx.memo

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -3,8 +3,6 @@ use bcr_wallet_core::AppState;
 use chrono::{DateTime, Utc};
 use tracing::info;
 
-use crate::WalletSettings;
-
 pub async fn cmd_info(app_state: &AppState) -> Result<String> {
     let mut res = String::new();
     let wallet_ids = app_state.get_wallets_ids().await?;
@@ -60,38 +58,27 @@ pub async fn cmd_info(app_state: &AppState) -> Result<String> {
     Ok(res)
 }
 
-pub async fn cmd_add_wallet(
-    app_state: &AppState,
-    settings: &WalletSettings,
-    name: &str,
-) -> Result<String> {
+pub async fn cmd_add_wallet(app_state: &AppState, name: &str) -> Result<String> {
     let mut res = String::new();
-    let id = app_state
-        .add_wallet(
-            name.to_owned(),
-            settings.mint_url.to_owned(),
-            settings.mnemonic.to_owned(),
-        )
-        .await?;
+    let id = app_state.add_wallet(name.to_owned()).await?;
     push_break(&mut res);
     push_break(&mut res);
     res.push_str(&format!("Created Wallet for {name} - Wallet ID: {id}.\n"));
     Ok(res)
 }
 
-pub async fn cmd_restore_wallet(
-    app_state: &AppState,
-    settings: &WalletSettings,
-    name: &str,
-) -> Result<String> {
+pub async fn cmd_delete_wallet(app_state: &AppState, name: &str, id: usize) -> Result<String> {
     let mut res = String::new();
-    let id = app_state
-        .restore_wallet(
-            name.to_owned(),
-            settings.mint_url.to_owned(),
-            settings.mnemonic.to_owned(),
-        )
-        .await?;
+    app_state.delete_wallet(id).await?;
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!("Deleted Wallet for {name} - Wallet ID: {id}.\n"));
+    Ok(res)
+}
+
+pub async fn cmd_restore_wallet(app_state: &AppState, name: &str) -> Result<String> {
+    let mut res = String::new();
+    let id = app_state.restore_wallet(name.to_owned()).await?;
     push_break(&mut res);
     push_break(&mut res);
     res.push_str(&format!("Restored Wallet for {name} - Wallet ID: {id}.\n"));

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -46,6 +46,8 @@ enum Commands {
     Clear { id: usize },
     #[command(name = "add_wallet")]
     AddWallet,
+    #[command(name = "delete_wallet")]
+    DeleteWallet { id: usize },
     #[command(name = "restore_wallet")]
     RestoreWallet,
     #[command(name = "receive")]
@@ -113,6 +115,7 @@ async fn main() -> Result<()> {
         network: settings.network,
         nostr_relays: settings.nostr_relays.clone(),
         mnemonic: settings.mnemonic.clone(),
+        default_mint_url: settings.mint_url.clone(),
         same_mint_safe_mode: SameMintSafeMode::Disabled,
         // Disabled for now until Clowder stabilizes more
         // same_mint_safe_mode: SameMintSafeMode::Enabled {
@@ -154,14 +157,21 @@ async fn main() -> Result<()> {
             info!(
                 "Adding wallet for {}: {}",
                 cli.wallet,
-                command::cmd_add_wallet(&app_state, &settings, &cli.wallet).await?
+                command::cmd_add_wallet(&app_state, &cli.wallet).await?
+            );
+        }
+        Commands::DeleteWallet { id } => {
+            info!(
+                "Deleting wallet for {}: {}",
+                cli.wallet,
+                command::cmd_delete_wallet(&app_state, &cli.wallet, id).await?
             );
         }
         Commands::RestoreWallet => {
             info!(
                 "Restoring wallet for {}: {}",
                 cli.wallet,
-                command::cmd_restore_wallet(&app_state, &settings, &cli.wallet).await?
+                command::cmd_restore_wallet(&app_state, &cli.wallet).await?
             );
         }
         Commands::RequestPayment {

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -1,8 +1,13 @@
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 use anyhow::Result;
-use bcr_wallet_core::AppState;
+use bcr_wallet_core::{
+    AppState,
+    config::{AppStateConfig, SameMintSafeMode},
+    generate_random_mnemonic,
+};
 use clap::{Parser, Subcommand};
+use nostr_sdk::RelayUrl;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 use tracing_subscriber::{
@@ -15,9 +20,11 @@ mod command;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletSettings {
     pub mint_url: cashu::MintUrl,
-    pub mnemonic: String,
+    pub mnemonic: bip39::Mnemonic,
     pub log_level: String,
-    pub db_path: String,
+    pub db_path: PathBuf,
+    pub network: bitcoin::Network,
+    pub nostr_relays: Vec<RelayUrl>,
 }
 
 #[derive(Parser)]
@@ -101,7 +108,18 @@ async fn main() -> Result<()> {
 
     println!("{LOGO}");
 
-    let app_state = AppState::initialize(&settings.db_path).await?;
+    let app_state_cfg = AppStateConfig {
+        db_path: settings.db_path.clone(),
+        network: settings.network,
+        nostr_relays: settings.nostr_relays.clone(),
+        mnemonic: settings.mnemonic.clone(),
+        same_mint_safe_mode: SameMintSafeMode::Disabled,
+        // Disabled for now until Clowder stabilizes more
+        // same_mint_safe_mode: SameMintSafeMode::Enabled {
+        //     expiration: chrono::TimeDelta::minutes(15),
+        // },
+    };
+    let app_state = AppState::initialize(app_state_cfg).await?;
 
     match cli.command {
         Commands::Info => {
@@ -194,7 +212,7 @@ async fn main() -> Result<()> {
             );
         }
         Commands::GenMnemonic => {
-            info!("{}", app_state.generate_random_mnemonic(12));
+            info!("{}", generate_random_mnemonic(12));
         }
         Commands::Recover { .. } => {
             info!("Recover for {}: NOT IMPLEMENTED", cli.wallet,);

--- a/crates/bcr-wallet-core/src/config.rs
+++ b/crates/bcr-wallet-core/src/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::error::Result;
 use nostr_sdk::{Keys, RelayUrl, nips::nip06::FromMnemonic, nips::nip19::Nip19Profile};
 
@@ -9,46 +11,31 @@ pub enum SameMintSafeMode {
     Enabled { expiration: chrono::TimeDelta },
     Disabled,
 }
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct Settings {
+
+#[derive(Debug, Clone)]
+pub struct AppStateConfig {
+    pub db_path: PathBuf,
     pub network: bitcoin::Network,
-    pub mnemonic: bip39::Mnemonic,
     pub nostr_relays: Vec<RelayUrl>,
+    pub mnemonic: bip39::Mnemonic,
     pub same_mint_safe_mode: SameMintSafeMode,
 }
 
-impl Default for Settings {
-    fn default() -> Self {
-        Self {
-            network: bitcoin::Network::Testnet,
-            mnemonic: bip39::Mnemonic::generate(12).expect("Failed to generate default mnemonic"),
-            nostr_relays: vec![
-                RelayUrl::parse("wss://bcr-relay-dev.minibill.tech")
-                    .expect("Invalid default relay URL"),
-            ],
-            same_mint_safe_mode: SameMintSafeMode::Disabled,
-            // Disabled for now until Clowder stabilizes more
-            // same_mint_safe_mode: SameMintSafeMode::Enabled {
-            //     expiration: chrono::TimeDelta::minutes(15),
-            // },
-        }
-    }
-}
-
-pub struct Config {
+#[derive(Debug, Clone)]
+pub struct NostrConfig {
     pub nprofile: Nip19Profile,
     pub nostr_signer: Keys,
     pub relays: Vec<RelayUrl>,
 }
 
-impl Config {
-    pub fn new(settings: Settings) -> Result<Self> {
-        let keys = Keys::from_mnemonic(settings.mnemonic.to_string(), None)?;
+impl NostrConfig {
+    pub fn new(mnemonic: bip39::Mnemonic, nostr_relays: Vec<RelayUrl>) -> Result<Self> {
+        let keys = Keys::from_mnemonic(mnemonic.to_string(), None)?;
 
         Ok(Self {
-            nprofile: Nip19Profile::new(keys.public_key, settings.nostr_relays.clone()),
+            nprofile: Nip19Profile::new(keys.public_key, nostr_relays.clone()),
             nostr_signer: keys,
-            relays: settings.nostr_relays,
+            relays: nostr_relays,
         })
     }
 }

--- a/crates/bcr-wallet-core/src/config.rs
+++ b/crates/bcr-wallet-core/src/config.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crate::error::Result;
+use cashu::MintUrl;
 use nostr_sdk::{Keys, RelayUrl, nips::nip06::FromMnemonic, nips::nip19::Nip19Profile};
 
 pub const LOCK_REDUCTION_SECONDS_PER_HOP: u64 = 600;
@@ -19,6 +20,7 @@ pub struct AppStateConfig {
     pub nostr_relays: Vec<RelayUrl>,
     pub mnemonic: bip39::Mnemonic,
     pub same_mint_safe_mode: SameMintSafeMode,
+    pub default_mint_url: MintUrl,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/bcr-wallet-core/src/db.rs
+++ b/crates/bcr-wallet-core/src/db.rs
@@ -37,13 +37,6 @@ pub async fn build_wallet_dbs(
     Ok((txdb, ((debitdb, mintmeltdb), creditdb)))
 }
 
-pub async fn build_settingsdb(
-    _db_version: u32,
-    db: Arc<redb::Database>,
-) -> Result<prod::ProductionSettingsRepository> {
-    prod::ProductionSettingsRepository::new(db)
-}
-
 pub async fn build_jobsdb(
     _db_version: u32,
     db: Arc<redb::Database>,

--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -1,6 +1,6 @@
 use anyhow::Error as AnyError;
 use bitcoin::hashes::sha256::Hash as Sha256;
-use cashu::nut02 as cdk02;
+use cashu::{MintUrl, nut02 as cdk02};
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -72,6 +72,8 @@ pub enum Error {
     CounterKidMismatch,
     #[error("counter in local DB not found: {0}")]
     CounterNotFound(cdk02::Id),
+    #[error("There already exists a wallet - delete it to create a new one")]
+    WalletAlreadyExists,
     #[error("wallet id {0} not found")]
     WalletIdNotFound(String),
     #[error("wallet at idx {0} not found")]
@@ -102,6 +104,10 @@ pub enum Error {
     NoDebitCurrencyInMint(Vec<cashu::CurrencyUnit>),
     #[error("network mismatch, ours: {0}, theirs: {1}")]
     InvalidNetwork(bitcoin::Network, bitcoin::Network),
+    #[error("mnemonic mismatch")]
+    InvalidMnemonic,
+    #[error("mint url mismatch, ours: {0}, theirs: {1}")]
+    InvalidMintUrl(MintUrl, MintUrl),
     #[error("payment request, missing amount")]
     MissingAmount,
     #[error("payment request unknown {0}")]

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -1,7 +1,8 @@
+use crate::config::AppStateConfig;
 use crate::job::JobState;
 use crate::mint::MintConnector;
 use crate::{
-    config::{Config, SameMintSafeMode, Settings},
+    config::{NostrConfig, SameMintSafeMode},
     purse::Wallet,
     types::{PaymentSummary, RedemptionSummary},
     wallet::{CreditPocket, WalletBalance},
@@ -33,7 +34,7 @@ pub mod persistence;
 pub mod pocket;
 mod purse;
 mod restore;
-mod types;
+pub mod types;
 pub mod utils;
 pub mod wallet;
 
@@ -44,7 +45,6 @@ mod prod {
     pub type ProductionMintMeltRepository = crate::persistence::redb::MintMeltDB;
     pub type ProductionPurseRepository = crate::persistence::redb::PurseDB;
     pub type ProductionTransactionRepository = crate::persistence::redb::TransactionDB;
-    pub type ProductionSettingsRepository = crate::persistence::redb::SettingsDB;
     pub type ProductionJobsRepository = crate::persistence::redb::JobsDB;
 }
 
@@ -66,71 +66,67 @@ pub enum LocalDB {
 
 pub struct AppState {
     purse: Arc<ProductionPurse>,
-    settings: Arc<prod::ProductionSettingsRepository>,
     jobs: Arc<prod::ProductionJobsRepository>,
     db: Arc<redb::Database>,
+    cfg: AppStateConfig,
 }
 
 impl AppState {
     pub const DB_VERSION: u32 = 1;
 
-    pub async fn initialize(db_path: &str) -> Result<Self> {
+    pub async fn initialize(cfg: AppStateConfig) -> Result<Self> {
         tracing::debug!("Initializing API");
 
         // Open Database file - only allowed to do once!
-        let db = Arc::new(redb::Database::create(db_path)?);
+        let db = Arc::new(redb::Database::create(&cfg.db_path)?);
 
         let pursedb = db::build_pursedb(AppState::DB_VERSION, db.clone()).await?;
-        let settingsdb = Arc::new(db::build_settingsdb(AppState::DB_VERSION, db.clone()).await?);
         let jobsdb = Arc::new(db::build_jobsdb(AppState::DB_VERSION, db.clone()).await?);
-        let settings = settingsdb.clone().load().await?;
-        let config = Config::new(settings)?;
-        let nostr_cl = nostr_sdk::Client::new(config.nostr_signer);
-        for relay in &config.relays {
+
+        let nostr_cfg = NostrConfig::new(cfg.mnemonic.clone(), cfg.nostr_relays.clone())?;
+        let nostr_cl = nostr_sdk::Client::new(nostr_cfg.nostr_signer);
+        for relay in &nostr_cfg.relays {
             nostr_cl.add_relay(relay).await?;
         }
         nostr_cl.connect().await;
         let http_cl = reqwest::Client::new();
-        let purse = ProductionPurse::new(pursedb, http_cl, nostr_cl, config.nprofile).await?;
-        let mut appstate = AppState::new(Arc::new(purse), settingsdb, jobsdb, db);
-        appstate.load_wallets().await?;
+        let purse = ProductionPurse::new(pursedb, http_cl, nostr_cl, nostr_cfg.nprofile).await?;
+        let mut appstate = AppState::new(Arc::new(purse), jobsdb, db, cfg);
+        appstate
+            .load_wallets(appstate.cfg.same_mint_safe_mode)
+            .await?;
         Ok(appstate)
     }
 
     fn new(
         purse: Arc<ProductionPurse>,
-        settings: Arc<prod::ProductionSettingsRepository>,
         jobs: Arc<prod::ProductionJobsRepository>,
         db: Arc<redb::Database>,
+        cfg: AppStateConfig,
     ) -> Self {
         tracing::debug!("Creating new AppState");
         Self {
             purse,
-            settings,
             jobs,
             db,
+            cfg,
         }
     }
 
-    pub async fn load_settings(&self) -> Result<Settings> {
-        self.settings.clone().load().await
-    }
-
-    pub async fn load_wallets(&mut self) -> Result<()> {
+    pub async fn load_wallets(&mut self, same_mint_safe_mode: SameMintSafeMode) -> Result<()> {
         tracing::debug!("AppState::load_wallets()");
 
-        let settings = self.load_settings().await?;
         let purse = self.get_purse();
         let db = self.get_db();
         let w_ids = purse.list_wallets().await?;
         for wid in w_ids {
             tracing::debug!("Loading wallet with id: {wid}");
             let w_cfg = purse.load_wallet_config(&wid).await?;
-            if w_cfg.network != settings.network {
+            if w_cfg.network != self.cfg.network {
                 tracing::info!(
                     "Skipping wallet {wid} with network {:?}, expected {:?}",
                     w_cfg.network,
-                    settings.network,
+                    self.cfg.network,
                 );
                 continue;
             }
@@ -141,7 +137,7 @@ impl AppState {
                 w_cfg.mnemonic,
                 LocalDB::Keep,
                 Self::DB_VERSION,
-                settings.same_mint_safe_mode,
+                same_mint_safe_mode,
                 db.clone(),
             )
             .await?;
@@ -162,10 +158,6 @@ impl AppState {
         self.purse.clone()
     }
 
-    fn get_settingsdb(&self) -> Arc<prod::ProductionSettingsRepository> {
-        self.settings.clone()
-    }
-
     fn get_jobsdb(&self) -> Arc<prod::ProductionJobsRepository> {
         self.jobs.clone()
     }
@@ -179,20 +171,18 @@ impl AppState {
         &self,
         name: String,
         mint_url: MintUrl,
-        mnemonic: String,
+        mnemonic: bip39::Mnemonic,
     ) -> Result<usize> {
         tracing::debug!("Adding a new wallet for mint {name}, {mint_url}, {mnemonic}");
 
-        let settings = self.get_settingsdb().load().await?;
-        let mnemonic = bip39::Mnemonic::from_str(&mnemonic)?;
         let wallet = build_wallet(
             name,
-            settings.network,
+            self.cfg.network,
             mint_url,
             mnemonic,
             LocalDB::Keep,
             AppState::DB_VERSION,
-            settings.same_mint_safe_mode,
+            self.cfg.same_mint_safe_mode,
             self.get_db(),
         )
         .await?;
@@ -207,20 +197,18 @@ impl AppState {
         &self,
         name: String,
         mint_url: MintUrl,
-        mnemonic: String,
+        mnemonic: bip39::Mnemonic,
     ) -> Result<usize> {
         tracing::debug!("Restoring a new wallet for mint {name}, {mint_url}");
 
-        let settings = self.get_settingsdb().load().await?;
-        let mnemonic = bip39::Mnemonic::from_str(&mnemonic)?;
         let wallet = build_wallet(
             name,
-            settings.network,
+            self.cfg.network,
             mint_url,
             mnemonic,
             LocalDB::Delete,
             AppState::DB_VERSION,
-            settings.same_mint_safe_mode,
+            self.cfg.same_mint_safe_mode,
             self.get_db(),
         )
         .await?;
@@ -424,6 +412,15 @@ impl AppState {
         Ok(tx_ids)
     }
 
+    pub async fn wallet_list_txs(&self, idx: usize) -> Result<Vec<Transaction>> {
+        tracing::debug!("wallet_list_txs({idx})");
+
+        let wallet = self.get_wallet(idx).await?;
+        let mut txs = wallet.read().await.list_txs().await?;
+        txs.sort_by(|a, b| b.timestamp.cmp(&a.timestamp)); // sort by timestamp desc
+        Ok(txs.into_iter().map(|t| t.into()).collect())
+    }
+
     pub async fn get_wallets_ids(&self) -> Result<Vec<usize>> {
         tracing::debug!("get_wallet_ids");
         let purse = self.get_purse();
@@ -434,26 +431,6 @@ impl AppState {
         tracing::debug!("get_wallet_names");
         let purse = self.get_purse();
         purse.names().await
-    }
-
-    pub fn generate_random_mnemonic(&self, mnemonic_len: u32) -> String {
-        let mnemonic_len = if mnemonic_len == 0 { 12 } else { mnemonic_len };
-        tracing::info!("Generate random {}-word mnemonic", mnemonic_len);
-
-        const VALID_MNEMONIC_LENGTHS: [u32; 5] = [12, 15, 18, 21, 24];
-        assert!(
-            VALID_MNEMONIC_LENGTHS.contains(&mnemonic_len),
-            "word count must be one of: {VALID_MNEMONIC_LENGTHS:?}"
-        );
-        let returned =
-            bip39::Mnemonic::generate_in(bip39::Language::English, mnemonic_len as usize);
-        match returned {
-            Ok(mnemonic) => mnemonic.to_string(),
-            Err(e) => {
-                tracing::error!("generate_random_mnemonic({mnemonic_len}): {e}");
-                String::default()
-            }
-        }
     }
 
     /// Checks when the jobs were run the last time and if it's greater than 1 day
@@ -511,6 +488,25 @@ impl AppState {
         }
         // successful = true
         !job_failed
+    }
+}
+
+pub fn generate_random_mnemonic(mnemonic_len: u32) -> String {
+    let mnemonic_len = if mnemonic_len == 0 { 12 } else { mnemonic_len };
+    tracing::info!("Generate random {}-word mnemonic", mnemonic_len);
+
+    const VALID_MNEMONIC_LENGTHS: [u32; 5] = [12, 15, 18, 21, 24];
+    assert!(
+        VALID_MNEMONIC_LENGTHS.contains(&mnemonic_len),
+        "word count must be one of: {VALID_MNEMONIC_LENGTHS:?}"
+    );
+    let returned = bip39::Mnemonic::generate_in(bip39::Language::English, mnemonic_len as usize);
+    match returned {
+        Ok(mnemonic) => mnemonic.to_string(),
+        Err(e) => {
+            tracing::error!("generate_random_mnemonic({mnemonic_len}): {e}");
+            String::default()
+        }
     }
 }
 

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -92,9 +92,7 @@ impl AppState {
         let http_cl = reqwest::Client::new();
         let purse = ProductionPurse::new(pursedb, http_cl, nostr_cl, nostr_cfg.nprofile).await?;
         let mut appstate = AppState::new(Arc::new(purse), jobsdb, db, cfg);
-        appstate
-            .load_wallets(appstate.cfg.same_mint_safe_mode)
-            .await?;
+        appstate.load_wallets().await?;
         Ok(appstate)
     }
 
@@ -113,7 +111,7 @@ impl AppState {
         }
     }
 
-    pub async fn load_wallets(&mut self, same_mint_safe_mode: SameMintSafeMode) -> Result<()> {
+    pub async fn load_wallets(&mut self) -> Result<()> {
         tracing::debug!("AppState::load_wallets()");
 
         let purse = self.get_purse();
@@ -122,14 +120,35 @@ impl AppState {
         for wid in w_ids {
             tracing::debug!("Loading wallet with id: {wid}");
             let w_cfg = purse.load_wallet_config(&wid).await?;
+
             if w_cfg.network != self.cfg.network {
-                tracing::info!(
-                    "Skipping wallet {wid} with network {:?}, expected {:?}",
+                tracing::error!(
+                    "Network mismatch: wallet {wid} with network {:?}, expected {:?}",
                     w_cfg.network,
                     self.cfg.network,
                 );
-                continue;
+                return Err(Error::InvalidNetwork(w_cfg.network, self.cfg.network));
             }
+
+            if w_cfg.mnemonic != self.cfg.mnemonic {
+                tracing::error!(
+                    "Mnemonic mismatch: wallet {wid} has a different mnemonic than the one given via config"
+                );
+                return Err(Error::InvalidMnemonic);
+            }
+
+            if w_cfg.mint != self.cfg.default_mint_url {
+                tracing::error!(
+                    "Mint URL mismatch: wallet {wid} with mint url {}, expected: {}",
+                    w_cfg.mint,
+                    self.cfg.default_mint_url
+                );
+                return Err(Error::InvalidMintUrl(
+                    w_cfg.mint.clone(),
+                    self.cfg.default_mint_url.clone(),
+                ));
+            }
+
             let wallet = build_wallet(
                 w_cfg.name,
                 w_cfg.network,
@@ -137,7 +156,7 @@ impl AppState {
                 w_cfg.mnemonic,
                 LocalDB::Keep,
                 Self::DB_VERSION,
-                same_mint_safe_mode,
+                self.cfg.same_mint_safe_mode,
                 db.clone(),
             )
             .await?;
@@ -167,19 +186,19 @@ impl AppState {
     }
     // methods
 
-    pub async fn add_wallet(
-        &self,
-        name: String,
-        mint_url: MintUrl,
-        mnemonic: bip39::Mnemonic,
-    ) -> Result<usize> {
-        tracing::debug!("Adding a new wallet for mint {name}, {mint_url}, {mnemonic}");
+    pub async fn add_wallet(&self, name: String) -> Result<usize> {
+        let mint_url = self.cfg.default_mint_url.clone();
+        tracing::debug!("Adding a new wallet for mint {name}, {mint_url}");
+        let purse = self.get_purse();
+        if !purse.can_add_wallet().await {
+            return Err(Error::WalletAlreadyExists);
+        }
 
         let wallet = build_wallet(
             name,
             self.cfg.network,
             mint_url,
-            mnemonic,
+            self.cfg.mnemonic.clone(),
             LocalDB::Keep,
             AppState::DB_VERSION,
             self.cfg.same_mint_safe_mode,
@@ -187,25 +206,24 @@ impl AppState {
         )
         .await?;
 
-        let purse = self.get_purse();
         let idx = purse.add_wallet(wallet).await?;
 
         Ok(idx)
     }
 
-    pub async fn restore_wallet(
-        &self,
-        name: String,
-        mint_url: MintUrl,
-        mnemonic: bip39::Mnemonic,
-    ) -> Result<usize> {
+    pub async fn restore_wallet(&self, name: String) -> Result<usize> {
+        let mint_url = self.cfg.default_mint_url.clone();
         tracing::debug!("Restoring a new wallet for mint {name}, {mint_url}");
+        let purse = self.get_purse();
+        if !purse.can_add_wallet().await {
+            return Err(Error::WalletAlreadyExists);
+        }
 
         let wallet = build_wallet(
             name,
             self.cfg.network,
             mint_url,
-            mnemonic,
+            self.cfg.mnemonic.clone(),
             LocalDB::Delete,
             AppState::DB_VERSION,
             self.cfg.same_mint_safe_mode,
@@ -214,9 +232,16 @@ impl AppState {
         .await?;
         wallet.restore_local_proofs().await?;
 
-        let purse = self.get_purse();
         let idx = purse.add_wallet(wallet).await?;
         Ok(idx)
+    }
+
+    pub async fn delete_wallet(&self, idx: usize) -> Result<()> {
+        tracing::debug!("delete wallet {idx}");
+        self.wallet_clean_local_db(idx).await?;
+        let purse = self.get_purse();
+        purse.delete_wallet(idx).await?;
+        Ok(())
     }
 
     pub async fn get_wallet_name(&self, idx: usize) -> Result<String> {
@@ -425,12 +450,6 @@ impl AppState {
         tracing::debug!("get_wallet_ids");
         let purse = self.get_purse();
         Ok(purse.ids().await.iter().map(|id| *id as usize).collect())
-    }
-
-    pub async fn get_wallets_names(&self) -> Result<Vec<String>> {
-        tracing::debug!("get_wallet_names");
-        let purse = self.get_purse();
-        purse.names().await
     }
 
     /// Checks when the jobs were run the last time and if it's greater than 1 day

--- a/crates/bcr-wallet-core/src/persistence/inmemory.rs
+++ b/crates/bcr-wallet-core/src/persistence/inmemory.rs
@@ -1,6 +1,5 @@
 use crate::{
     TStamp,
-    config::Settings,
     error::{Error, Result},
     persistence::Commitment,
     pocket::{PocketRepository, debit::MintMeltRepository},
@@ -197,6 +196,11 @@ impl TransactionRepository for InMemoryTransactionRepository {
             .collect();
         Ok(tx_ids)
     }
+    async fn list_txs(&self) -> Result<Vec<Transaction>> {
+        let transactions = self.transactions.lock().unwrap();
+        let txs: Vec<Transaction> = transactions.values().cloned().collect();
+        Ok(txs)
+    }
     async fn update_metadata(
         &self,
         tx_id: TransactionId,
@@ -243,20 +247,5 @@ impl MintMeltRepository for InMemoryMintMeltRepository {
         let mut melts = self.melts.lock().unwrap();
         melts.remove(&qid);
         Ok(())
-    }
-}
-
-///////////////////////////////////////////// InMemorySettingsRepository
-#[derive(Default)]
-pub struct InMemorySettingsRepository {
-    setting: Arc<Mutex<Settings>>,
-}
-impl InMemorySettingsRepository {
-    pub async fn store(&self, setting: Settings) -> Result<()> {
-        *self.setting.lock().unwrap() = setting;
-        Ok(())
-    }
-    pub async fn load(&self) -> Result<Settings> {
-        Ok(self.setting.lock().unwrap().clone())
     }
 }

--- a/crates/bcr-wallet-core/src/persistence/redb.rs
+++ b/crates/bcr-wallet-core/src/persistence/redb.rs
@@ -1,6 +1,5 @@
 use crate::{
     TStamp,
-    config::Settings,
     error::{Error, Result},
     job::JobState,
     persistence::Commitment,
@@ -665,6 +664,26 @@ impl TransactionDB {
         }
     }
 
+    fn list_txs_sync(
+        db: Arc<Database>,
+        tx_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+    ) -> Result<Vec<TransactionEntry>> {
+        let read_txn = db.begin_read()?;
+
+        match read_txn.open_table(tx_table) {
+            Ok(table) => {
+                let mut res = Vec::new();
+                for (_, v) in table.range::<&[u8]>(..)?.flatten() {
+                    let tx: TransactionEntry = ciborium::from_reader(v.value().as_slice())?;
+                    res.push(tx);
+                }
+                Ok(res)
+            }
+            Err(TableError::TableDoesNotExist(_)) => Ok(vec![]),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     fn update_meta_sync(
         db: Arc<Database>,
         tx_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
@@ -722,6 +741,13 @@ impl TransactionRepository for TransactionDB {
         let db_clone = self.db.clone();
         let table = self.transaction_table;
         spawn_blocking(move || Self::list_tx_ids_sync(db_clone, table)).await?
+    }
+
+    async fn list_txs(&self) -> Result<Vec<Transaction>> {
+        let db_clone = self.db.clone();
+        let table = self.transaction_table;
+        let res = spawn_blocking(move || Self::list_txs_sync(db_clone, table)).await??;
+        Ok(res.into_iter().map(|entry| entry.into()).collect())
     }
 
     async fn update_metadata(
@@ -1068,64 +1094,6 @@ impl MintMeltRepository for MintMeltDB {
         let table = self.melt_table;
         spawn_blocking(move || Self::delete_melt_sync(db_clone, table, qid)).await??;
         Ok(())
-    }
-}
-
-///////////////////////////////////////////// SettingEntry
-const SETTINGS_TABLE: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new("settings");
-
-///////////////////////////////////////////// SettingsDB
-pub struct SettingsDB {
-    db: Arc<Database>,
-}
-
-impl SettingsDB {
-    const SETTINGS_MAIN_ID: &'static str = "main";
-
-    pub fn new(db: Arc<Database>) -> Result<Self> {
-        Ok(Self { db })
-    }
-
-    fn store_sync(&self, settings: Settings) -> Result<()> {
-        let write_txn = self.db.begin_write()?;
-
-        {
-            let mut table = write_txn.open_table(SETTINGS_TABLE)?;
-
-            let mut serialized = Vec::new();
-            ciborium::into_writer(&settings, &mut serialized)?;
-            table.insert(Self::SETTINGS_MAIN_ID.as_bytes(), serialized)?;
-        }
-
-        write_txn.commit()?;
-        Ok(())
-    }
-
-    fn load_sync(&self) -> Result<Settings> {
-        let read_txn = self.db.begin_read()?;
-
-        match read_txn.open_table(SETTINGS_TABLE) {
-            Ok(table) => {
-                let entry = table.get(Self::SETTINGS_MAIN_ID.as_bytes())?;
-                match entry {
-                    Some(e) => {
-                        let settings: Settings = ciborium::from_reader(e.value().as_slice())?;
-                        Ok(settings)
-                    }
-                    None => Ok(Settings::default()),
-                }
-            }
-            Err(TableError::TableDoesNotExist(_)) => Ok(Settings::default()),
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    pub async fn store(self: Arc<Self>, settings: Settings) -> Result<()> {
-        spawn_blocking(move || self.store_sync(settings)).await?
-    }
-
-    pub async fn load(self: Arc<Self>) -> Result<Settings> {
-        spawn_blocking(move || self.load_sync()).await?
     }
 }
 

--- a/crates/bcr-wallet-core/src/persistence/redb.rs
+++ b/crates/bcr-wallet-core/src/persistence/redb.rs
@@ -847,7 +847,6 @@ impl PurseDB {
         }
     }
 
-    #[allow(unused)]
     fn delete_sync(db: Arc<Database>, wallet_id: &str) -> Result<()> {
         let write_txn = db.begin_write()?;
 

--- a/crates/bcr-wallet-core/src/purse.rs
+++ b/crates/bcr-wallet-core/src/purse.rs
@@ -34,6 +34,7 @@ pub trait PurseRepository: sync::SendSync {
 pub trait Wallet: sync::SendSync {
     fn config(&self) -> Result<WalletConfig>;
     fn name(&self) -> String;
+    fn id(&self) -> String;
     fn mint_url(&self) -> Result<MintUrl>;
     #[allow(dead_code)]
     fn betas(&self) -> Vec<MintUrl>;
@@ -113,6 +114,7 @@ impl<Wlt> Purse<Wlt> {
     pub async fn load_wallet_config(&self, wallet_id: &str) -> Result<WalletConfig> {
         self.repo.load(wallet_id).await
     }
+
     pub async fn list_wallets(&self) -> Result<Vec<String>> {
         self.repo.list_ids().await
     }
@@ -127,19 +129,10 @@ impl<Wlt> Purse<Wlt> {
         let w_len = self.wallets.lock().await.len();
         (0..w_len as u32).collect()
     }
-}
 
-impl<Wlt> Purse<Wlt>
-where
-    Wlt: Wallet,
-{
-    pub async fn names(&self) -> Result<Vec<String>> {
-        let wallets = self.wallets.lock().await;
-        let mut names = Vec::with_capacity(wallets.len());
-        for w in wallets.iter() {
-            names.push(w.read().await.name());
-        }
-        Ok(names)
+    // Current limitation to 1 wallet
+    pub async fn can_add_wallet(&self) -> bool {
+        self.wallets.lock().await.is_empty()
     }
 }
 
@@ -152,6 +145,16 @@ where
         let mut wallets = self.wallets.lock().await;
         wallets.push(Arc::new(RwLock::new(wallet)));
         Ok(wallets.len() - 1)
+    }
+
+    pub async fn delete_wallet(&self, idx: usize) -> Result<()> {
+        let Some(wlt) = self.wallets.lock().await.get(idx).cloned() else {
+            return Err(Error::WalletNotFound(idx));
+        };
+        let id = wlt.read().await.id();
+        self.repo.delete(&id).await?;
+        self.wallets.lock().await.remove(idx);
+        Ok(())
     }
 
     pub async fn prepare_pay(&self, idx: usize, input: String, now: u64) -> Result<PaymentSummary> {

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -123,6 +123,7 @@ pub trait TransactionRepository: sync::SendSync {
     #[allow(dead_code)]
     async fn delete_tx(&self, tx_id: TransactionId) -> Result<()>;
     async fn list_tx_ids(&self) -> Result<Vec<TransactionId>>;
+    async fn list_txs(&self) -> Result<Vec<Transaction>>;
     async fn update_metadata(
         &self,
         tx_id: TransactionId,
@@ -226,6 +227,10 @@ impl<DebtPck> Wallet<DebtPck> {
 
     pub async fn list_tx_ids(&self) -> Result<Vec<TransactionId>> {
         self.tx_repo.list_tx_ids().await
+    }
+
+    pub async fn list_txs(&self) -> Result<Vec<Transaction>> {
+        self.tx_repo.list_txs().await
     }
 }
 

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -862,6 +862,10 @@ where
         self.name.clone()
     }
 
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
     fn mint_url(&self) -> Result<cashu::MintUrl> {
         Ok(self.client.mint_url())
     }


### PR DESCRIPTION
* Add endpoint for listing full transactions (instead of only being able to list ids and loading each one separately), returns Transactions sorted by timestamp descending
* Move Config outwards to the library caller from the SettingsDB
  * @mtbitcr Here we need to make a decision on whether we want 1 mnemonic for all (nostr client, wallet), or several and how initialization should work