### PR TITLE
Dont store mnemonic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.7.1
 
 * Remove `bcr-wallet-lib` in favor of `bcr-common::wallet` for `Token`
+* Don't persist mnemonic anymore (breaking DB change)
 
 # 0.7.0
 

--- a/crates/bcr-wallet-cli/bob.toml
+++ b/crates/bcr-wallet-cli/bob.toml
@@ -1,6 +1,6 @@
 # mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
 mint_url = "https://wildcat-dev-docker.minibill.tech"
-mnemonic = "trip piano round arrest seven kangaroo used critic museum decline erupt horse"
+mnemonic = "spoil frost juice sketch spirit fine trophy puzzle crater roast holiday payment"
 log_level = "DEBUG"
 db_path = "./bob.db"
 network = "testnet"

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -16,7 +16,7 @@ use cashu::{CurrencyUnit, KeySetInfo, MintInfo, MintUrl};
 use cdk::wallet::{MintConnector as MintCon, types::TransactionId};
 use chrono::Utc;
 use error::{Error, Result};
-use secp256k1::{Keypair, SECP256K1, SecretKey};
+use secp256k1::{Keypair, SECP256K1};
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
@@ -131,7 +131,7 @@ impl AppState {
                 return Err(Error::InvalidNetwork(w_cfg.network, self.cfg.network));
             }
 
