### PR TITLE
Implement Mint and Melt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
     * `wallet_reclaim_tx(wallet_id, tx_id)` - reclaims the funds from the given transaction
 * Add `id` to Transaction Response
 * Rename `CashedIn` to `Settled` (breaking DB Change)
+* Removed `wallet_check_pending_melts` - since onchain melts execute immediately
+* Add mint and melt
+    * Add `wallet_prepare_melt` - prepares a melt, returns a payment summary
+    * Add `wallet_melt` - executes the melt, returning a transaction id
+    * Add optional `btc_tx_id` to `Transaction` - the Bitcoin transaction ID (e.g. from a melt operation)
+    * Add optional `quote_id` to `Transaction` - the Mint quote ID (e.g. from a mint operation)
+    * Add `wallet_mint` -  creates a mint request for the given amount, returns a mint summary, with the amount and BTC address to pay to
+    * Add `wallet_check_pending_mints` - checks the open mint requests and attempts to mint them, if they were paid (Also called during the regular job runs)
 
 # 0.7.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ cdk-common = {version = "=0.13.1", default-features = false}
 chrono = {version  = "0.4"}
 ciborium = {version="0.2"}
 futures = {version = "0.3"}
-hex = {version = "0.4"}
 mockall = {version  = "0.13"}
 nostr = {version = "0.43"}
 nostr-sdk = {version = "0.43", features = ["nip59"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["crates/bcr-wallet-core", "crates/bcr-wallet-cli"]
 [workspace.dependencies]
 anyhow = {version = "1"}
 async-trait = {version = "0.1"}
-bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "7f88db960c1d8a8cdacc0340ea36ae61cbf05f8d"}
+bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "ff597168aade1035e644c47d527d69f21b8a4e64"}
 bip39 = {version = "2.1", features = ["rand"]}
 bitcoin = {version = "0.32"}
 borsh = {version = "1"}
@@ -21,6 +21,7 @@ cdk-common = {version = "=0.13.1", default-features = false}
 chrono = {version  = "0.4"}
 ciborium = {version="0.2"}
 futures = {version = "0.3"}
+hex = {version = "0.4"}
 mockall = {version  = "0.13"}
 nostr = {version = "0.43"}
 nostr-sdk = {version = "0.43", features = ["nip59"]}

--- a/crates/bcr-wallet-cli/alice.toml
+++ b/crates/bcr-wallet-cli/alice.toml
@@ -1,10 +1,10 @@
 ## Other mint URLs
 #mint_url = "http://localhost:4343"
 # mint_url = "http://localhost:8080"
-# mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
+mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
 # mint_url = "https://mint.wildcat1.clowder1.minibill.tech"
 
-mint_url = "https://wildcat-dev-docker.minibill.tech"
+# mint_url = "https://wildcat-dev-docker.minibill.tech"
 mnemonic = "royal scheme canoe flame sell jewel valve citizen deal patch stereo walk"
 log_level = "DEBUG"
 db_path = "./alice.db"