-            let keypair = keypair_from_mnemonic(&self.cfg.mnemonic)?;
+            let keypair = keypair_from_mnemonic(&self.cfg.mnemonic);
             if w_cfg.pub_key != keypair.public_key() {
                 tracing::error!(
                     "Key mismatch: wallet {wid} has a different pubkey than the one given via the config mnemonic"
@@ -693,7 +693,7 @@ async fn build_wallet(
     db: Arc<redb::Database>,
 ) -> Result<ProductionWallet> {
     let seed = seed_from_mnemonic(&mnemonic);
-    let keypair = keypair_from_mnemonic(&mnemonic)?;
+    let keypair = keypair_from_mnemonic(&mnemonic);
     // retrieving mint details
     let client = ProductionConnector::new(mint_url.clone());
     let keyset_infos = client.get_mint_keysets().await?.keysets;
@@ -758,14 +758,10 @@ async fn build_wallet(
 }
 
 // converts a mnemonic to a secp256k1 keypair
-fn keypair_from_mnemonic(mnemonic: &bip39::Mnemonic) -> Result<Keypair> {
+fn keypair_from_mnemonic(mnemonic: &bip39::Mnemonic) -> Keypair {
     let seed = seed_from_mnemonic(mnemonic);
-    let (key, _) = seed.split_at(32);
-    let secret = SecretKey::from_slice(key).map_err(|e| {
-        tracing::error!("Could not get secp256k1 key from mnemonic: {e}");
-        Error::InvalidMnemonic
-    })?;
-    Ok(Keypair::from_secret_key(SECP256K1, &secret))
+    let (key, _) = seed.split_at(secp256k1::constants::SECRET_KEY_SIZE);
+    Keypair::from_seckey_slice(SECP256K1, key).expect("key to be correct size")
 }
 
 fn seed_from_mnemonic(mnemonic: &bip39::Mnemonic) -> [u8; 64] {

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -16,6 +16,7 @@ use cashu::{CurrencyUnit, KeySetInfo, MintInfo, MintUrl};
 use cdk::wallet::{MintConnector as MintCon, types::TransactionId};
 use chrono::Utc;
 use error::{Error, Result};
+use secp256k1::{Keypair, SECP256K1, SecretKey};
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
@@ -130,9 +131,10 @@ impl AppState {
                 return Err(Error::InvalidNetwork(w_cfg.network, self.cfg.network));
             }
 
-            if w_cfg.mnemonic != self.cfg.mnemonic {
+            let keypair = keypair_from_mnemonic(&self.cfg.mnemonic)?;
+            if w_cfg.pub_key != keypair.public_key() {
                 tracing::error!(
-                    "Mnemonic mismatch: wallet {wid} has a different mnemonic than the one given via config"
+                    "Key mismatch: wallet {wid} has a different pubkey than the one given via the config mnemonic"
                 );
                 return Err(Error::InvalidMnemonic);
             }
@@ -153,7 +155,7 @@ impl AppState {
                 w_cfg.name,
                 w_cfg.network,
                 w_cfg.mint,
-                w_cfg.mnemonic,
+                self.cfg.mnemonic.clone(),
                 LocalDB::Keep,
                 Self::DB_VERSION,
                 self.cfg.same_mint_safe_mode,
@@ -690,7 +692,8 @@ async fn build_wallet(
     same_mint_safe_mode: SameMintSafeMode,
     db: Arc<redb::Database>,
 ) -> Result<ProductionWallet> {
-    let seed = mnemonic.to_seed("");
+    let seed = seed_from_mnemonic(&mnemonic);
+    let keypair = keypair_from_mnemonic(&mnemonic)?;
     // retrieving mint details
     let client = ProductionConnector::new(mint_url.clone());
     let keyset_infos = client.get_mint_keysets().await?.keysets;
@@ -745,11 +748,26 @@ async fn build_wallet(
         (debit_pocket, credit_pocket),
         name,
         wallet_id,
-        mnemonic,
+        keypair.public_key(),
         beta_clients,
         Box::new(|url| Box::new(crate::mint::HttpClientExt::new(url))),
         same_mint_safe_mode,
     )
     .await?;
     Ok(new_wallet)
+}
+
+// converts a mnemonic to a secp256k1 keypair
+fn keypair_from_mnemonic(mnemonic: &bip39::Mnemonic) -> Result<Keypair> {
+    let seed = seed_from_mnemonic(mnemonic);
+    let (key, _) = seed.split_at(32);
+    let secret = SecretKey::from_slice(key).map_err(|e| {
+        tracing::error!("Could not get secp256k1 key from mnemonic: {e}");
+        Error::InvalidMnemonic
+    })?;
+    Ok(Keypair::from_secret_key(SECP256K1, &secret))
+}
+
+fn seed_from_mnemonic(mnemonic: &bip39::Mnemonic) -> [u8; 64] {
+    mnemonic.to_seed("")
 }

--- a/crates/bcr-wallet-core/src/persistence/redb.rs
+++ b/crates/bcr-wallet-core/src/persistence/redb.rs
@@ -769,7 +769,7 @@ struct WalletEntry {
     name: String,
     network: bitcoin::Network,
     mint: cashu::MintUrl,
-    mnemonic: bip39::Mnemonic,
+    pub_key: secp256k1::PublicKey,
     debit: CurrencyUnit,
     credit: Option<CurrencyUnit>,
 }
@@ -780,7 +780,7 @@ impl std::convert::From<WalletConfig> for WalletEntry {
             name: wallet.name,
             network: wallet.network,
             mint: wallet.mint,
-            mnemonic: wallet.mnemonic,
+            pub_key: wallet.pub_key,
             debit: wallet.debit,
             credit: wallet.credit,
         }
@@ -793,7 +793,7 @@ impl std::convert::From<WalletEntry> for WalletConfig {
             name: wallet.name,
             network: wallet.network,
             mint: wallet.mint,
-            mnemonic: wallet.mnemonic,
+            pub_key: wallet.pub_key,
             debit: wallet.debit,
             credit: wallet.credit,
         }

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -34,7 +34,7 @@ pub struct WalletConfig {
     pub mint: MintUrl,
     pub debit: CurrencyUnit,
     pub credit: Option<CurrencyUnit>,
-    pub mnemonic: bip39::Mnemonic,
+    pub pub_key: secp256k1::PublicKey,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -164,7 +164,7 @@ pub struct Wallet<DebtPck> {
     credit: Box<dyn CreditPocket>,
     name: String,
     id: String,
-    mnemonic: bip39::Mnemonic,
+    pub_key: secp256k1::PublicKey,
     current_payment: Mutex<Option<PayReference>>,
     clowder_id: bitcoin::secp256k1::PublicKey,
     client_factory: Box<dyn Fn(cashu::MintUrl) -> Box<dyn MintConnector> + Send + Sync>,
@@ -185,7 +185,7 @@ impl<DebtPck> Wallet<DebtPck> {
         (debit, credit): (DebtPck, Box<dyn CreditPocket>),
         name: String,
         id: String,
-        mnemonic: bip39::Mnemonic,
+        pub_key: secp256k1::PublicKey,
         beta_clients: HashMap<cashu::MintUrl, Box<dyn MintConnector>>,
         client_factory: Box<dyn Fn(cashu::MintUrl) -> Box<dyn MintConnector> + Send + Sync>,
         safe_mode: SameMintSafeMode,
@@ -199,7 +199,7 @@ impl<DebtPck> Wallet<DebtPck> {
             credit,
             name,
             id,
-            mnemonic,
+            pub_key,
             current_payment: Mutex::new(None),
             beta_clients,
             clowder_id,
@@ -854,7 +854,7 @@ where
             debit: self.debit.unit(),
             credit: self.credit.maybe_unit(),
             mint: self.client.mint_url(),
-            mnemonic: self.mnemonic.clone(),
+            pub_key: self.pub_key,
         })
     }
 


### PR DESCRIPTION
* Removes `mnemonic` from persistence layer
* Calculates public key and checks, if the existing wallet matches with the given mnemonic that way
* Only keeps mnemonic / seed in-memory, it's never stored