--- a/crates/bcr-wallet-cli/bob.toml
+++ b/crates/bcr-wallet-cli/bob.toml
@@ -1,5 +1,5 @@
-mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
-# mint_url = "https://wildcat-dev-docker.minibill.tech"
+# mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
+mint_url = "https://wildcat-dev-docker.minibill.tech"
 mnemonic = "spoil frost juice sketch spirit fine trophy puzzle crater roast holiday payment"
 log_level = "DEBUG"
 db_path = "./bob.db"

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -52,9 +52,15 @@ pub async fn cmd_info(app_state: &AppState) -> Result<String> {
             push_break(&mut res);
 
             for tx in transactions.iter() {
+                let quote_or_btc_tx_id = match (tx.btc_tx_id, &tx.quote_id) {
+                    (Some(_), Some(_)) => String::default(),
+                    (Some(btc_tx_id), None) => btc_tx_id.to_string(),
+                    (None, Some(quote_id)) => quote_id.to_string(),
+                    (None, None) => String::default(),
+                };
                 res.push_str(&format!(
-                    "\t\tId: {} \t Amount: {} {} \t Fees: {}  \t Status: {:?} \t {} \tType: {:<10} \t {:?} \t Memo: {}",
-                    tx.id, tx.amount, tx.unit, tx.fees,  tx.status, format_timestamp(tx.tstamp), &format!("{:?}", tx.ptype), tx.direction,tx.memo
+                    "\t\tId: {} \t Amount: {} {} \t Fees: {}  \t Status: {:?} \t {} \tType: {:<10} \t {:?} \t Memo: {} \t BTC TxID/Quote ID: {}",
+                    tx.id, tx.amount, tx.unit, tx.fees,  tx.status, format_timestamp(tx.tstamp), &format!("{:?}", tx.ptype), tx.direction, tx.memo, quote_or_btc_tx_id 
                 ));
                 push_break(&mut res);
             }
@@ -259,6 +265,58 @@ pub async fn cmd_reclaim(
     res.push_str(&format!(
         "Reclaim Funds for {name}, Tx: {tx_id} - Wallet ID: {id} - Reclaimed: {reclaimed}.\n"
     ));
+    Ok(res)
+}
+
+pub async fn cmd_melt(
+    app_state: &AppState,
+    name: &str,
+    id: usize,
+    amount: u64,
+    address: &str,
+    description: &Option<String>,
+) -> Result<String> {
+    let mut res = String::new();
+    let melt_summary = app_state
+        .wallet_prepare_melt(id, amount, address.to_owned(), description.to_owned())
+        .await?;
+
+    info!(
+        "Melt Summary: Amount: {}, Unit: {}",
+        &melt_summary.amount, &melt_summary.unit
+    );
+
+    let tx_id = app_state
+        .wallet_melt(melt_summary.request_id.to_string())
+        .await?;
+
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!(
+        "Melt for {name}, Amount: {amount}, Address: {address} - Wallet ID: {id}.\n"
+    ));
+    push_break(&mut res);
+    res.push_str(&format!("Transaction ID: {tx_id}"));
+
+    Ok(res)
+}
+
+pub async fn cmd_mint(app_state: &AppState, name: &str, id: usize, amount: u64) -> Result<String> {
+    let mut res = String::new();
+
+    let mint_summary = app_state.wallet_mint(id, amount).await?;
+
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!(
+        "Mint for {name}, Amount: {amount} - Wallet ID: {id}.\n"
+    ));
+    push_break(&mut res);
+    res.push_str(&format!(
+        "Mint Summary - Pay {amount} to address {}",
+        mint_summary.address.assume_checked()
+    ));
+
     Ok(res)
 }
 

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -33,7 +33,6 @@ pub struct WalletSettings {
 struct Cli {
     #[arg(short, long, default_value = "default")]
     wallet: String,
-
     #[command(subcommand)]
     command: Commands,
 }
@@ -72,6 +71,15 @@ enum Commands {
     },
     #[command(name = "reclaim")]
     Reclaim { id: usize, tx_id: String },
+    #[command(name = "melt")]
+    Melt {
+        id: usize,
+        amount: u64,
+        address: String,
+        description: Option<String>,
+    },
+    #[command(name = "mint")]
+    Mint { id: usize, amount: u64 },
     #[command(name = "migrate_rabid")]
     MigrateRabid,
     #[command(name = "run_jobs")]
@@ -225,6 +233,26 @@ async fn main() -> Result<()> {
                 "Reclaim for {}: {}",
                 cli.wallet,
                 command::cmd_reclaim(&app_state, &cli.wallet, id, &tx_id).await?
+            );
+        }
+        Commands::Melt {
+            id,
+            amount,
+            address,
+            description,
+        } => {
+            info!(
+                "Melt for {}: {}",
+                cli.wallet,
+                command::cmd_melt(&app_state, &cli.wallet, id, amount, &address, &description)
+                    .await?
+            );
+        }
+        Commands::Mint { id, amount } => {
+            info!(
+                "Mint for {}: {}",
+                cli.wallet,
+                command::cmd_mint(&app_state, &cli.wallet, id, amount).await?
             );
         }
         Commands::MigrateRabid => {

--- a/crates/bcr-wallet-core/Cargo.toml
+++ b/crates/bcr-wallet-core/Cargo.toml
@@ -20,7 +20,6 @@ cdk = { workspace = true, features = ["wallet"] }
 chrono = {workspace = true}
 ciborium = {workspace = true}
 futures = {workspace = true}
-hex = {workspace=true}
 nostr = {workspace = true}
 nostr-sdk = {workspace = true, features = ["nip06"]}
 rand = {workspace = true}

--- a/crates/bcr-wallet-core/Cargo.toml
+++ b/crates/bcr-wallet-core/Cargo.toml
@@ -20,6 +20,7 @@ cdk = { workspace = true, features = ["wallet"] }
 chrono = {workspace = true}
 ciborium = {workspace = true}
 futures = {workspace = true}
+hex = {workspace=true}
 nostr = {workspace = true}
 nostr-sdk = {workspace = true, features = ["nip06"]}
 rand = {workspace = true}

--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -28,6 +28,8 @@ pub enum Error {
     Cdk10(#[from] cashu::nut10::Error),
     #[error("cashu::amount: {0}")]
     CdkAmount(#[from] cashu::amount::Error),
+    #[error("cashu::dhke: {0}")]
+    CdkDhke(#[from] cashu::dhke::Error),
     #[error("bitcoin::bip32 {0}")]
     BtcBip32(#[from] bitcoin::bip32::Error),
     #[error("uuid:: {0}")]
@@ -82,6 +84,8 @@ pub enum Error {
     EmptyToken(String),
     #[error("invalid token: {0}")]
     InvalidToken(String),
+    #[error("invalid bitcoin address: {0}")]
+    InvalidBitcoinAddress(String),
     #[error("Invalid Hash Lock on Beta Proofs, expected {0} got {1}")]
     InvalidHashLock(Sha256, String),
     #[error("no active keyset")]
@@ -120,6 +124,10 @@ pub enum Error {
     MeltUnpaid(String),
     #[error("melt op not found: {0}")]
     MeltNotFound(String),
+    #[error("mint op not found: {0}")]
+    MintNotFound(String),
+    #[error("mint op failed: {0}")]
+    MintingError(String),
     #[error("inter-mint payment not supported yet")]
     InterMint,
     #[error("spending conditions not supported yet")]

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -1,6 +1,7 @@
 use crate::config::AppStateConfig;
 use crate::job::JobState;
 use crate::mint::MintConnector;
+use crate::types::MintSummary;
 use crate::utils::tx_can_be_refreshed;
 use crate::{
     config::{NostrConfig, SameMintSafeMode},
@@ -355,16 +356,66 @@ impl AppState {
         Ok(CreatedToken { tx_id, token })
     }
 
+    pub async fn wallet_prepare_melt(
+        &self,
+        idx: usize,
+        amount: u64,
+        address: String,
+        description: Option<String>,
+    ) -> Result<PaymentSummary> {
+        tracing::debug!("wallet_prepare_melt({idx}, {amount}, {address}, {description:?})");
+
+        let parsed_amount = bitcoin::Amount::from_sat(amount);
+        let parsed_address = bitcoin::Address::from_str(&address)
+            .map_err(|_| Error::InvalidBitcoinAddress(address.clone()))?;
+
+        if !parsed_address.is_valid_for_network(self.cfg.network) {
+            return Err(Error::InvalidBitcoinAddress(address.clone()));
+        }
+
+        let purse = self.get_purse();
+        let summary = purse
+            .prepare_melt(idx, parsed_amount, parsed_address, description)
+            .await?;
+        Ok(summary)
+    }
+
+    pub async fn wallet_melt(&self, rid: String) -> Result<TransactionId> {
+        let tstamp = chrono::Utc::now().timestamp() as u64;
+        tracing::debug!("wallet_melt({rid}, {tstamp})");
+
+        let purse = self.get_purse();
+        let rid = Uuid::from_str(&rid)?;
+        let tx_id = purse.melt(rid, tstamp).await?;
+        Ok(tx_id)
+    }
+
+    pub async fn wallet_mint(&self, idx: usize, amount: u64) -> Result<MintSummary> {
+        tracing::debug!("wallet_mint({idx}, {amount})");
+
+        let parsed_amount = bitcoin::Amount::from_sat(amount);
+        let purse = self.get_purse();
+        let summary = purse.mint(idx, parsed_amount).await?;
+        Ok(summary)
+    }
+
+    pub async fn wallet_check_pending_mints(&self, idx: usize) -> Result<Vec<TransactionId>> {
+        tracing::debug!("wallet_check_pending_mints({idx})");
+
+        let purse = self.get_purse();
+        let tx_ids = purse.check_pending_mints(idx).await?;
+        Ok(tx_ids)
+    }
+
     pub async fn wallet_prepare_payment(
         &self,
         idx: usize,
         input: String,
     ) -> Result<PaymentSummary> {
-        let now = chrono::Utc::now().timestamp() as u64;
         tracing::debug!("wallet_prepare_payment({idx}, {input})");
 
         let purse = self.get_purse();
-        let summary = purse.prepare_pay(idx, input, now).await?;
+        let summary = purse.prepare_pay(idx, input).await?;
         Ok(summary)
     }
 
@@ -415,13 +466,6 @@ impl AppState {
         let max_wait = core::time::Duration::from_secs(max_wait_sec);
         let tx_id = purse.check_received_payment(max_wait, p_id).await?;
         Ok(tx_id)
-    }
-
-    pub async fn wallet_check_pending_melts(&self, idx: usize) -> Result<cashu::Amount> {
-        tracing::debug!("wallet_check_pending_melts({idx})");
-
-        let wallet = self.get_wallet(idx).await?;
-        wallet.read().await.check_pending_melts().await
     }
 
     pub async fn wallet_list_tx_ids(&self, idx: usize) -> Result<Vec<TransactionId>> {
@@ -554,6 +598,24 @@ impl AppState {
                     );
                 }
             };
+            match self.wallet_check_pending_mints(*wallet_id as usize).await {
+                Ok(result) => {
+                    tracing::info!(
+                        "Received {} transactions from pending mints for wallet {wallet_id}, Tx Ids: {:?}",
+                        result.len(),
+                        result
+                            .iter()
+                            .map(|txid| txid.to_string())
+                            .collect::<Vec<String>>()
+                    );
+                }
+                Err(e) => {
+                    job_failed = true;
+                    tracing::error!(
+                        "Error running wallet_check_pending_mints job for wallet {wallet_id}: {e}"
+                    );
+                }
+            }
         }
 
         // successful = true
@@ -644,7 +706,7 @@ pub enum PaymentType {
     NotApplicable,
     Token,
     Cdk18,
-    Lightning,
+    OnChain,
 }
 
 impl std::convert::From<types::PaymentType> for PaymentType {
@@ -653,7 +715,7 @@ impl std::convert::From<types::PaymentType> for PaymentType {
             types::PaymentType::NotApplicable => PaymentType::NotApplicable,
             types::PaymentType::Token => PaymentType::Token,
             types::PaymentType::Cdk18 => PaymentType::Cdk18,
-            types::PaymentType::Lightning => PaymentType::Lightning,
+            types::PaymentType::OnChain => PaymentType::OnChain,
         }
     }
 }
@@ -689,12 +751,15 @@ pub struct Transaction {
     pub memo: String,
     pub ptype: PaymentType,
     pub status: TransactionStatus,
+    pub btc_tx_id: Option<bitcoin::Txid>,
+    pub quote_id: Option<String>,
 }
 
 impl std::convert::From<cdk::wallet::types::Transaction> for Transaction {
     fn from(tx: cdk::wallet::types::Transaction) -> Self {
         let status = TransactionStatus::from(types::get_transaction_status(&tx.metadata));
         let ptype = PaymentType::from(types::get_payment_type(&tx.metadata));
+        let btc_tx_id = types::get_btc_tx_id(&tx.metadata);
         Self {
             id: tx.id().to_string(),
             amount: u64::from(tx.amount),
@@ -705,6 +770,8 @@ impl std::convert::From<cdk::wallet::types::Transaction> for Transaction {
             memo: tx.memo.unwrap_or_default(),
             ptype,
             status,
+            btc_tx_id,
+            quote_id: tx.quote_id,
         }
     }
 }
@@ -838,13 +905,17 @@ async fn build_wallet(
     Ok(new_wallet)
 }
 
-// converts a mnemonic to a secp256k1 keypair
-fn keypair_from_mnemonic(mnemonic: &bip39::Mnemonic) -> Keypair {
-    let seed = seed_from_mnemonic(mnemonic);
+fn seed_from_mnemonic(mnemonic: &bip39::Mnemonic) -> [u8; 64] {
+    mnemonic.to_seed("")
+}
+
+fn keypair_from_seed(seed: [u8; 64]) -> Keypair {
     let (key, _) = seed.split_at(secp256k1::constants::SECRET_KEY_SIZE);
     Keypair::from_seckey_slice(SECP256K1, key).expect("key to be correct size")
 }
 
-fn seed_from_mnemonic(mnemonic: &bip39::Mnemonic) -> [u8; 64] {
-    mnemonic.to_seed("")
+// converts a mnemonic to a secp256k1 keypair
+fn keypair_from_mnemonic(mnemonic: &bip39::Mnemonic) -> Keypair {
+    let seed = seed_from_mnemonic(mnemonic);
+    keypair_from_seed(seed)
 }

--- a/crates/bcr-wallet-core/src/mint.rs
+++ b/crates/bcr-wallet-core/src/mint.rs
@@ -2,7 +2,7 @@ use crate::{TStamp, error::Result, sync};
 use async_trait::async_trait;
 use bcr_common::wire::{
     clowder::{self as wire_clowder, ConnectedMintsResponse},
-    keys as wire_keys, swap as wire_swap,
+    keys as wire_keys, melt as wire_melt, mint as wire_mint, swap as wire_swap,
 };
 use bitcoin::base64::prelude::*;
 use cashu::Proof;
@@ -61,6 +61,31 @@ pub trait MintConnector: cdk::wallet::MintConnector + sync::SendSync {
         TStamp,
         secp256k1::schnorr::Signature,
     )>;
+
+    async fn post_melt_quote_onchain(
+        &self,
+        req: wire_melt::MeltQuoteOnchainRequest,
+    ) -> Result<wire_melt::MeltQuoteOnchainResponse>;
+
+    async fn post_melt_onchain(
+        &self,
+        req: cashu::MeltRequest<String>,
+    ) -> Result<wire_melt::MeltQuoteOnchainResponse>;
+
+    async fn post_mint_quote_onchain(
+        &self,
+        req: wire_mint::MintQuoteOnchainRequest,
+    ) -> Result<wire_mint::MintQuoteOnchainResponse>;
+
+    async fn get_mint_quote_onchain(
+        &self,
+        quote_id: String,
+    ) -> Result<wire_mint::MintQuoteOnchainResponse>;
+
+    async fn post_mint_onchain(
+        &self,
+        req: cashu::MintRequest<String>,
+    ) -> Result<cashu::MintResponse>;
 }
 
 #[derive(Debug, Clone)]
@@ -443,6 +468,81 @@ impl MintConnector for HttpClientExt {
             payload.expiration,
             response.commitment,
         ))
+    }
+
+    async fn post_melt_quote_onchain(
+        &self,
+        req: wire_melt::MeltQuoteOnchainRequest,
+    ) -> Result<wire_melt::MeltQuoteOnchainResponse> {
+        let url = self
+            .url
+            .join("v1/melt/quote/onchain")
+            .expect("melt_quote_onchain url error");
+        debug!("HTTP call to melt_quote_onchain on {url}");
+
+        let res = self.secondary.post(url).json(&req).send().await?;
+        let response: wire_melt::MeltQuoteOnchainResponse = res.json().await?;
+        Ok(response)
+    }
+
+    async fn post_melt_onchain(
+        &self,
+        req: cashu::MeltRequest<String>,
+    ) -> Result<wire_melt::MeltQuoteOnchainResponse> {
+        let url = self
+            .url
+            .join("v1/melt/onchain")
+            .expect("melt_onchain url error");
+        debug!("HTTP call to melt_onchain on {url}");
+
+        let res = self.secondary.post(url).json(&req).send().await?;
+        let response: wire_melt::MeltQuoteOnchainResponse = res.json().await?;
+        Ok(response)
+    }
+
+    async fn post_mint_quote_onchain(
+        &self,
+        req: wire_mint::MintQuoteOnchainRequest,
+    ) -> Result<wire_mint::MintQuoteOnchainResponse> {
+        let url = self
+            .url
+            .join("v1/mint/quote/onchain")
+            .expect("mint_quote_onchain url error");
+        debug!("HTTP call to mint_quote_onchain on {url}");
+
+        let res = self.secondary.post(url).json(&req).send().await?;
+        let response: wire_mint::MintQuoteOnchainResponse = res.json().await?;
+        Ok(response)
+    }
+
+    async fn get_mint_quote_onchain(
+        &self,
+        quote_id: String,
+    ) -> Result<wire_mint::MintQuoteOnchainResponse> {
+        let url = self
+            .url
+            .join(&format!("v1/mint/quote/onchain/{quote_id}"))
+            .expect("get mint_onchain url error");
+        debug!("HTTP call to get mint_quote_onchain on {url}");
+
+        let res = self.secondary.get(url).send().await?;
+        let response: wire_mint::MintQuoteOnchainResponse = res.json().await?;
+        Ok(response)
+    }
+
+    async fn post_mint_onchain(
+        &self,
+        req: cashu::MintRequest<String>,
+    ) -> Result<cashu::MintResponse> {
+        let url = self
+            .url
+            .join("v1/mint/onchain")
+            .expect("mint_onchain url error");
+        debug!("HTTP call to mint_onchain on {url}");
+
+        let res = self.secondary.post(url).json(&req).send().await?;
+        let response: cashu::MintResponse = res.json().await?;
+        Ok(response)
     }
 }
 
@@ -885,5 +985,80 @@ impl MintConnector for SentinelClient {
             payload.expiration,
             response.commitment,
         ))
+    }
+
+    async fn post_melt_quote_onchain(
+        &self,
+        req: wire_melt::MeltQuoteOnchainRequest,
+    ) -> Result<wire_melt::MeltQuoteOnchainResponse> {
+        let url = self
+            .url
+            .join("v1/melt/quote/onchain")
+            .expect("melt_quote_onchain url error");
+        debug!("HTTP call on sentinel to melt_quote_onchain on {url}");
+
+        let res = self.secondary.post(url).json(&req).send().await?;
+        let response: wire_melt::MeltQuoteOnchainResponse = res.json().await?;
+        Ok(response)
+    }
+
+    async fn post_melt_onchain(
+        &self,
+        req: cashu::MeltRequest<String>,
+    ) -> Result<wire_melt::MeltQuoteOnchainResponse> {
+        let url = self
+            .url
+            .join("v1/melt/onchain")
+            .expect("melt_onchain url error");
+        debug!("HTTP call on sentinel to melt_onchain on {url}");
+
+        let res = self.secondary.post(url).json(&req).send().await?;
+        let response: wire_melt::MeltQuoteOnchainResponse = res.json().await?;
+        Ok(response)
+    }
+
+    async fn post_mint_quote_onchain(
+        &self,
+        req: wire_mint::MintQuoteOnchainRequest,
+    ) -> Result<wire_mint::MintQuoteOnchainResponse> {
+        let url = self
+            .url
+            .join("v1/mint/quote/onchain")
+            .expect("mint_quote_onchain url error");
+        debug!("HTTP call on sentinel to mint_quote_onchain on {url}");
+
+        let res = self.secondary.post(url).json(&req).send().await?;
+        let response: wire_mint::MintQuoteOnchainResponse = res.json().await?;
+        Ok(response)
+    }
+
+    async fn get_mint_quote_onchain(
+        &self,
+        quote_id: String,
+    ) -> Result<wire_mint::MintQuoteOnchainResponse> {
+        let url = self
+            .url
+            .join(&format!("v1/mint/quote/onchain/{quote_id}"))
+            .expect("get mint_onchain url error");
+        debug!("HTTP call on sentinel to get mint_quote_onchain on {url}");
+
+        let res = self.secondary.get(url).send().await?;
+        let response: wire_mint::MintQuoteOnchainResponse = res.json().await?;
+        Ok(response)
+    }
+
+    async fn post_mint_onchain(
+        &self,
+        req: cashu::MintRequest<String>,
+    ) -> Result<cashu::MintResponse> {
+        let url = self
+            .url
+            .join("v1/mint/onchain")
+            .expect("mint_onchain url error");
+        debug!("HTTP call on sentinel to mint_onchain on {url}");
+
+        let res = self.secondary.post(url).json(&req).send().await?;
+        let response: cashu::MintResponse = res.json().await?;
+        Ok(response)
     }
 }

--- a/crates/bcr-wallet-core/src/persistence/mod.rs
+++ b/crates/bcr-wallet-core/src/persistence/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "memory-db")]
-pub mod inmemory;
 pub mod redb;
 use crate::TStamp;
 

--- a/crates/bcr-wallet-core/src/persistence/redb.rs
+++ b/crates/bcr-wallet-core/src/persistence/redb.rs
@@ -5,10 +5,11 @@ use crate::{
     persistence::Commitment,
     pocket::{PocketRepository, debit::MintMeltRepository},
     purse::PurseRepository,
-    types::WalletConfig,
+    types::{MintSummary, WalletConfig},
     wallet::TransactionRepository,
 };
 use async_trait::async_trait;
+use bitcoin::address::NetworkUnchecked;
 use cashu::{
     Amount, CurrencyUnit, MintUrl, nut00 as cdk00, nut01 as cdk01, nut02 as cdk02, nut07 as cdk07,
     nut12 as cdk12, secret::Secret,
@@ -17,6 +18,7 @@ use cdk::wallet::types::{Transaction, TransactionDirection, TransactionId};
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, TableError};
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 use tokio::task::spawn_blocking;
+use uuid::Uuid;
 
 ///////////////////////////////////////////// ProofEntry
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
@@ -1005,23 +1007,65 @@ fn convert_melt_entry_to(entry: MeltEntry) -> (String, Option<cdk00::PreMintSecr
     (quote_id, Some(cdk00::PreMintSecrets { secrets, keyset_id }))
 }
 
+///////////////////////////////////////////// MintEntry
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+struct MintEntry {
+    quote_id: Uuid,
+    amount: bitcoin::Amount,
+    address: bitcoin::Address<NetworkUnchecked>,
+    expiry: u64,
+}
+
+fn convert_mint_entry_from(
+    quote_id: Uuid,
+    amount: bitcoin::Amount,
+    address: bitcoin::Address<NetworkUnchecked>,
+    expiry: u64,
+) -> MintEntry {
+    MintEntry {
+        quote_id,
+        amount,
+        address,
+        expiry,
+    }
+}
+
+fn convert_mint_entry_to(entry: MintEntry) -> MintSummary {
+    MintSummary {
+        quote_id: entry.quote_id,
+        amount: entry.amount,
+        address: entry.address,
+        expiry: entry.expiry,
+    }
+}
+
 ///////////////////////////////////////////// MintMeltDB
 pub struct MintMeltDB {
     db: Arc<Database>,
     melt_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+    mint_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
 }
 
 impl MintMeltDB {
     const MELT_BASE_DB_NAME: &'static str = "melts";
+    const MINT_BASE_DB_NAME: &'static str = "mints";
 
     pub fn new(db: Arc<Database>, unit: &CurrencyUnit) -> Result<Self> {
         // Leak once to get static string, because of dynamically generated table names
         let melt_name: &'static str =
             Box::leak(format!("{unit}_{}", Self::MELT_BASE_DB_NAME).into_boxed_str());
+        let mint_name: &'static str =
+            Box::leak(format!("{unit}_{}", Self::MINT_BASE_DB_NAME).into_boxed_str());
         let melt_table = TableDefinition::new(melt_name);
-        Ok(MintMeltDB { db, melt_table })
+        let mint_table = TableDefinition::new(mint_name);
+        Ok(MintMeltDB {
+            db,
+            melt_table,
+            mint_table,
+        })
     }
 
+    // melt
     fn store_melt_sync(
         db: Arc<Database>,
         melt_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
@@ -1100,10 +1144,90 @@ impl MintMeltDB {
             Err(e) => Err(e.into()),
         }
     }
+
+    // mint
+    fn store_mint_sync(
+        db: Arc<Database>,
+        mint_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        mint: MintEntry,
+    ) -> Result<Uuid> {
+        let write_txn = db.begin_write()?;
+
+        {
+            let mut table = write_txn.open_table(mint_table)?;
+
+            let mut serialized = Vec::new();
+            ciborium::into_writer(&mint, &mut serialized)?;
+            table.insert(mint.quote_id.as_bytes().as_slice(), serialized)?;
+        }
+
+        write_txn.commit()?;
+        Ok(mint.quote_id)
+    }
+
+    fn load_mint_sync(
+        db: Arc<Database>,
+        mint_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        qid: Uuid,
+    ) -> Result<Option<MintEntry>> {
+        let read_txn = db.begin_read()?;
+
+        match read_txn.open_table(mint_table) {
+            Ok(table) => {
+                let entry = table.get(qid.as_bytes().as_slice())?;
+                match entry {
+                    Some(e) => {
+                        let entry: MintEntry = ciborium::from_reader(e.value().as_slice())?;
+                        Ok(Some(entry))
+                    }
+                    None => Ok(None),
+                }
+            }
+            Err(TableError::TableDoesNotExist(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn delete_mint_sync(
+        db: Arc<Database>,
+        mint_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        qid: Uuid,
+    ) -> Result<()> {
+        let write_txn = db.begin_write()?;
+
+        {
+            let mut table = write_txn.open_table(mint_table)?;
+            table.remove(qid.as_bytes().as_slice())?;
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    fn list_mints_sync(
+        db: Arc<Database>,
+        mint_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+    ) -> Result<Vec<Uuid>> {
+        let read_txn = db.begin_read()?;
+
+        match read_txn.open_table(mint_table) {
+            Ok(table) => {
+                let mut res = Vec::new();
+                for (_, v) in table.range::<&[u8]>(..)?.flatten() {
+                    let entry: MintEntry = ciborium::from_reader(v.value().as_slice())?;
+                    res.push(entry.quote_id);
+                }
+                Ok(res)
+            }
+            Err(TableError::TableDoesNotExist(_)) => Ok(vec![]),
+            Err(e) => Err(e.into()),
+        }
+    }
 }
 
 #[async_trait]
 impl MintMeltRepository for MintMeltDB {
+    // melt
     async fn store_melt(
         &self,
         qid: String,
@@ -1135,6 +1259,41 @@ impl MintMeltRepository for MintMeltDB {
         let db_clone = self.db.clone();
         let table = self.melt_table;
         spawn_blocking(move || Self::delete_melt_sync(db_clone, table, qid)).await??;
+        Ok(())
+    }
+    // mint
+    async fn store_mint(
+        &self,
+        quote_id: Uuid,
+        amount: bitcoin::Amount,
+        address: bitcoin::Address<NetworkUnchecked>,
+        expiry: u64,
+    ) -> Result<Uuid> {
+        let db_clone = self.db.clone();
+        let table = self.mint_table;
+        let entry = convert_mint_entry_from(quote_id, amount, address, expiry);
+        spawn_blocking(move || Self::store_mint_sync(db_clone, table, entry)).await?
+    }
+
+    async fn load_mint(&self, qid: Uuid) -> Result<MintSummary> {
+        let db_clone = self.db.clone();
+        let table = self.mint_table;
+        let res = spawn_blocking(move || Self::load_mint_sync(db_clone, table, qid)).await??;
+        let entry = res.ok_or(Error::MintNotFound(qid.clone().to_string()))?;
+        let summary = convert_mint_entry_to(entry);
+        Ok(summary)
+    }
+
+    async fn list_mints(&self) -> Result<Vec<Uuid>> {
+        let db_clone = self.db.clone();
+        let table = self.mint_table;
+        spawn_blocking(move || Self::list_mints_sync(db_clone, table)).await?
+    }
+
+    async fn delete_mint(&self, qid: Uuid) -> Result<()> {
+        let db_clone = self.db.clone();
+        let table = self.mint_table;
+        spawn_blocking(move || Self::delete_mint_sync(db_clone, table, qid)).await??;
         Ok(())
     }
 }

--- a/crates/bcr-wallet-core/src/pocket/debit.rs
+++ b/crates/bcr-wallet-core/src/pocket/debit.rs
@@ -1,17 +1,18 @@
 use crate::{
     MintConnector,
     error::{Error, Result},
+    keypair_from_seed,
     pocket::*,
     restore,
-    types::{MeltSummary, SendSummary},
+    types::{MeltSummary, MintSummary, SendSummary},
     wallet,
 };
 use async_trait::async_trait;
+use bcr_common::wire::{melt as wire_melt, mint as wire_mint};
 use cashu::{
     Amount, CurrencyUnit, KeySet, KeySetInfo, amount::SplitTarget, nut00 as cdk00, nut01 as cdk01,
-    nut05 as cdk05, nut23 as cdk23,
+    nut05 as cdk05,
 };
-use cdk::Error as CdkError;
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
@@ -30,6 +31,7 @@ struct MeltReference {
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait MintMeltRepository: sync::SendSync {
+    // melt
     async fn store_melt(
         &self,
         qid: String,
@@ -38,6 +40,17 @@ pub trait MintMeltRepository: sync::SendSync {
     async fn load_melt(&self, qid: String) -> Result<cdk00::PreMintSecrets>;
     async fn list_melts(&self) -> Result<Vec<String>>;
     async fn delete_melt(&self, qid: String) -> Result<()>;
+    // mint
+    async fn store_mint(
+        &self,
+        quote_id: Uuid,
+        amount: bitcoin::Amount,
+        address: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
+        expiry: u64,
+    ) -> Result<Uuid>;
+    async fn load_mint(&self, qid: Uuid) -> Result<MintSummary>;
+    async fn list_mints(&self) -> Result<Vec<Uuid>>;
+    async fn delete_mint(&self, qid: Uuid) -> Result<()>;
 }
 
 ///////////////////////////////////////////// debit pocket
@@ -66,6 +79,42 @@ impl Pocket {
             current_send: Mutex::new(None),
             current_melt: Mutex::new(None),
         }
+    }
+
+    pub fn generate_blinds(
+        keyset_id: cashu::Id,
+        amount: cashu::Amount,
+    ) -> Result<(
+        Vec<cashu::BlindedMessage>,
+        Vec<cashu::secret::Secret>,
+        Vec<cashu::SecretKey>,
+    )> {
+        let amounts: Vec<cashu::Amount> = amount.split();
+        let mut blinded_messages = Vec::with_capacity(amounts.len());
+        let mut secrets = Vec::with_capacity(amounts.len());
+        let mut rs = Vec::with_capacity(amounts.len());
+
+        for amount in amounts {
+            let blind = Self::generate_blind(keyset_id, amount)?;
+            blinded_messages.push(blind.0);
+            secrets.push(blind.1);
+            rs.push(blind.2);
+        }
+
+        Ok((blinded_messages, secrets, rs))
+    }
+
+    pub fn generate_blind(
+        kid: cashu::Id,
+        amount: cashu::Amount,
+    ) -> Result<(
+        cashu::BlindedMessage,
+        cashu::secret::Secret,
+        cashu::SecretKey,
+    )> {
+        let secret = cashu::secret::Secret::new(hex::encode(rand::random::<[u8; 32]>()));
+        let (b_, r) = cashu::dhke::blind_message(secret.as_bytes(), None)?;
+        Ok((cashu::BlindedMessage::new(amount, kid, b_), secret, r))
     }
 
     fn find_active_keysetid(&self, keysets_info: &[KeySetInfo]) -> Result<cashu::KeySetInfo> {
@@ -167,6 +216,97 @@ impl Pocket {
             }
         }
         Err(Error::InsufficientFunds)
+    }
+
+    async fn check_pending_mint(
+        &self,
+        qid: Uuid,
+        keysets_info: &[KeySetInfo],
+        client: &dyn MintConnector,
+        tstamp: u64,
+        safe_mode: wallet::SafeMode,
+    ) -> Result<Option<(cashu::Amount, Vec<cashu::PublicKey>)>> {
+        let mint_summary = self.mdb.load_mint(qid).await?;
+        let mint_state = client.get_mint_quote_onchain(qid.to_string()).await?;
+
+        match mint_state.state {
+            Some(mint_quote_state) => {
+                match mint_quote_state {
+                    cashu::MintQuoteState::Unpaid => {
+                        tracing::info!("Mint {qid} not paid yet - skipping");
+                        if mint_state.expiry < tstamp {
+                            tracing::info!("Mint request with id {qid} expired - deleting.");
+                            self.mdb.delete_mint(qid).await?;
+                        }
+                        Ok(None)
+                    }
+                    cashu::MintQuoteState::Paid => {
+                        tracing::info!("Mint {qid} paid - attempting to mint..");
+                        let (active_keyset_info, active_keyset) =
+                            self.find_active_keyset(keysets_info, client).await?;
+                        let (blinded_messages, secrets, rs) = Self::generate_blinds(
+                            active_keyset_info.id,
+                            cashu::Amount::from(mint_summary.amount.to_sat()),
+                        )?;
+
+                        let mint_req = cashu::MintRequest {
+                            quote: mint_summary.quote_id.to_string(),
+                            outputs: blinded_messages,
+                            signature: None,
+                        };
+                        match client.post_mint_onchain(mint_req).await {
+                            Ok(mint_response) => {
+                                // create proofs
+                                let blinded_signatures = mint_response.signatures;
+                                let inputs = cashu::dhke::construct_proofs(
+                                    blinded_signatures,
+                                    rs,
+                                    secrets,
+                                    &active_keyset.keys,
+                                )?;
+
+                                let mut proofs: HashMap<cdk01::PublicKey, cdk00::Proof> =
+                                    HashMap::with_capacity(inputs.len());
+                                for input in inputs.into_iter() {
+                                    let y = input.y()?;
+                                    proofs.insert(y, input);
+                                }
+                                let safe_mode_clone = safe_mode.clone();
+
+                                // swap proofs
+                                let (amount, ys) = self
+                                    .digest_proofs(
+                                        client,
+                                        (active_keyset_info, active_keyset),
+                                        proofs,
+                                        safe_mode_clone,
+                                    )
+                                    .await?;
+
+                                // delete local record
+                                self.mdb.delete_mint(qid).await?;
+
+                                tracing::info!("Minted {qid} successfully for {amount}");
+                                Ok(Some((amount, ys)))
+                            }
+                            Err(e) => {
+                                tracing::error!("Couldn't mint quote {qid}: {e}");
+                                Err(Error::MintingError(qid.to_string()))
+                            }
+                        }
+                    }
+                    cashu::MintQuoteState::Issued => {
+                        tracing::warn!("Mint {qid} already issued - deleting");
+                        self.mdb.delete_mint(qid).await?;
+                        Ok(None)
+                    }
+                }
+            }
+            None => {
+                tracing::warn!("Mint {qid} has no state set - skipping");
+                Ok(None)
+            }
+        }
     }
 }
 
@@ -312,49 +452,55 @@ impl wallet::DebitPocket for Pocket {
         Ok(reclaimed)
     }
 
-    async fn prepare_melt(
+    async fn prepare_onchain_melt(
         &self,
-        invoice: cashu::Bolt11Invoice,
+        invoice: wire_melt::OnchainInvoice,
         keysets_info: &[KeySetInfo],
         client: &dyn MintConnector,
     ) -> Result<MeltSummary> {
-        let request = cdk23::MeltQuoteBolt11Request {
+        let secret_key = keypair_from_seed(self.seed).secret_key();
+        let signature = cdk01::SecretKey::from(secret_key).sign(&[])?; // not used currently - sign empty message
+        let request = wire_melt::MeltQuoteOnchainRequest {
             request: invoice,
             unit: self.unit.clone(),
             options: None,
+            signature,
         };
-        let response = client.post_melt_quote(request).await?;
+        let response = client.post_melt_quote_onchain(request).await?;
         let total_amount = response.amount + response.fee_reserve;
-        let (sendsummary, send_ref) = self.compute_send_costs(total_amount, keysets_info).await?;
+        let (sendsummary, send_ref) = self
+            .compute_send_costs(Amount::from(total_amount.to_sat()), keysets_info)
+            .await?;
 
         let mut summary = MeltSummary::new();
         summary.amount = sendsummary.amount;
         summary.fees = sendsummary.send_fees + sendsummary.swap_fees;
-        summary.reserved_fees = response.fee_reserve;
+        summary.reserved_fees = Amount::from(response.fee_reserve.to_sat());
         summary.expiry = response.expiry;
         let melt_ref = MeltReference {
             rid: summary.request_id,
-            mint_quote: response.quote,
+            mint_quote: response.quote.to_string(),
             send_proofs: send_ref.send_proofs,
             swap_proof: send_ref.swap_proof,
-            reserved_fees: response.fee_reserve,
+            reserved_fees: Amount::from(response.fee_reserve.to_sat()),
         };
         self.current_melt.lock().unwrap().replace(melt_ref);
         Ok(summary)
     }
 
-    async fn pay_melt(
+    async fn pay_onchain_melt(
         &self,
         rid: Uuid,
         keysets_info: &[KeySetInfo],
         client: &dyn MintConnector,
         safe_mode: wallet::SafeMode,
-    ) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>> {
+    ) -> Result<(bitcoin::Txid, HashMap<cdk01::PublicKey, cdk00::Proof>)> {
         let melt_ref = self.current_melt.lock().unwrap().take();
         let melt_ref = melt_ref.ok_or(Error::NoPrepareRef(rid))?;
         if melt_ref.rid != rid {
             return Err(Error::NoPrepareRef(rid));
         }
+
         let (info, keyset) = self.find_active_keyset(keysets_info, client).await?;
         let sending_proofs = send_proofs(
             melt_ref.send_proofs,
@@ -366,6 +512,7 @@ impl wallet::DebitPocket for Pocket {
             safe_mode,
         )
         .await?;
+
         let premints = if melt_ref.reserved_fees != Amount::ZERO {
             let counter = self.pdb.counter(info.id).await?;
             let premints = cdk00::PreMintSecrets::from_seed(
@@ -382,85 +529,96 @@ impl wallet::DebitPocket for Pocket {
         } else {
             None
         };
+
         let request = cdk05::MeltRequest::new(
             melt_ref.mint_quote,
             sending_proofs.values().cloned().collect(),
             premints.clone().map(|p| p.blinded_messages()),
         );
-        let response = client.post_melt(request).await?;
-        if matches!(
-            response.state,
-            cdk05::QuoteState::Pending | cdk05::QuoteState::Unpaid | cdk05::QuoteState::Unknown
-        ) {
-            tracing::warn!("DbPocket::pay_melt: melt not paid yet, storing quote");
-            self.mdb
-                .store_melt(response.quote.clone(), premints)
-                .await?;
-            return Err(Error::MeltUnpaid(response.quote));
+        let response = client.post_melt_onchain(request).await?;
+
+        if !matches!(response.state, cdk05::QuoteState::Paid) {
+            return Err(Error::MeltUnpaid(response.quote.to_string()));
         }
+
+        let Some(tx_id) = response.txid else {
+            tracing::warn!("DbPocket::pay_melt: did not receive btc transaction id");
+            return Err(Error::MeltUnpaid(response.quote.to_string()));
+        };
+
         if let Some(premints) = premints {
             let change = unblind_proofs(&keyset, response.change.unwrap_or(Vec::new()), premints);
             for proof in change {
                 self.pdb.store_new(proof).await?;
             }
         }
-        Ok(sending_proofs)
+        Ok((tx_id, sending_proofs))
     }
 
-    async fn check_pending_melts(&self, client: &dyn MintConnector) -> Result<Amount> {
-        let mut recouped = Amount::ZERO;
-        let melt_ids = self.mdb.list_melts().await?;
-        for mid in melt_ids {
-            let response = client.get_melt_quote_status(&mid).await;
-            match response {
-                Err(CdkError::UnknownQuote) | Err(CdkError::ExpiredQuote(..)) => {
-                    tracing::warn!("DbPocket::check_pending_melts: removing quote {mid}");
-                    self.mdb.delete_melt(mid).await?;
+    async fn mint_onchain(
+        &self,
+        amount: bitcoin::Amount,
+        client: &dyn MintConnector,
+    ) -> Result<MintSummary> {
+        let request = wire_mint::MintQuoteOnchainRequest {
+            amount,
+            unit: self.unit.clone(),
+        };
+
+        // Request mint quote
+        let response = client.post_mint_quote_onchain(request).await?;
+        let mint_summary = MintSummary {
+            quote_id: response.quote,
+            amount: response.amount,
+            address: response.address,
+            expiry: response.expiry,
+        };
+
+        // Store mint quote
+        self.mdb
+            .store_mint(
+                mint_summary.quote_id,
+                mint_summary.amount,
+                mint_summary.address.clone(),
+                mint_summary.expiry,
+            )
+            .await?;
+        Ok(mint_summary)
+    }
+
+    async fn check_pending_mints(
+        &self,
+        keysets_info: &[KeySetInfo],
+        client: &dyn MintConnector,
+        tstamp: u64,
+        safe_mode: wallet::SafeMode,
+    ) -> Result<HashMap<Uuid, (cashu::Amount, Vec<cashu::PublicKey>)>> {
+        let mint_ids = self.mdb.list_mints().await?;
+        let mut res = HashMap::with_capacity(mint_ids.len());
+
+        tracing::debug!("check pending mints for {} mints", mint_ids.len());
+        for qid in mint_ids {
+            match self
+                .check_pending_mint(qid, keysets_info, client, tstamp, safe_mode.clone())
+                .await
+            {
+                Ok(Some(mint_res)) => {
+                    res.insert(qid, mint_res);
                 }
-                Ok(cdk23::MeltQuoteBolt11Response {
-                    state: cdk05::QuoteState::Paid,
-                    change: Some(signatures),
-                    ..
-                }) => {
-                    let premints = self.mdb.load_melt(mid.clone()).await?;
-                    let keyset = client.get_mint_keyset(premints.keyset_id).await?;
-                    let proofs = unblind_proofs(&keyset, signatures, premints);
-                    for proof in proofs {
-                        let amount = proof.amount;
-                        match self.pdb.store_new(proof).await {
-                            Ok(_) => {
-                                recouped += amount;
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    "DbPocket::check_pending_melts: error storing proof {mid}: {e}"
-                                );
-                            }
-                        }
-                    }
-                    self.mdb.delete_melt(mid).await?;
-                }
-                Ok(cdk23::MeltQuoteBolt11Response {
-                    state: cdk05::QuoteState::Failed,
-                    ..
-                }) => {
-                    tracing::warn!("DbPocket::check_pending_melts: removing failed quote {mid}");
-                    self.mdb.delete_melt(mid).await?;
-                }
-                Ok(cdk23::MeltQuoteBolt11Response { state, .. }) => {
-                    tracing::warn!("DbPocket::check_pending_melts: quote {mid} still {state}");
-                }
+                Ok(None) => {} // nop
                 Err(e) => {
-                    tracing::warn!("DbPocket::check_pending_melts: unexpected err: {e}");
+                    tracing::error!("Error while checking pending mint for {qid}: {e}");
                 }
-            }
+            };
         }
-        Ok(recouped)
+        Ok(res)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use crate::{
         utils::tests::MockMintConnector,
@@ -471,7 +629,8 @@ mod tests {
 
     fn pocket(pdb: Arc<dyn PocketRepository>, mdb: Arc<dyn MintMeltRepository>) -> super::Pocket {
         let unit = CurrencyUnit::Sat;
-        let seed = [0u8; 64];
+        let mnemonic = bip39::Mnemonic::generate(12).unwrap();
+        let seed = mnemonic.to_seed("");
         super::Pocket::new(unit, pdb, mdb, seed)
     }
 
@@ -588,5 +747,206 @@ mod tests {
             .await
             .expect("reclaim works");
         assert_eq!(reclaimed, Amount::from(24u64));
+    }
+
+    #[tokio::test]
+    async fn prepare_onchain_melt() {
+        let (info, keyset) = core_tests::generate_random_ecash_keyset();
+        let k_infos = vec![KeySetInfo::from(info)];
+        let amounts = [Amount::from(8u64), Amount::from(16u64)];
+        let proofs = core_tests::generate_random_ecash_proofs(&keyset, &amounts);
+        let proofs_map: HashMap<cdk01::PublicKey, cdk00::Proof> =
+            HashMap::from_iter(proofs.into_iter().map(|p| {
+                let y = p.y().expect("Hash to curve should not fail");
+                (y, p)
+            }));
+
+        let amount = bitcoin::Amount::from_sat(24);
+
+        let mdb = MockMintMeltRepository::new();
+        let mut pdb = MockPocketRepository::new();
+        let mut connector = MockMintConnector::new();
+
+        pdb.expect_list_unspent()
+            .times(1)
+            .returning(move || Ok(proofs_map.clone()));
+
+        connector
+            .expect_post_melt_quote_onchain()
+            .times(1)
+            .returning(move |_| {
+                Ok(wire_melt::MeltQuoteOnchainResponse {
+                    quote: Uuid::new_v4(),
+                    txid: None,
+                    fee_reserve: bitcoin::Amount::ZERO,
+                    amount,
+                    state: cashu::MeltQuoteState::Pending,
+                    expiry: chrono::Utc::now().timestamp() as u64,
+                    unit: Some(CurrencyUnit::Sat),
+                    change: None,
+                })
+            });
+
+        let invoice = wire_melt::OnchainInvoice {
+            amount,
+            address: bitcoin::Address::from_str("tb1qteyk7pfvvql2r2zrsu4h4xpvju0nz7ykvguyk0")
+                .unwrap(),
+        };
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+
+        let summary = pocket
+            .prepare_onchain_melt(invoice, &k_infos, &connector)
+            .await
+            .expect("prepare melt works");
+        assert_eq!(summary.amount, Amount::from(amount.to_sat()));
+    }
+
+    #[tokio::test]
+    async fn pay_onchain_melt() {
+        let uuid = Uuid::new_v4();
+        let tx_id = bitcoin::Txid::from_str(
+            "c66bdb3be47c2252cf60bf98da828c595592b91637e4bab88471a7eb76e81562",
+        )
+        .unwrap();
+        let (info, keyset) = core_tests::generate_random_ecash_keyset();
+        let kid = info.id;
+        let k_infos = vec![KeySetInfo::from(info)];
+        let amount = bitcoin::Amount::from_sat(24);
+
+        let mdb = MockMintMeltRepository::new();
+        let pdb = MockPocketRepository::new();
+        let mut connector = MockMintConnector::new();
+
+        let cloned_keyset = keyset.clone();
+        connector
+            .expect_get_mint_keyset()
+            .times(1)
+            .with(eq(kid))
+            .returning(move |_| Ok(KeySet::from(cloned_keyset.clone())));
+
+        connector
+            .expect_post_melt_onchain()
+            .times(1)
+            .returning(move |_| {
+                Ok(wire_melt::MeltQuoteOnchainResponse {
+                    quote: uuid,
+                    txid: Some(tx_id),
+                    fee_reserve: bitcoin::Amount::ZERO,
+                    amount,
+                    state: cashu::MeltQuoteState::Paid,
+                    expiry: chrono::Utc::now().timestamp() as u64,
+                    unit: Some(CurrencyUnit::Sat),
+                    change: None,
+                })
+            });
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+        let melt_ref = MeltReference {
+            rid: uuid,
+            mint_quote: uuid.to_string(),
+            send_proofs: vec![],
+            swap_proof: None,
+            reserved_fees: Amount::ZERO,
+        };
+        pocket.current_melt.lock().unwrap().replace(melt_ref);
+
+        let res = pocket
+            .pay_onchain_melt(uuid, &k_infos, &connector, wallet::SafeMode::Disabled)
+            .await
+            .expect("pay melt works");
+        assert_eq!(res.0, tx_id);
+    }
+
+    #[tokio::test]
+    async fn mint_onchain() {
+        let amount = bitcoin::Amount::from_sat(24);
+
+        let mut mdb = MockMintMeltRepository::new();
+        let pdb = MockPocketRepository::new();
+        let mut connector = MockMintConnector::new();
+
+        mdb.expect_store_mint()
+            .times(1)
+            .returning(|_, _, _, _| Ok(Uuid::new_v4()));
+
+        connector
+            .expect_post_mint_quote_onchain()
+            .times(1)
+            .returning(move |_| {
+                Ok(wire_mint::MintQuoteOnchainResponse {
+                    quote: Uuid::new_v4(),
+                    address: bitcoin::Address::from_str(
+                        "tb1qteyk7pfvvql2r2zrsu4h4xpvju0nz7ykvguyk0",
+                    )
+                    .unwrap(),
+                    amount,
+                    expiry: chrono::Utc::now().timestamp() as u64,
+                    state: Some(cashu::MintQuoteState::Unpaid),
+                })
+            });
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+
+        let summary = pocket
+            .mint_onchain(amount, &connector)
+            .await
+            .expect("mint onchain works");
+        assert_eq!(summary.amount, amount);
+    }
+
+    #[tokio::test]
+    async fn check_pending_mints() {
+        let uuid = Uuid::new_v4();
+        let amount = bitcoin::Amount::from_sat(24);
+        let (info, _) = core_tests::generate_random_ecash_keyset();
+        let k_infos = vec![KeySetInfo::from(info)];
+
+        let mut mdb = MockMintMeltRepository::new();
+        let pdb = MockPocketRepository::new();
+        let mut connector = MockMintConnector::new();
+
+        mdb.expect_list_mints()
+            .times(1)
+            .returning(move || Ok(vec![uuid]));
+
+        mdb.expect_load_mint().times(1).returning(move |_| {
+            Ok(MintSummary {
+                quote_id: uuid,
+                amount,
+                address: bitcoin::Address::from_str("tb1qteyk7pfvvql2r2zrsu4h4xpvju0nz7ykvguyk0")
+                    .unwrap(),
+                expiry: chrono::Utc::now().timestamp() as u64,
+            })
+        });
+
+        connector
+            .expect_get_mint_quote_onchain()
+            .times(1)
+            .returning(move |_| {
+                Ok(wire_mint::MintQuoteOnchainResponse {
+                    quote: uuid,
+                    address: bitcoin::Address::from_str(
+                        "tb1qteyk7pfvvql2r2zrsu4h4xpvju0nz7ykvguyk0",
+                    )
+                    .unwrap(),
+                    amount,
+                    expiry: chrono::Utc::now().timestamp() as u64,
+                    state: Some(cashu::MintQuoteState::Unpaid),
+                })
+            });
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+
+        let res = pocket
+            .check_pending_mints(
+                &k_infos,
+                &connector,
+                chrono::Utc::now().timestamp() as u64,
+                wallet::SafeMode::Disabled,
+            )
+            .await
+            .expect("check pending mint works");
+        assert_eq!(res.len(), 0);
     }
 }

--- a/crates/bcr-wallet-core/src/pocket/debit.rs
+++ b/crates/bcr-wallet-core/src/pocket/debit.rs
@@ -81,42 +81,6 @@ impl Pocket {
         }
     }
 
-    pub fn generate_blinds(
-        keyset_id: cashu::Id,
-        amount: cashu::Amount,
-    ) -> Result<(
-        Vec<cashu::BlindedMessage>,
-        Vec<cashu::secret::Secret>,
-        Vec<cashu::SecretKey>,
-    )> {
-        let amounts: Vec<cashu::Amount> = amount.split();
-        let mut blinded_messages = Vec::with_capacity(amounts.len());
-        let mut secrets = Vec::with_capacity(amounts.len());
-        let mut rs = Vec::with_capacity(amounts.len());
-
-        for amount in amounts {
-            let blind = Self::generate_blind(keyset_id, amount)?;
-            blinded_messages.push(blind.0);
-            secrets.push(blind.1);
-            rs.push(blind.2);
-        }
-
-        Ok((blinded_messages, secrets, rs))
-    }
-
-    pub fn generate_blind(
-        kid: cashu::Id,
-        amount: cashu::Amount,
-    ) -> Result<(
-        cashu::BlindedMessage,
-        cashu::secret::Secret,
-        cashu::SecretKey,
-    )> {
-        let secret = cashu::secret::Secret::new(hex::encode(rand::random::<[u8; 32]>()));
-        let (b_, r) = cashu::dhke::blind_message(secret.as_bytes(), None)?;
-        Ok((cashu::BlindedMessage::new(amount, kid, b_), secret, r))
-    }
-
     fn find_active_keysetid(&self, keysets_info: &[KeySetInfo]) -> Result<cashu::KeySetInfo> {
         let active_info = keysets_info
             .iter()
@@ -244,14 +208,22 @@ impl Pocket {
                         tracing::info!("Mint {qid} paid - attempting to mint..");
                         let (active_keyset_info, active_keyset) =
                             self.find_active_keyset(keysets_info, client).await?;
-                        let (blinded_messages, secrets, rs) = Self::generate_blinds(
-                            active_keyset_info.id,
+                        let kid = active_keyset.id;
+
+                        let counter = self.pdb.counter(kid).await?;
+                        let premint = cashu::PreMintSecrets::from_seed(
+                            kid,
+                            counter,
+                            &self.seed,
                             cashu::Amount::from(mint_summary.amount.to_sat()),
+                            &SplitTarget::None,
                         )?;
+                        let increment = premint.len() as u32;
+                        self.pdb.increment_counter(kid, counter, increment).await?;
 
                         let mint_req = cashu::MintRequest {
                             quote: mint_summary.quote_id.to_string(),
-                            outputs: blinded_messages,
+                            outputs: premint.blinded_messages(),
                             signature: None,
                         };
                         match client.post_mint_onchain(mint_req).await {
@@ -260,8 +232,8 @@ impl Pocket {
                                 let blinded_signatures = mint_response.signatures;
                                 let inputs = cashu::dhke::construct_proofs(
                                     blinded_signatures,
-                                    rs,
-                                    secrets,
+                                    premint.rs(),
+                                    premint.secrets(),
                                     &active_keyset.keys,
                                 )?;
 

--- a/crates/bcr-wallet-core/src/purse.rs
+++ b/crates/bcr-wallet-core/src/purse.rs
@@ -4,8 +4,8 @@ use crate::{
     persistence::redb::PurseDB,
     sync,
     types::{
-        self, PAYMENT_TYPE_METADATA_KEY, PaymentSummary, TRANSACTION_STATUS_METADATA_KEY,
-        WalletConfig,
+        self, MintSummary, PAYMENT_TYPE_METADATA_KEY, PaymentSummary,
+        TRANSACTION_STATUS_METADATA_KEY, WalletConfig,
     },
 };
 use async_trait::async_trait;
@@ -41,7 +41,14 @@ pub trait Wallet: sync::SendSync {
     #[allow(dead_code)]
     fn clowder_id(&self) -> bitcoin::secp256k1::PublicKey;
     fn mint_urls(&self) -> Result<Vec<MintUrl>>;
-    async fn prepare_pay(&self, input: String, now: u64) -> Result<PaymentSummary>;
+    async fn prepare_melt(
+        &self,
+        amount: bitcoin::Amount,
+        address: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
+        description: Option<String>,
+    ) -> Result<PaymentSummary>;
+
+    async fn prepare_pay(&self, input: String) -> Result<PaymentSummary>;
     async fn is_wallet_mint_rabid(&self) -> Result<bool>;
     async fn mint_substitute(&self) -> Result<Option<MintUrl>>;
     async fn pay(
@@ -51,6 +58,9 @@ pub trait Wallet: sync::SendSync {
         http_cl: &reqwest::Client,
         tstamp: u64,
     ) -> Result<(TransactionId, Option<Token>)>;
+
+    async fn mint(&self, amount: bitcoin::Amount) -> Result<MintSummary>;
+    async fn check_pending_mints(&self) -> Result<Vec<TransactionId>>;
 
     async fn migrate_pockets_substitute(
         &mut self,
@@ -154,11 +164,59 @@ where
         Ok(())
     }
 
-    pub async fn prepare_pay(&self, idx: usize, input: String, now: u64) -> Result<PaymentSummary> {
+    pub async fn prepare_melt(
+        &self,
+        idx: usize,
+        amount: bitcoin::Amount,
+        address: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
+        description: Option<String>,
+    ) -> Result<PaymentSummary> {
         let Some(wlt) = self.get_wallet(idx).await else {
             return Err(Error::WalletNotFound(idx));
         };
-        let summary = wlt.read().await.prepare_pay(input, now).await?;
+        let summary = wlt
+            .read()
+            .await
+            .prepare_melt(amount, address, description)
+            .await?;
+        let pref = PaymentReference {
+            payment_ref: summary.request_id,
+            wallet_idx: idx,
+        };
+        *self.current_payment.lock().await = Some(pref);
+        Ok(summary)
+    }
+
+    pub async fn melt(&self, p_id: Uuid, tstamp: u64) -> Result<TransactionId> {
+        let p_ref = self.current_payment.lock().await.take();
+        let Some(pref) = p_ref else {
+            tracing::error!("No current payment reference found");
+            return Err(Error::NoPrepareRef(p_id));
+        };
+        if pref.payment_ref != p_id {
+            tracing::error!(
+                "Payment reference ID mismatch: expected {}, got {}",
+                pref.payment_ref,
+                p_id
+            );
+            return Err(Error::NoPrepareRef(p_id));
+        }
+        let Some(wlt) = self.get_wallet(pref.wallet_idx).await else {
+            return Err(Error::Internal(String::from("Wallet not found for melt")));
+        };
+        let (txid, _) = wlt
+            .read()
+            .await
+            .pay(p_id, &self.nostr_cl, &self.http_cl, tstamp)
+            .await?;
+        Ok(txid)
+    }
+
+    pub async fn prepare_pay(&self, idx: usize, input: String) -> Result<PaymentSummary> {
+        let Some(wlt) = self.get_wallet(idx).await else {
+            return Err(Error::WalletNotFound(idx));
+        };
+        let summary = wlt.read().await.prepare_pay(input).await?;
         let pref = PaymentReference {
             payment_ref: summary.request_id,
             wallet_idx: idx,
@@ -192,6 +250,22 @@ where
             .pay(p_id, &self.nostr_cl, &self.http_cl, tstamp)
             .await?;
         Ok(txid)
+    }
+
+    pub async fn mint(&self, idx: usize, amount: bitcoin::Amount) -> Result<MintSummary> {
+        let Some(wlt) = self.get_wallet(idx).await else {
+            return Err(Error::WalletNotFound(idx));
+        };
+        let summary = wlt.read().await.mint(amount).await?;
+        Ok(summary)
+    }
+
+    pub async fn check_pending_mints(&self, idx: usize) -> Result<Vec<TransactionId>> {
+        let Some(wlt) = self.get_wallet(idx).await else {
+            return Err(Error::WalletNotFound(idx));
+        };
+        let tx_ids = wlt.read().await.check_pending_mints().await?;
+        Ok(tx_ids)
     }
 
     pub async fn prepare_payment_request(

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -1,3 +1,4 @@
+use bitcoin::address::NetworkUnchecked;
 use cashu::{Amount, CurrencyUnit, MintUrl};
 use std::{collections::HashMap, str::FromStr};
 use uuid::Uuid;
@@ -56,12 +57,20 @@ impl MeltSummary {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct MintSummary {
+    pub quote_id: Uuid,
+    pub amount: bitcoin::Amount,
+    pub address: bitcoin::Address<NetworkUnchecked>,
+    pub expiry: u64,
+}
+
 #[derive(strum::EnumString, strum::Display, Debug, Clone)]
 pub enum PaymentType {
     NotApplicable,
     Token,
     Cdk18,
-    Lightning,
+    OnChain,
 }
 
 #[derive(Debug, Clone)]
@@ -99,6 +108,12 @@ pub fn get_payment_type(metas: &HashMap<String, String>) -> PaymentType {
     PaymentType::from_str(ptype).unwrap_or(PaymentType::NotApplicable)
 }
 
+pub const BTC_TX_ID_TYPE_METADATA_KEY: &str = "btc_tx_id";
+pub fn get_btc_tx_id(metas: &HashMap<String, String>) -> Option<bitcoin::Txid> {
+    let tx_id = metas.get(BTC_TX_ID_TYPE_METADATA_KEY)?;
+    bitcoin::Txid::from_str(tx_id).ok()
+}
+
 impl std::convert::From<SendSummary> for PaymentSummary {
     fn from(value: SendSummary) -> Self {
         Self {
@@ -122,7 +137,7 @@ impl std::convert::From<MeltSummary> for PaymentSummary {
             fees: value.fees,
             reserved_fees: value.reserved_fees,
             expiry: value.expiry,
-            ptype: PaymentType::Lightning,
+            ptype: PaymentType::OnChain,
         }
     }
 }

--- a/crates/bcr-wallet-core/src/utils.rs
+++ b/crates/bcr-wallet-core/src/utils.rs
@@ -90,7 +90,7 @@ pub mod tests {
     use crate::TStamp;
     use crate::error::Result;
     use async_trait::async_trait;
-    use bcr_common::wire::keys as wire_keys;
+    use bcr_common::wire::{keys as wire_keys, melt as wire_melt, mint as wire_mint};
     use cashu::{
         nut02 as cdk02, nut03 as cdk03, nut04 as cdk04, nut05 as cdk05, nut06 as cdk06,
         nut07 as cdk07, nut09 as cdk09, nut23 as cdk23,
@@ -204,6 +204,28 @@ pub mod tests {
             TStamp,
             secp256k1::schnorr::Signature,
         )>;
+        async fn post_melt_quote_onchain(
+            &self,
+            req: wire_melt::MeltQuoteOnchainRequest,
+        ) -> Result<wire_melt::MeltQuoteOnchainResponse>;
+        async fn post_melt_onchain(
+            &self,
+            req: cashu::MeltRequest<String>,
+        ) -> Result<wire_melt::MeltQuoteOnchainResponse>;
+        async fn post_mint_quote_onchain(
+            &self,
+            req: wire_mint::MintQuoteOnchainRequest,
+        ) -> Result<wire_mint::MintQuoteOnchainResponse>;
+
+        async fn get_mint_quote_onchain(
+            &self,
+            quote_id: String,
+        ) -> Result<wire_mint::MintQuoteOnchainResponse>;
+
+        async fn post_mint_onchain(
+            &self,
+            req: cashu::MintRequest<String>,
+        ) -> Result<cashu::MintResponse>;
         }
     }
 }

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -5,21 +5,23 @@ use crate::{
     purse::{self},
     sync,
     types::{
-        self, MeltSummary, PAYMENT_TYPE_METADATA_KEY, PaymentSummary, RedemptionSummary,
-        SendSummary, TRANSACTION_STATUS_METADATA_KEY, WalletConfig,
+        self, BTC_TX_ID_TYPE_METADATA_KEY, MeltSummary, MintSummary, PAYMENT_TYPE_METADATA_KEY,
+        PaymentSummary, RedemptionSummary, SendSummary, TRANSACTION_STATUS_METADATA_KEY,
+        WalletConfig,
     },
     utils::tx_can_be_refreshed,
 };
 use async_trait::async_trait;
 use bcr_common::wallet::Token;
-use bcr_common::wire::{clowder as wire_clowder, keys as wire_keys};
+use bcr_common::wire::{clowder as wire_clowder, keys as wire_keys, melt as wire_melt};
 use bitcoin::hashes::{Hash, sha256::Hash as Sha256};
-use cashu::{Amount, Bolt11Invoice, CurrencyUnit, KeySetInfo, MintUrl, Proof};
+use cashu::{Amount, CurrencyUnit, KeySetInfo, MintUrl, Proof};
 use cdk::wallet::types::{Transaction, TransactionDirection, TransactionId};
 use nostr_sdk::nips::nip19::{FromBech32, Nip19Profile};
 use std::{collections::HashMap, str::FromStr, sync::Mutex};
 use uuid::Uuid;
 
+#[derive(Debug, Clone)]
 pub enum SafeMode {
     Disabled,
     Enabled {
@@ -106,20 +108,31 @@ pub trait DebitPocket: Pocket {
         client: &dyn MintConnector,
         safe_mode: SafeMode,
     ) -> Result<Amount>;
-    async fn prepare_melt(
+    async fn prepare_onchain_melt(
         &self,
-        invoice: Bolt11Invoice,
+        invoice: wire_melt::OnchainInvoice,
         keysets_info: &[KeySetInfo],
         client: &dyn MintConnector,
     ) -> Result<MeltSummary>;
-    async fn pay_melt(
+    async fn pay_onchain_melt(
         &self,
         rid: Uuid,
         keysets_info: &[KeySetInfo],
         client: &dyn MintConnector,
         safe_mode: SafeMode,
-    ) -> Result<HashMap<cashu::PublicKey, cashu::Proof>>;
-    async fn check_pending_melts(&self, client: &dyn MintConnector) -> Result<Amount>;
+    ) -> Result<(bitcoin::Txid, HashMap<cashu::PublicKey, cashu::Proof>)>;
+    async fn mint_onchain(
+        &self,
+        amount: bitcoin::Amount,
+        client: &dyn MintConnector,
+    ) -> Result<MintSummary>;
+    async fn check_pending_mints(
+        &self,
+        keysets_info: &[KeySetInfo],
+        client: &dyn MintConnector,
+        tstamp: u64,
+        safe_mode: SafeMode,
+    ) -> Result<HashMap<Uuid, (cashu::Amount, Vec<cashu::PublicKey>)>>;
 }
 
 #[async_trait]
@@ -149,7 +162,7 @@ pub enum PaymentType {
         transport: cashu::Transport,
         id: Option<String>,
     },
-    Bolt11,
+    OnChain,
     Token,
 }
 
@@ -292,20 +305,6 @@ where
         }
     }
 
-    fn check_bolt11_invoice(&self, invoice: &Bolt11Invoice, now: u64) -> Result<()> {
-        if invoice.network() != self.network {
-            return Err(Error::InvalidNetwork(self.network, invoice.network()));
-        }
-        let now = std::time::Duration::from_secs(now);
-        if now > invoice.duration_since_epoch() + invoice.expiry_time() {
-            return Err(Error::PaymentExpired);
-        }
-        if invoice.amount_milli_satoshis().is_none() {
-            return Err(Error::MissingAmount);
-        };
-        Ok(())
-    }
-
     pub async fn clean_local_db(&self) -> Result<u32> {
         let credit_ys = self.credit.clean_local_proofs(self.client.as_ref()).await?;
         let debit_ys = self.debit.clean_local_proofs(self.client.as_ref()).await?;
@@ -357,10 +356,6 @@ where
         debit?;
         credit?;
         Ok(())
-    }
-
-    pub async fn check_pending_melts(&self) -> Result<Amount> {
-        self.debit.check_pending_melts(self.client.as_ref()).await
     }
 
     pub async fn load_tx(&self, tx_id: TransactionId) -> Result<Transaction> {
@@ -967,7 +962,33 @@ where
         Ok(self.client.mint_url())
     }
 
-    async fn prepare_pay(&self, input: String, now: u64) -> Result<PaymentSummary> {
+    async fn prepare_melt(
+        &self,
+        amount: bitcoin::Amount,
+        address: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
+        description: Option<String>,
+    ) -> Result<PaymentSummary> {
+        let infos = self.client.get_mint_keysets().await?.keysets;
+
+        let invoice = wire_melt::OnchainInvoice { address, amount };
+
+        let m_summary = self
+            .debit
+            .prepare_onchain_melt(invoice.clone(), &infos, self.client.as_ref())
+            .await?;
+        let summary = PaymentSummary::from(m_summary);
+        let pref = PayReference {
+            request_id: summary.request_id,
+            unit: summary.unit.clone(),
+            fees: summary.fees,
+            ptype: PaymentType::OnChain,
+            memo: description,
+        };
+        *self.current_payment.lock().unwrap() = Some(pref);
+        Ok(summary)
+    }
+
+    async fn prepare_pay(&self, input: String) -> Result<PaymentSummary> {
         let infos = self.client.get_mint_keysets().await?.keysets;
 
         if let Ok(request) = cashu::PaymentRequest::from_str(&input) {
@@ -990,22 +1011,6 @@ where
                     id: request.payment_id,
                 },
                 memo: request.description,
-            };
-            *self.current_payment.lock().unwrap() = Some(pref);
-            Ok(summary)
-        } else if let Ok(invoice) = Bolt11Invoice::from_str(&input) {
-            self.check_bolt11_invoice(&invoice, now)?;
-            let m_summary = self
-                .debit
-                .prepare_melt(invoice.clone(), &infos, self.client.as_ref())
-                .await?;
-            let summary = PaymentSummary::from(m_summary);
-            let pref = PayReference {
-                request_id: summary.request_id,
-                unit: summary.unit.clone(),
-                fees: summary.fees,
-                ptype: PaymentType::Bolt11,
-                memo: Some(invoice.description().to_string()),
             };
             *self.current_payment.lock().unwrap() = Some(pref);
             Ok(summary)
@@ -1098,46 +1103,6 @@ where
                     .await?;
                 Ok((tx_id, None))
             }
-            PaymentType::Bolt11 => {
-                let proofs = self
-                    .debit
-                    .pay_melt(
-                        request_id,
-                        &infos,
-                        self.client.as_ref(),
-                        SafeMode::new(self.safe_mode, self.clowder_id),
-                    )
-                    .await?;
-                let (ys, proofs): (Vec<cashu::PublicKey>, Vec<cashu::Proof>) =
-                    proofs.into_iter().unzip();
-                let amount = proofs
-                    .iter()
-                    .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
-                let mut metadata = HashMap::default();
-                metadata.insert(
-                    PAYMENT_TYPE_METADATA_KEY.to_owned(),
-                    types::PaymentType::Lightning.to_string(),
-                );
-                metadata.insert(
-                    TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-                    types::TransactionStatus::Pending.to_string(),
-                );
-
-                let partial_tx = Transaction {
-                    mint_url: self.client.mint_url(),
-                    fee: fees,
-                    direction: TransactionDirection::Outgoing,
-                    memo,
-                    timestamp: now,
-                    unit: unit.clone(),
-                    ys,
-                    amount,
-                    metadata,
-                    quote_id: None,
-                };
-                let tx_id = self.tx_repo.store_tx(partial_tx).await?;
-                Ok((tx_id, None))
-            }
             PaymentType::Token => {
                 let (proofs, token) = if unit == self.credit.unit() {
                     let p = self
@@ -1210,7 +1175,103 @@ where
                 let tx_id = self.tx_repo.store_tx(partial_tx).await?;
                 Ok((tx_id, Some(token)))
             }
+            PaymentType::OnChain => {
+                let (btc_tx_id, proofs) = self
+                    .debit
+                    .pay_onchain_melt(
+                        request_id,
+                        &infos,
+                        self.client.as_ref(),
+                        SafeMode::new(self.safe_mode, self.clowder_id),
+                    )
+                    .await?;
+                let (ys, proofs): (Vec<cashu::PublicKey>, Vec<cashu::Proof>) =
+                    proofs.into_iter().unzip();
+                let amount = proofs
+                    .iter()
+                    .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
+                let mut metadata = HashMap::default();
+                metadata.insert(
+                    PAYMENT_TYPE_METADATA_KEY.to_owned(),
+                    types::PaymentType::OnChain.to_string(),
+                );
+                metadata.insert(
+                    TRANSACTION_STATUS_METADATA_KEY.to_owned(),
+                    types::TransactionStatus::Settled.to_string(),
+                );
+
+                metadata.insert(
+                    BTC_TX_ID_TYPE_METADATA_KEY.to_owned(),
+                    btc_tx_id.to_string(),
+                );
+
+                let partial_tx = Transaction {
+                    mint_url: self.client.mint_url(),
+                    fee: fees,
+                    direction: TransactionDirection::Outgoing,
+                    memo,
+                    timestamp: now,
+                    unit: unit.clone(),
+                    ys,
+                    amount,
+                    metadata,
+                    quote_id: None,
+                };
+                let tx_id = self.tx_repo.store_tx(partial_tx).await?;
+                Ok((tx_id, None))
+            }
         }
+    }
+
+    async fn mint(&self, amount: bitcoin::Amount) -> Result<MintSummary> {
+        let summary = self
+            .debit
+            .mint_onchain(amount, self.client.as_ref())
+            .await?;
+        Ok(summary)
+    }
+
+    async fn check_pending_mints(&self) -> Result<Vec<TransactionId>> {
+        let mut res = Vec::new();
+        let keysets_info = self.client.get_mint_keysets().await?.keysets;
+        let now = chrono::Utc::now();
+        let pending_mints_result = self
+            .debit
+            .check_pending_mints(
+                &keysets_info,
+                self.client.as_ref(),
+                now.timestamp() as u64,
+                SafeMode::new(self.safe_mode, self.clowder_id),
+            )
+            .await?;
+
+        for (qid, (amount, ys)) in pending_mints_result {
+            let mut metadata = HashMap::default();
+            metadata.insert(
+                PAYMENT_TYPE_METADATA_KEY.to_owned(),
+                types::PaymentType::OnChain.to_string(),
+            );
+            metadata.insert(
+                TRANSACTION_STATUS_METADATA_KEY.to_owned(),
+                types::TransactionStatus::Settled.to_string(),
+            );
+
+            let tx = Transaction {
+                mint_url: self.client.mint_url(),
+                fee: cashu::Amount::ZERO,
+                direction: TransactionDirection::Incoming,
+                memo: None,
+                timestamp: now.timestamp() as u64,
+                unit: self.debit_unit(),
+                ys,
+                amount,
+                metadata,
+                quote_id: Some(qid.to_string()),
+            };
+            let tx_id = self.tx_repo.store_tx(tx).await?;
+            res.push(tx_id);
+        }
+        Ok(res)
     }
 
     async fn receive_proofs(


### PR DESCRIPTION
* Removed `wallet_check_pending_melts` - since onchain melts execute immediately
* Add mint and melt
    * Add `wallet_prepare_melt` - prepares a melt, returns a payment summary - calling `wallet_pay` with the `request id` executes the melt
    * Add optional `btc_tx_id` to `Transaction` - the Bitcoin transaction ID (e.g. from a melt operation)
    * Add optional `quote_id` to `Transaction` - the Mint quote ID (e.g. from a mint operation)
    * Add `wallet_mint` -  creates a mint request for the given amount, returns a mint summary, with the amount and BTC address to pay to
    * Add `wallet_check_pending_mints` - checks the open mint requests and attempts to mint them, if they were paid (Also called during the regular job runs)
