### PR TITLE
Offline Pay by Token, Migrate Rabid and other Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.7.8
+
+* Add `clowder_id`, `betas` and `mint_keysets` to `WalletConfig` (breaking DB change)
+* Improve Offline functionality and performance
+    * Clowder ID is fetched at wallet initialization and cached in DB
+    * Betas are fetched at wallet initialization and cached in DB
+    * Mint keysets are fetched at wallet initialization and cached in DB / refetched on-demand
+* We always initialize Credit Sat Pocket now with `crsat`, even if the Mint doesn't have a credit keyset
+* Add endpoints `wallet_mint_is_rabid` and `wallet_mint_is_offline` to check whether a wallet mint is rabid, or offline
+* Removed `purse_migrate_rabid` from daily jobs - it now has to be called directly and returns a map of migrated wallets with their new mints
+* Removed the check for `default_mint_url` to have to match the wallet - it's just logged now
+* Implement a hacky demo-version of `offline_pay_by_token`, where the wallet can create a token even if the alpha mint is offline
+
 # 0.7.7
 
 * Fix Offline intermint exchange

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.7.7"
+version = "0.7.8"
 edition = "2024"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
 # Wallet Core
 
 Bitcredit wallet core in Rust
+
+## CLI
+
+1. git clone git@github.com:BitcreditProtocol/Wallet-Core.git
+2. install just (https://github.com/casey/just)
+3. Use wallet:
+
+Set configs in crates/bcr-wallet-cli/alice.toml
+
+To reset just rm crates/bcr-wallet-cli/alice.db
+
+```
+just cli -w alice restore_wallet
+
+just cli -w alice info
+
+just cli -w alice receive 0 $token
+
+just cli -w alice send_payment 0 $token
+
+just cli -w alice request_payment 0 150 sat
+
+just cli -w alice melt 0 1000 $btcaddress
+
+just cli -w alice pay_by_token 0 100 sat
+
+just cli -w alice mint 0 1200
+
+just cli -w alice reclaim 0 $txid
+```

--- a/crates/bcr-wallet-cli/bob.toml
+++ b/crates/bcr-wallet-cli/bob.toml
@@ -1,4 +1,4 @@
-mint_url = "https://mint.wildcat3.clowder1.minibill.tech"
+mint_url = "https://mint.wildcat1.clowder1.minibill.tech"
 # mint_url = "https://wildcat-dev-docker.minibill.tech"
 mnemonic = "spoil frost juice sketch spirit fine trophy puzzle crater roast holiday payment"
 log_level = "DEBUG"

--- a/crates/bcr-wallet-cli/carol.toml
+++ b/crates/bcr-wallet-cli/carol.toml
@@ -1,4 +1,4 @@
-mint_url = "https://mint.wildcat1.clowder1.minibill.tech"
+mint_url = "https://mint.wildcat3.clowder1.minibill.tech"
 # mint_url = "https://wildcat-dev-docker.minibill.tech"
 mnemonic = "ridge brain slice tomorrow what poet jacket soda audit reflect process labor"
 log_level = "DEBUG"

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -116,11 +116,13 @@ pub async fn cmd_receive(
 ) -> Result<String> {
     let mut res = String::new();
     let swapped = app_state.wallet_receive_token(id, token.to_owned()).await?;
+    let tx = app_state.wallet_load_tx(id, &swapped.to_string()).await?;
     push_break(&mut res);
     push_break(&mut res);
     res.push_str(&format!(
         "Received token {token}, returned {swapped} for {name} - Wallet ID: {id}.\n"
     ));
+    res.push_str(&format!("tx: {tx:?}.\n"));
     Ok(res)
 }
 
@@ -320,6 +322,25 @@ pub async fn cmd_mint(app_state: &AppState, name: &str, id: usize, amount: u64) 
         mint_summary.address.assume_checked()
     ));
 
+    Ok(res)
+}
+
+pub async fn cmd_migrate_rabid(app_state: &AppState, name: &str) -> Result<String> {
+    let mut res = String::new();
+
+    let migrated = app_state.purse_migrate_rabid().await?;
+
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!("Migrate Rabid for {name}:\n"));
+    push_break(&mut res);
+    if migrated.is_empty() {
+        res.push_str("Nothing migrated.\n");
+    } else {
+        for (k, v) in migrated.iter() {
+            res.push_str(&format!("Migrated Wallet {} to {}.\n", k, v));
+        }
+    }
     Ok(res)
 }
 

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -88,6 +88,8 @@ enum Commands {
     GenMnemonic,
     #[command(name = "check_token")]
     CheckToken { token: String },
+    #[command(name = "check_rabid_offline")]
+    CheckRabidOffline { id: usize },
 }
 
 #[tokio::main]
@@ -258,8 +260,11 @@ async fn main() -> Result<()> {
             );
         }
         Commands::MigrateRabid => {
-            info!("Migrate Rabid for {}", cli.wallet,);
-            app_state.purse_migrate_rabid().await?
+            info!(
+                "Migrate Rabid for {}: {}",
+                cli.wallet,
+                command::cmd_migrate_rabid(&app_state, &cli.wallet).await?
+            )
         }
         Commands::RunJobs => {
             info!("RunJobs for {}:", cli.wallet);
@@ -268,6 +273,15 @@ async fn main() -> Result<()> {
         Commands::CheckToken { token } => {
             info!("Checking token for {}:", cli.wallet);
             info!("{}", is_valid_token(&token)?);
+        }
+        Commands::CheckRabidOffline { id } => {
+            info!(
+                "Check Rabid/Offline for {} and wallet {}: Rabid: {}, Offline: {}",
+                cli.wallet,
+                id,
+                app_state.wallet_mint_is_rabid(id).await?,
+                app_state.wallet_mint_is_offline(id).await?,
+            );
         }
     }
 

--- a/crates/bcr-wallet-core/src/db.rs
+++ b/crates/bcr-wallet-core/src/db.rs
@@ -13,7 +13,7 @@ pub async fn build_wallet_dbs(
     _db_version: u32,
     wallet_id: &str,
     debit: &CurrencyUnit,
-    credit: Option<&CurrencyUnit>,
+    credit: &CurrencyUnit,
     _local: LocalDB,
     db: Arc<redb::Database>,
 ) -> Result<(
@@ -23,17 +23,13 @@ pub async fn build_wallet_dbs(
             prod::ProductionPocketRepository,
             prod::ProductionMintMeltRepository,
         ),
-        Option<prod::ProductionPocketRepository>,
+        prod::ProductionPocketRepository,
     ),
 )> {
     let txdb = prod::ProductionTransactionRepository::new(db.clone(), wallet_id)?;
     let debitdb = prod::ProductionPocketRepository::new(db.clone(), debit)?;
     let mintmeltdb = prod::ProductionMintMeltRepository::new(db.clone(), debit)?;
-    let creditdb = if let Some(cr) = credit {
-        Some(prod::ProductionPocketRepository::new(db, cr)?)
-    } else {
-        None
-    };
+    let creditdb = prod::ProductionPocketRepository::new(db, credit)?;
     Ok((txdb, ((debitdb, mintmeltdb), creditdb)))
 }
 

--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -144,6 +144,8 @@ pub enum Error {
     InvalidClowderPath,
     #[error("Beta not found")]
     BetaNotFound(cashu::MintUrl),
+    #[error("No Substitute could be determined")]
+    NoSubstitute,
     #[error("Unsupported: {0}")]
     Unsupported(String),
     #[error("insufficient amount for melting {0}")]

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::config::AppStateConfig;
 use crate::job::JobState;
 use crate::mint::MintConnector;
-use crate::types::MintSummary;
+use crate::types::{MintSummary, WalletConfig};
 use crate::utils::tx_can_be_refreshed;
 use crate::{
     config::{NostrConfig, SameMintSafeMode},
@@ -74,6 +74,7 @@ pub struct AppState {
 }
 
 impl AppState {
+    pub const CREDIT_SAT_UNIT: &str = "crsat";
     pub const DB_VERSION: u32 = 1;
     pub const MINT_MELT_THRESHOLD_SAT: u64 = 1000;
 
@@ -114,7 +115,7 @@ impl AppState {
         }
     }
 
-    pub async fn load_wallets(&mut self) -> Result<()> {
+    async fn load_wallets(&mut self) -> Result<()> {
         tracing::debug!("AppState::load_wallets()");
 
         let purse = self.get_purse();
@@ -122,7 +123,7 @@ impl AppState {
         let w_ids = purse.list_wallets().await?;
         for wid in w_ids {
             tracing::debug!("Loading wallet with id: {wid}");
-            let w_cfg = purse.load_wallet_config(&wid).await?;
+            let mut w_cfg = purse.load_wallet_config(&wid).await?;
 
             if w_cfg.network != self.cfg.network {
                 tracing::error!(
@@ -133,6 +134,7 @@ impl AppState {
                 return Err(Error::InvalidNetwork(w_cfg.network, self.cfg.network));
             }
 
+            let seed = seed_from_mnemonic(&self.cfg.mnemonic);
             let keypair = keypair_from_mnemonic(&self.cfg.mnemonic);
             if w_cfg.pub_key != keypair.public_key() {
                 tracing::error!(
@@ -142,26 +144,62 @@ impl AppState {
             }
 
             if w_cfg.mint != self.cfg.default_mint_url {
-                tracing::error!(
+                tracing::warn!(
                     "Mint URL mismatch: wallet {wid} with mint url {}, expected: {}",
                     w_cfg.mint,
                     self.cfg.default_mint_url
                 );
-                return Err(Error::InvalidMintUrl(
-                    w_cfg.mint.clone(),
-                    self.cfg.default_mint_url.clone(),
-                ));
             }
 
+            let client = ProductionConnector::new(w_cfg.mint.clone());
+
+            // Attempt to fetch clowder id/betas/keyset infos and fall back to saved ones
+            match client.get_clowder_id().await {
+                Ok(cid) => {
+                    w_cfg.clowder_id = cid;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Could not fetch clowder_id while loading wallets - falling back to config {}: {e}",
+                        &w_cfg.clowder_id.to_string()
+                    );
+                }
+            };
+            match client.get_mint_keysets().await {
+                Ok(ks) => {
+                    w_cfg.mint_keyset_infos = ks.keysets;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Could not fetch mint keysets while loading wallets - falling back to config {:?}: {e}",
+                        &w_cfg.mint_keyset_infos
+                    );
+                }
+            };
+            match client.get_clowder_betas().await {
+                Ok(betas) => {
+                    w_cfg.betas = betas;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Could not fetch betas while loading wallets - falling back to config {:?}: {e}",
+                        &w_cfg
+                            .betas
+                            .iter()
+                            .map(|b| b.to_string())
+                            .collect::<Vec<String>>()
+                    );
+                }
+            };
+
             let wallet = build_wallet(
-                w_cfg.name,
-                w_cfg.network,
-                w_cfg.mint,
-                self.cfg.mnemonic.clone(),
+                w_cfg,
+                client,
                 LocalDB::Keep,
                 Self::DB_VERSION,
                 self.cfg.same_mint_safe_mode,
                 db.clone(),
+                seed,
             )
             .await?;
             purse.add_wallet(wallet).await?;
@@ -198,7 +236,7 @@ impl AppState {
             return Err(Error::WalletAlreadyExists);
         }
 
-        let wallet = build_wallet(
+        let wallet = create_new_wallet(
             name,
             self.cfg.network,
             mint_url,
@@ -223,7 +261,7 @@ impl AppState {
             return Err(Error::WalletAlreadyExists);
         }
 
-        let wallet = build_wallet(
+        let wallet = create_new_wallet(
             name,
             self.cfg.network,
             mint_url,
@@ -319,13 +357,27 @@ impl AppState {
         Ok(deleted)
     }
 
-    pub async fn purse_migrate_rabid(&self) -> Result<()> {
+    pub async fn wallet_mint_is_rabid(&self, idx: usize) -> Result<bool> {
+        tracing::debug!("wallet_is_rabid({idx})");
+        let wallet = self.get_wallet(idx).await?;
+        let is_rabid = wallet.read().await.is_wallet_mint_rabid().await?;
+        Ok(is_rabid)
+    }
+
+    pub async fn wallet_mint_is_offline(&self, idx: usize) -> Result<bool> {
+        tracing::debug!("wallet_is_offline({idx})");
+        let wallet = self.get_wallet(idx).await?;
+        let is_offline = wallet.read().await.is_wallet_mint_offline().await?;
+        Ok(is_offline)
+    }
+
+    pub async fn purse_migrate_rabid(&self) -> Result<HashMap<String, MintUrl>> {
         tracing::debug!("purse_migrate_rabid");
 
         let purse = self.get_purse();
-        purse.migrate_rabid_wallets().await?;
+        let migrated = purse.migrate_rabid_wallets().await?;
 
-        Ok(())
+        Ok(migrated)
     }
 
     pub async fn wallet_prepare_pay_by_token(
@@ -445,11 +497,8 @@ impl AppState {
         tracing::debug!("wallet_prepare_pay_request({idx}, {amount}, {unit}, {description:?})");
 
         let amount = cashu::Amount::from(amount);
-        let unit = if unit.trim().is_empty() {
-            None
-        } else {
-            cashu::CurrencyUnit::from_str(&unit).ok()
-        };
+        let unit = cashu::CurrencyUnit::from_str(&unit)
+            .map_err(|_| Error::InvalidCurrencyUnit(unit.clone()))?;
         let purse = self.get_purse();
         let request = purse
             .prepare_payment_request(amount, unit, description)
@@ -639,11 +688,6 @@ impl AppState {
     /// Returns a boolean indicating if all jobs ran to success
     pub async fn execute_daily_jobs(&self) -> bool {
         let mut job_failed = false;
-        if let Err(e) = self.purse_migrate_rabid().await {
-            job_failed = true;
-            tracing::error!("Error running purse_migrate_rabid job: {e}");
-        }
-
         let wallet_ids = self.get_purse().ids().await;
         for wallet_id in wallet_ids.iter() {
             match self.wallet_redeem_credit(*wallet_id as usize).await {
@@ -812,9 +856,9 @@ fn build_mint_id(url: &MintUrl, info: &MintInfo) -> Vec<u8> {
     }
 }
 
-fn find_currency_units(
-    keyset_infos: &[KeySetInfo],
-) -> Result<(CurrencyUnit, Option<CurrencyUnit>)> {
+// Attempts to find debit and credit units in the given keysets
+// Falls back to crsat for credit, if there is no keyset for it
+fn find_currency_units(keyset_infos: &[KeySetInfo]) -> Result<(CurrencyUnit, CurrencyUnit)> {
     let currencies = keyset_infos
         .iter()
         .map(|k| k.unit.clone())
@@ -830,12 +874,23 @@ fn find_currency_units(
     let debit_unit = currencies
         .iter()
         .find(|unit| !unit.to_string().starts_with("cr"));
-    if debit_unit.is_none() {
-        let currencies = currencies.iter().cloned().collect();
-        return Err(Error::NoDebitCurrencyInMint(currencies));
-    }
-    let debit_unit = debit_unit.unwrap();
-    Ok((debit_unit.clone(), credit_unit.cloned()))
+
+    let debit_unit = match debit_unit {
+        Some(du) => du,
+        None => {
+            let currencies = currencies.iter().cloned().collect();
+            return Err(Error::NoDebitCurrencyInMint(currencies));
+        }
+    };
+
+    let credit_unit: CurrencyUnit = credit_unit.cloned().unwrap_or_else(|| {
+        tracing::warn!(
+            "app::add_wallet: no credit unit in keyset - setting {} for credit_pocket",
+            AppState::CREDIT_SAT_UNIT
+        );
+        CurrencyUnit::from_str(AppState::CREDIT_SAT_UNIT).expect("credit sat is a valid unit")
+    });
+    Ok((debit_unit.clone(), credit_unit))
 }
 
 fn build_wallet_id(seed: &[u8; 64]) -> String {
@@ -847,7 +902,7 @@ fn build_wallet_id(seed: &[u8; 64]) -> String {
         .to_string()
 }
 
-async fn build_wallet(
+async fn create_new_wallet(
     name: String,
     network: bitcoin::Network,
     mint_url: cashu::MintUrl,
@@ -859,42 +914,74 @@ async fn build_wallet(
 ) -> Result<ProductionWallet> {
     let seed = seed_from_mnemonic(&mnemonic);
     let keypair = keypair_from_mnemonic(&mnemonic);
-    // retrieving mint details
     let client = ProductionConnector::new(mint_url.clone());
-    let keyset_infos = client.get_mint_keysets().await?.keysets;
-    let (debit_unit, credit_unit) = find_currency_units(&keyset_infos)?;
-    // building wallet dbs
+
     let wallet_id = build_wallet_id(&seed);
+    let clowder_id = client.get_clowder_id().await?;
+    let keyset_infos = client.get_mint_keysets().await?.keysets;
+    let betas = client.get_clowder_betas().await?;
+    let (debit_unit, credit_unit) = find_currency_units(&keyset_infos)?;
+
+    let w_cfg = WalletConfig {
+        wallet_id,
+        name,
+        network,
+        mint: mint_url,
+        mint_keyset_infos: keyset_infos,
+        clowder_id,
+        debit: debit_unit,
+        credit: credit_unit,
+        pub_key: keypair.public_key(),
+        betas,
+    };
+    build_wallet(
+        w_cfg,
+        client,
+        local,
+        db_version,
+        same_mint_safe_mode,
+        db,
+        seed,
+    )
+    .await
+}
+
+async fn build_wallet(
+    w_cfg: WalletConfig,
+    client: ProductionConnector,
+    local: LocalDB,
+    db_version: u32,
+    same_mint_safe_mode: SameMintSafeMode,
+    db: Arc<redb::Database>,
+    seed: [u8; 64],
+) -> Result<ProductionWallet> {
+    // building wallet dbs
     let (tx_repo, ((debitdb, mintmeltdb), creditdb)) = crate::db::build_wallet_dbs(
         db_version,
-        &wallet_id,
-        &debit_unit,
-        credit_unit.as_ref(),
+        &w_cfg.wallet_id,
+        &w_cfg.debit,
+        &w_cfg.credit,
         local,
         db,
     )
     .await?;
+
     // building the debit pocket
     let debit_pocket = ProductionDebitPocket::new(
-        debit_unit.clone(),
+        w_cfg.debit.clone(),
         Arc::new(debitdb),
         Arc::new(mintmeltdb),
         seed,
     );
     // building the credit pocket
-    let credit_pocket: Box<dyn CreditPocket> = if let Some(unit) = &credit_unit {
-        let creditdb = creditdb.expect("Credit pocket DB should be present");
-        let pocket = ProductionCreditPocket::new(unit.clone(), Arc::new(creditdb), seed);
-        Box::new(pocket)
-    } else {
-        tracing::warn!("app::add_wallet: credit_pocket = DummyPocket");
-        Box::new(crate::pocket::credit::DummyPocket {})
-    };
+    let credit_pocket: Box<dyn CreditPocket> = Box::new(ProductionCreditPocket::new(
+        w_cfg.credit,
+        Arc::new(creditdb),
+        seed,
+    ));
 
     let mut beta_clients = HashMap::<cashu::MintUrl, Box<dyn MintConnector>>::new();
-
-    let betas_urls = client.get_clowder_betas().await?;
-    for beta in betas_urls.clone() {
+    for beta in w_cfg.betas.clone() {
         let beta_client = ProductionConnector::new(beta.clone());
         beta_clients.insert(beta, Box::new(beta_client));
     }
@@ -903,17 +990,19 @@ async fn build_wallet(
     let client = if matches!(same_mint_safe_mode, SameMintSafeMode::Disabled) {
         Box::new(client) as Box<dyn MintConnector>
     } else {
-        let cl = crate::mint::SentinelClient::new(client, betas_urls);
+        let cl = crate::mint::SentinelClient::new(client, w_cfg.betas);
         Box::new(cl) as Box<dyn MintConnector>
     };
     let new_wallet: ProductionWallet = ProductionWallet::new(
-        network,
+        w_cfg.network,
         client,
+        w_cfg.mint_keyset_infos,
         Box::new(tx_repo),
         (debit_pocket, credit_pocket),
-        name,
-        wallet_id,
-        keypair.public_key(),
+        w_cfg.name,
+        w_cfg.wallet_id,
+        w_cfg.pub_key,
+        w_cfg.clowder_id,
         beta_clients,
         Box::new(|url| Box::new(crate::mint::HttpClientExt::new(url))),
         same_mint_safe_mode,

--- a/crates/bcr-wallet-core/src/mint.rs
+++ b/crates/bcr-wallet-core/src/mint.rs
@@ -276,7 +276,10 @@ impl MintConnector for HttpClientExt {
         &self,
         alpha_id: bitcoin::secp256k1::PublicKey,
     ) -> CdkResult<wire_clowder::AlphaStateResponse> {
-        debug!("Clowder client call to get_alpha_status");
+        debug!(
+            "Clowder client call to get_alpha_status on {} for {alpha_id}",
+            self.mint_url().to_string()
+        );
         self.clowder
             .get_status(alpha_id)
             .await
@@ -288,7 +291,10 @@ impl MintConnector for HttpClientExt {
         &self,
         alpha_id: bitcoin::secp256k1::PublicKey,
     ) -> CdkResult<wire_clowder::ConnectedMintResponse> {
-        debug!("Clowder client call to get_alpha_substitute");
+        debug!(
+            "Clowder client call to get_alpha_substitute on {} for {alpha_id}",
+            self.mint_url().to_string()
+        );
         self.clowder
             .get_substitute(alpha_id)
             .await

--- a/crates/bcr-wallet-core/src/persistence/redb.rs
+++ b/crates/bcr-wallet-core/src/persistence/redb.rs
@@ -814,9 +814,12 @@ struct WalletEntry {
     name: String,
     network: bitcoin::Network,
     mint: cashu::MintUrl,
+    mint_keyset_infos: Vec<cashu::KeySetInfo>,
+    clowder_id: bitcoin::secp256k1::PublicKey,
     pub_key: secp256k1::PublicKey,
     debit: CurrencyUnit,
-    credit: Option<CurrencyUnit>,
+    credit: CurrencyUnit,
+    betas: Vec<MintUrl>,
 }
 impl std::convert::From<WalletConfig> for WalletEntry {
     fn from(wallet: WalletConfig) -> Self {
@@ -825,9 +828,12 @@ impl std::convert::From<WalletConfig> for WalletEntry {
             name: wallet.name,
             network: wallet.network,
             mint: wallet.mint,
+            mint_keyset_infos: wallet.mint_keyset_infos,
+            clowder_id: wallet.clowder_id,
             pub_key: wallet.pub_key,
             debit: wallet.debit,
             credit: wallet.credit,
+            betas: wallet.betas,
         }
     }
 }
@@ -838,9 +844,12 @@ impl std::convert::From<WalletEntry> for WalletConfig {
             name: wallet.name,
             network: wallet.network,
             mint: wallet.mint,
+            mint_keyset_infos: wallet.mint_keyset_infos,
+            clowder_id: wallet.clowder_id,
             pub_key: wallet.pub_key,
             debit: wallet.debit,
             credit: wallet.credit,
+            betas: wallet.betas,
         }
     }
 }

--- a/crates/bcr-wallet-core/src/pocket/credit.rs
+++ b/crates/bcr-wallet-core/src/pocket/credit.rs
@@ -354,10 +354,10 @@ impl wallet::Pocket for Pocket {
         let mut premints = HashMap::from([(active_info.id, premint_secrets)]);
         let keysets = HashMap::from([(active_info.id, active_keyset)]);
 
-        let mut blinds: Vec<cdk00::BlindedMessage> = Vec::new();
-        for premint in premints.values() {
-            blinds.extend(premint.blinded_messages());
-        }
+        let blinds: Vec<cdk00::BlindedMessage> = premints
+            .values()
+            .flat_map(|premint| premint.blinded_messages())
+            .collect();
 
         // swap
         let request = cdk03::SwapRequest::new(proofs, blinds);
@@ -370,17 +370,20 @@ impl wallet::Pocket for Pocket {
                 .and_modify(|v| v.push(signature.clone()))
                 .or_insert_with(|| vec![signature]);
         }
+
+        let mut current_amount = Amount::ZERO;
         // only collect sending proofs - change is discarded for now
         for (kid, signatures) in signatures.into_iter() {
             let premint = premints.remove(&kid).expect("premint should be here");
             let keyset = keysets.get(&kid).expect("keyset should be here");
             let mut unblinded_proofs = unblind_proofs(keyset, signatures, premint);
             unblinded_proofs.sort_by_key(|proof| std::cmp::Reverse(proof.amount));
-            let mut current_amount = Amount::ZERO;
             for proof in unblinded_proofs.into_iter() {
                 if current_amount + proof.amount <= send_amount {
                     current_amount += proof.amount;
                     swapped_proofs.push(proof);
+                } else {
+                    break;
                 }
             }
         }

--- a/crates/bcr-wallet-core/src/pocket/credit.rs
+++ b/crates/bcr-wallet-core/src/pocket/credit.rs
@@ -377,16 +377,14 @@ impl wallet::Pocket for Pocket {
         }
 
         let mut current_amount = Amount::ZERO;
-        // only collect sending proofs - change is discarded for now
+        // only collect sending proofs, so we can take all - change is discarded for now
         for (kid, signatures) in signatures.into_iter() {
             let premint = premints.remove(&kid).expect("premint should be here");
             let keyset = keysets.get(&kid).expect("keyset should be here");
             let unblinded_proofs = unblind_proofs(keyset, signatures, premint);
             for proof in unblinded_proofs.into_iter() {
-                if current_amount + proof.amount <= send_amount {
-                    current_amount += proof.amount;
-                    swapped_proofs.push(proof);
-                }
+                current_amount += proof.amount;
+                swapped_proofs.push(proof);
             }
         }
 

--- a/crates/bcr-wallet-core/src/pocket/credit.rs
+++ b/crates/bcr-wallet-core/src/pocket/credit.rs
@@ -341,6 +341,7 @@ impl wallet::Pocket for Pocket {
         let active_keyset = client.get_mint_keyset(active_info.id).await?;
         // calculate splits
         let send_splits = send_amount.split();
+        let send_splits_len = send_splits.len();
         let change_splits = change_amount.split();
         let mut splits: Vec<Amount> = Vec::with_capacity(send_splits.len() + change_splits.len());
         splits.extend(send_splits);
@@ -363,8 +364,12 @@ impl wallet::Pocket for Pocket {
         let request = cdk03::SwapRequest::new(proofs, blinds);
         let response = client.post_swap(request).await?;
 
+        // We only take the send_splits signatures, they add up to our send_amount
+        let mut send_signatures = response.signatures.clone();
+        send_signatures.truncate(send_splits_len);
+
         let mut signatures: HashMap<cashu::Id, Vec<cdk00::BlindSignature>> = HashMap::new();
-        for signature in response.signatures {
+        for signature in send_signatures {
             signatures
                 .entry(signature.keyset_id)
                 .and_modify(|v| v.push(signature.clone()))
@@ -376,17 +381,21 @@ impl wallet::Pocket for Pocket {
         for (kid, signatures) in signatures.into_iter() {
             let premint = premints.remove(&kid).expect("premint should be here");
             let keyset = keysets.get(&kid).expect("keyset should be here");
-            let mut unblinded_proofs = unblind_proofs(keyset, signatures, premint);
-            unblinded_proofs.sort_by_key(|proof| std::cmp::Reverse(proof.amount));
+            let unblinded_proofs = unblind_proofs(keyset, signatures, premint);
             for proof in unblinded_proofs.into_iter() {
                 if current_amount + proof.amount <= send_amount {
                     current_amount += proof.amount;
                     swapped_proofs.push(proof);
-                } else {
-                    break;
                 }
             }
         }
+
+        if current_amount != send_amount {
+            tracing::warn!(
+                "Mismatch between target {send_amount} and amount from proofs {current_amount}"
+            );
+        }
+
         Ok(swapped_proofs)
     }
 }

--- a/crates/bcr-wallet-core/src/pocket/credit.rs
+++ b/crates/bcr-wallet-core/src/pocket/credit.rs
@@ -293,14 +293,103 @@ impl wallet::Pocket for Pocket {
 
         Ok(proofs_by_keyset)
     }
+
+    async fn return_proofs_to_send_for_offline_payment(
+        &self,
+        rid: Uuid,
+    ) -> Result<(Amount, HashMap<cdk01::PublicKey, cdk00::Proof>)> {
+        let send_ref = {
+            let mut locked = self.current_send.lock().unwrap();
+            if locked.is_none() {
+                return Err(Error::NoPrepareRef(rid));
+            }
+            if locked.as_ref().unwrap().rid != rid {
+                return Err(Error::NoPrepareRef(rid));
+            }
+            locked.take().unwrap()
+        };
+        let proofs_to_send = return_proofs_to_send_for_offline_payment(
+            send_ref.send_proofs,
+            send_ref.swap_proof,
+            self.db.as_ref(),
+        )
+        .await?;
+        Ok(proofs_to_send)
+    }
+
+    async fn swap_to_unlocked_substitute_proofs(
+        &self,
+        proofs: Vec<cdk00::Proof>,
+        keysets_info: &[KeySetInfo],
+        client: &dyn MintConnector,
+        send_amount: Amount,
+    ) -> Result<Vec<cashu::Proof>> {
+        let mut swapped_proofs = Vec::new();
+        let total_amount = proofs.iter().fold(Amount::ZERO, |acc, p| acc + p.amount);
+        let change_amount = total_amount - send_amount;
+        tracing::debug!(
+            "Swapping to unlocked substitute credit proofs - {change_amount} will be lost."
+        );
+        // handle keyset
+        let active_info = keysets_info
+            .iter()
+            .find(|info| info.unit == self.unit && info.active && info.input_fee_ppk == 0);
+        let Some(active_info) = active_info else {
+            return Err(Error::NoActiveKeyset);
+        };
+
+        let active_keyset = client.get_mint_keyset(active_info.id).await?;
+        // calculate splits
+        let send_splits = send_amount.split();
+        let change_splits = change_amount.split();
+        let mut splits: Vec<Amount> = Vec::with_capacity(send_splits.len() + change_splits.len());
+        splits.extend(send_splits);
+        splits.extend(change_splits);
+        // create premints - no counter etc., since we're not persisting them anyway
+        let premint_secrets = cashu::PreMintSecrets::random(
+            active_info.id,
+            total_amount,
+            &SplitTarget::Values(splits),
+        )?;
+        let mut premints = HashMap::from([(active_info.id, premint_secrets)]);
+        let keysets = HashMap::from([(active_info.id, active_keyset)]);
+
+        let mut blinds: Vec<cdk00::BlindedMessage> = Vec::new();
+        for premint in premints.values() {
+            blinds.extend(premint.blinded_messages());
+        }
+
+        // swap
+        let request = cdk03::SwapRequest::new(proofs, blinds);
+        let response = client.post_swap(request).await?;
+
+        let mut signatures: HashMap<cashu::Id, Vec<cdk00::BlindSignature>> = HashMap::new();
+        for signature in response.signatures {
+            signatures
+                .entry(signature.keyset_id)
+                .and_modify(|v| v.push(signature.clone()))
+                .or_insert_with(|| vec![signature]);
+        }
+        // only collect sending proofs - change is discarded for now
+        for (kid, signatures) in signatures.into_iter() {
+            let premint = premints.remove(&kid).expect("premint should be here");
+            let keyset = keysets.get(&kid).expect("keyset should be here");
+            let mut unblinded_proofs = unblind_proofs(keyset, signatures, premint);
+            unblinded_proofs.sort_by_key(|proof| std::cmp::Reverse(proof.amount));
+            let mut current_amount = Amount::ZERO;
+            for proof in unblinded_proofs.into_iter() {
+                if current_amount + proof.amount <= send_amount {
+                    current_amount += proof.amount;
+                    swapped_proofs.push(proof);
+                }
+            }
+        }
+        Ok(swapped_proofs)
+    }
 }
 
 #[async_trait]
 impl wallet::CreditPocket for Pocket {
-    fn maybe_unit(&self) -> Option<CurrencyUnit> {
-        Some(self.unit.clone())
-    }
-
     async fn reclaim_proofs(
         &self,
         ys: &[cdk01::PublicKey],
@@ -396,87 +485,6 @@ impl wallet::CreditPocket for Pocket {
         }
         redemptions.sort_by_key(|r| r.tstamp);
         Ok(redemptions)
-    }
-}
-
-///////////////////////////////////////////// dummy pocket
-pub struct DummyPocket {}
-
-#[async_trait]
-impl wallet::Pocket for DummyPocket {
-    fn unit(&self) -> CurrencyUnit {
-        CurrencyUnit::Custom(String::from("dummy"))
-    }
-    async fn balance(&self) -> Result<cashu::Amount> {
-        Ok(cashu::Amount::ZERO)
-    }
-    async fn receive_proofs(
-        &self,
-        _client: &dyn MintConnector,
-        _keysets_info: &[KeySetInfo],
-        _proofs: Vec<cdk00::Proof>,
-        _safe_mode: SafeMode,
-    ) -> Result<(Amount, Vec<cdk01::PublicKey>)> {
-        Ok((Amount::ZERO, Vec::new()))
-    }
-    async fn prepare_send(&self, _: Amount, _: &[KeySetInfo]) -> Result<SendSummary> {
-        Err(Error::Any(AnyError::msg("DummyPocket is dummy")))
-    }
-    async fn send_proofs(
-        &self,
-        _: Uuid,
-        _: &[KeySetInfo],
-        _: &dyn MintConnector,
-        _: SafeMode,
-    ) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>> {
-        Err(Error::Any(AnyError::msg("DummyPocket is dummy")))
-    }
-    async fn clean_local_proofs(
-        &self,
-        _client: &dyn MintConnector,
-    ) -> Result<Vec<cdk01::PublicKey>> {
-        Ok(Vec::new())
-    }
-    async fn delete_proofs(&self) -> Result<HashMap<cashu::Id, Vec<cdk00::Proof>>> {
-        Ok(HashMap::new())
-    }
-
-    async fn restore_local_proofs(
-        &self,
-        _keysets_info: &[KeySetInfo],
-        _client: &dyn MintConnector,
-    ) -> Result<usize> {
-        Ok(0)
-    }
-}
-
-#[async_trait]
-impl wallet::CreditPocket for DummyPocket {
-    fn maybe_unit(&self) -> Option<CurrencyUnit> {
-        None
-    }
-    async fn reclaim_proofs(
-        &self,
-        _ys: &[cdk01::PublicKey],
-        _keysets_info: &[KeySetInfo],
-        _client: &dyn MintConnector,
-        _safe_mode: SafeMode,
-    ) -> Result<(Amount, Vec<cdk00::Proof>)> {
-        Ok((Amount::ZERO, Vec::new()))
-    }
-    async fn get_redeemable_proofs(
-        &self,
-        _keysets_info: &[KeySetInfo],
-        _client: &dyn MintConnector,
-    ) -> Result<Vec<cdk00::Proof>> {
-        Ok(Vec::new())
-    }
-    async fn list_redemptions(
-        &self,
-        _keysets_info: &[KeySetInfo],
-        _payment_window: std::time::Duration,
-    ) -> Result<Vec<RedemptionSummary>> {
-        Ok(Vec::new())
     }
 }
 

--- a/crates/bcr-wallet-core/src/pocket/debit.rs
+++ b/crates/bcr-wallet-core/src/pocket/debit.rs
@@ -454,11 +454,10 @@ impl wallet::Pocket for Pocket {
         )?;
         let mut premints = HashMap::from([(active_info.id, premint_secrets)]);
         let keysets = HashMap::from([(active_info.id, active_keyset)]);
-        let mut blinds: Vec<cdk00::BlindedMessage> = Vec::new();
-
-        for premint in premints.values() {
-            blinds.extend(premint.blinded_messages());
-        }
+        let blinds: Vec<cdk00::BlindedMessage> = premints
+            .values()
+            .flat_map(|premint| premint.blinded_messages())
+            .collect();
 
         // swap
         let request = cdk03::SwapRequest::new(proofs, blinds);
@@ -471,17 +470,20 @@ impl wallet::Pocket for Pocket {
                 .and_modify(|v| v.push(signature.clone()))
                 .or_insert_with(|| vec![signature]);
         }
+
+        let mut current_amount = Amount::ZERO;
         // only collect sending proofs - change is discarded for now
         for (kid, signatures) in signatures.into_iter() {
             let premint = premints.remove(&kid).expect("premint should be here");
             let keyset = keysets.get(&kid).expect("keyset should be here");
             let mut unblinded_proofs = unblind_proofs(keyset, signatures, premint);
             unblinded_proofs.sort_by_key(|proof| std::cmp::Reverse(proof.amount));
-            let mut current_amount = Amount::ZERO;
             for proof in unblinded_proofs.into_iter() {
                 if current_amount + proof.amount <= send_amount {
                     current_amount += proof.amount;
                     swapped_proofs.push(proof);
+                } else {
+                    break;
                 }
             }
         }

--- a/crates/bcr-wallet-core/src/pocket/debit.rs
+++ b/crates/bcr-wallet-core/src/pocket/debit.rs
@@ -442,6 +442,7 @@ impl wallet::Pocket for Pocket {
         let (active_info, active_keyset) = self.find_active_keyset(keysets_info, client).await?;
         // calculate splits
         let send_splits = send_amount.split();
+        let send_splits_len = send_splits.len();
         let change_splits = change_amount.split();
         let mut splits: Vec<Amount> = Vec::with_capacity(send_splits.len() + change_splits.len());
         splits.extend(send_splits);
@@ -463,8 +464,12 @@ impl wallet::Pocket for Pocket {
         let request = cdk03::SwapRequest::new(proofs, blinds);
         let response = client.post_swap(request).await?;
 
+        // We only take the send_splits signatures, they add up to our send_amount
+        let mut send_signatures = response.signatures.clone();
+        send_signatures.truncate(send_splits_len);
+
         let mut signatures: HashMap<cashu::Id, Vec<cdk00::BlindSignature>> = HashMap::new();
-        for signature in response.signatures {
+        for signature in send_signatures {
             signatures
                 .entry(signature.keyset_id)
                 .and_modify(|v| v.push(signature.clone()))
@@ -476,17 +481,21 @@ impl wallet::Pocket for Pocket {
         for (kid, signatures) in signatures.into_iter() {
             let premint = premints.remove(&kid).expect("premint should be here");
             let keyset = keysets.get(&kid).expect("keyset should be here");
-            let mut unblinded_proofs = unblind_proofs(keyset, signatures, premint);
-            unblinded_proofs.sort_by_key(|proof| std::cmp::Reverse(proof.amount));
+            let unblinded_proofs = unblind_proofs(keyset, signatures, premint);
             for proof in unblinded_proofs.into_iter() {
                 if current_amount + proof.amount <= send_amount {
                     current_amount += proof.amount;
                     swapped_proofs.push(proof);
-                } else {
-                    break;
                 }
             }
         }
+
+        if current_amount != send_amount {
+            tracing::warn!(
+                "Mismatch between target {send_amount} and amount from proofs {current_amount}"
+            );
+        }
+
         Ok(swapped_proofs)
     }
 }

--- a/crates/bcr-wallet-core/src/pocket/debit.rs
+++ b/crates/bcr-wallet-core/src/pocket/debit.rs
@@ -477,16 +477,14 @@ impl wallet::Pocket for Pocket {
         }
 
         let mut current_amount = Amount::ZERO;
-        // only collect sending proofs - change is discarded for now
+        // only collect sending proofs, so we can take all - change is discarded for now
         for (kid, signatures) in signatures.into_iter() {
             let premint = premints.remove(&kid).expect("premint should be here");
             let keyset = keysets.get(&kid).expect("keyset should be here");
             let unblinded_proofs = unblind_proofs(keyset, signatures, premint);
             for proof in unblinded_proofs.into_iter() {
-                if current_amount + proof.amount <= send_amount {
-                    current_amount += proof.amount;
-                    swapped_proofs.push(proof);
-                }
+                current_amount += proof.amount;
+                swapped_proofs.push(proof);
             }
         }
 

--- a/crates/bcr-wallet-core/src/pocket/debit.rs
+++ b/crates/bcr-wallet-core/src/pocket/debit.rs
@@ -401,6 +401,92 @@ impl wallet::Pocket for Pocket {
 
         Ok(proofs_by_keyset)
     }
+
+    async fn return_proofs_to_send_for_offline_payment(
+        &self,
+        rid: Uuid,
+    ) -> Result<(Amount, HashMap<cdk01::PublicKey, cdk00::Proof>)> {
+        let send_ref = {
+            let mut locked = self.current_send.lock().unwrap();
+            if locked.is_none() {
+                return Err(Error::NoPrepareRef(rid));
+            }
+            if locked.as_ref().unwrap().rid != rid {
+                return Err(Error::NoPrepareRef(rid));
+            }
+            locked.take().unwrap()
+        };
+        let proofs_to_send = return_proofs_to_send_for_offline_payment(
+            send_ref.send_proofs,
+            send_ref.swap_proof,
+            self.pdb.as_ref(),
+        )
+        .await?;
+        Ok(proofs_to_send)
+    }
+
+    async fn swap_to_unlocked_substitute_proofs(
+        &self,
+        proofs: Vec<cdk00::Proof>,
+        keysets_info: &[KeySetInfo],
+        client: &dyn MintConnector,
+        send_amount: Amount,
+    ) -> Result<Vec<cashu::Proof>> {
+        let mut swapped_proofs = Vec::new();
+        let total_amount = proofs.iter().fold(Amount::ZERO, |acc, p| acc + p.amount);
+        let change_amount = total_amount - send_amount;
+        tracing::debug!(
+            "Swapping to unlocked substitute debit proofs - {change_amount} will be lost."
+        );
+        // handle keyset
+        let (active_info, active_keyset) = self.find_active_keyset(keysets_info, client).await?;
+        // calculate splits
+        let send_splits = send_amount.split();
+        let change_splits = change_amount.split();
+        let mut splits: Vec<Amount> = Vec::with_capacity(send_splits.len() + change_splits.len());
+        splits.extend(send_splits);
+        splits.extend(change_splits);
+        // no counter etc., since we're not persisting them anyway
+        let premint_secrets = cashu::PreMintSecrets::random(
+            active_info.id,
+            total_amount,
+            &SplitTarget::Values(splits),
+        )?;
+        let mut premints = HashMap::from([(active_info.id, premint_secrets)]);
+        let keysets = HashMap::from([(active_info.id, active_keyset)]);
+        let mut blinds: Vec<cdk00::BlindedMessage> = Vec::new();
+
+        for premint in premints.values() {
+            blinds.extend(premint.blinded_messages());
+        }
+
+        // swap
+        let request = cdk03::SwapRequest::new(proofs, blinds);
+        let response = client.post_swap(request).await?;
+
+        let mut signatures: HashMap<cashu::Id, Vec<cdk00::BlindSignature>> = HashMap::new();
+        for signature in response.signatures {
+            signatures
+                .entry(signature.keyset_id)
+                .and_modify(|v| v.push(signature.clone()))
+                .or_insert_with(|| vec![signature]);
+        }
+        // only collect sending proofs - change is discarded for now
+        for (kid, signatures) in signatures.into_iter() {
+            let premint = premints.remove(&kid).expect("premint should be here");
+            let keyset = keysets.get(&kid).expect("keyset should be here");
+            let mut unblinded_proofs = unblind_proofs(keyset, signatures, premint);
+            unblinded_proofs.sort_by_key(|proof| std::cmp::Reverse(proof.amount));
+            let mut current_amount = Amount::ZERO;
+            for proof in unblinded_proofs.into_iter() {
+                if current_amount + proof.amount <= send_amount {
+                    current_amount += proof.amount;
+                    swapped_proofs.push(proof);
+                }
+            }
+        }
+        Ok(swapped_proofs)
+    }
 }
 
 #[async_trait]

--- a/crates/bcr-wallet-core/src/pocket/mod.rs
+++ b/crates/bcr-wallet-core/src/pocket/mod.rs
@@ -295,6 +295,32 @@ async fn send_proofs(
     Ok(sending_proofs)
 }
 
+///////////////////////////////////////////// return proofs to send for offline payment
+// WARN: This does not swap to target and is suited only for the current temporary offline pay by token flow
+// This just sets the proofs to pending-spent and returns them
+async fn return_proofs_to_send_for_offline_payment(
+    send_proofs: Vec<cdk01::PublicKey>,
+    swap_proof: Option<(Amount, cdk01::PublicKey)>,
+    db: &dyn PocketRepository,
+) -> Result<(Amount, HashMap<cdk01::PublicKey, cdk00::Proof>)> {
+    let mut send_amount = Amount::ZERO;
+    let mut sending_proofs: HashMap<cdk01::PublicKey, cdk00::Proof> = HashMap::new();
+    for y in send_proofs {
+        let proof = db.mark_as_pendingspent(y).await?;
+        send_amount += proof.amount;
+        sending_proofs.insert(y, proof);
+    }
+
+    // Also add swap proof as-is, without swapping to target
+    if let Some((swap_amount, swap_y)) = swap_proof {
+        let swap_proof = db.mark_as_pendingspent(swap_y).await?;
+        sending_proofs.insert(swap_y, swap_proof);
+        send_amount += swap_amount;
+    }
+
+    Ok((send_amount, sending_proofs))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bcr-wallet-core/src/pocket/mod.rs
+++ b/crates/bcr-wallet-core/src/pocket/mod.rs
@@ -118,10 +118,10 @@ async fn swap(
 ) -> Result<Amount> {
     let total_input = inputs.iter().fold(Amount::ZERO, |acc, p| acc + p.amount);
     let input_len = inputs.len();
-    let mut blinds: Vec<cdk00::BlindedMessage> = Vec::new();
-    for premint in premints.values() {
-        blinds.extend(premint.blinded_messages());
-    }
+    let blinds: Vec<cdk00::BlindedMessage> = premints
+        .values()
+        .flat_map(|premint| premint.blinded_messages())
+        .collect();
     if let SafeMode::Enabled { expire, alpha_pk } = safe_mode {
         let (fps, returned_blinds, exp, commitment) =
             utils::compel_commitment(inputs.clone(), blinds.clone(), expire, alpha_pk, client)

--- a/crates/bcr-wallet-core/src/purse.rs
+++ b/crates/bcr-wallet-core/src/purse.rs
@@ -25,7 +25,6 @@ use uuid::Uuid;
 pub trait PurseRepository: sync::SendSync {
     async fn store(&self, wallet: WalletConfig) -> Result<()>;
     async fn load(&self, wallet_id: &str) -> Result<WalletConfig>;
-    #[allow(dead_code)]
     async fn delete(&self, wallet_id: &str) -> Result<()>;
     async fn list_ids(&self) -> Result<Vec<String>>;
 }
@@ -36,7 +35,6 @@ pub trait Wallet: sync::SendSync {
     fn name(&self) -> String;
     fn id(&self) -> String;
     fn mint_url(&self) -> Result<MintUrl>;
-    #[allow(dead_code)]
     fn betas(&self) -> Vec<MintUrl>;
     #[allow(dead_code)]
     fn clowder_id(&self) -> bitcoin::secp256k1::PublicKey;
@@ -50,6 +48,7 @@ pub trait Wallet: sync::SendSync {
 
     async fn prepare_pay(&self, input: String) -> Result<PaymentSummary>;
     async fn is_wallet_mint_rabid(&self) -> Result<bool>;
+    async fn is_wallet_mint_offline(&self) -> Result<bool>;
     async fn mint_substitute(&self) -> Result<Option<MintUrl>>;
     async fn pay(
         &self,
@@ -65,7 +64,7 @@ pub trait Wallet: sync::SendSync {
     async fn migrate_pockets_substitute(
         &mut self,
         substitute: Box<dyn MintConnector>,
-    ) -> Result<()>;
+    ) -> Result<MintUrl>;
 
     async fn receive_proofs(
         &self,
@@ -83,6 +82,15 @@ pub trait Wallet: sync::SendSync {
         unit: CurrencyUnit,
         description: Option<String>,
     ) -> Result<PaymentSummary>;
+
+    async fn offline_pay_by_token(
+        &self,
+        request_id: Uuid,
+        unit: CurrencyUnit,
+        fees: Amount,
+        memo: Option<String>,
+        now: u64,
+    ) -> Result<(TransactionId, Option<Token>)>;
 }
 
 struct PaymentReference {
@@ -269,7 +277,7 @@ where
     pub async fn prepare_payment_request(
         &self,
         amount: Amount,
-        unit: Option<CurrencyUnit>,
+        unit: CurrencyUnit,
         description: Option<String>,
     ) -> Result<cdk18::PaymentRequest> {
         let mints = {
@@ -289,7 +297,7 @@ where
             payment_id: Some(Uuid::new_v4().to_string()),
             amount: Some(amount),
             mints: Some(mints),
-            unit,
+            unit: Some(unit),
             single_use: Some(true),
             description,
             nut10: None,
@@ -379,29 +387,39 @@ where
         Ok(None)
     }
 
-    pub async fn migrate_rabid_wallets(&self) -> Result<()> {
+    pub async fn migrate_rabid_wallets(&self) -> Result<HashMap<String, MintUrl>> {
+        let mut res = HashMap::new();
         let wlts = self.wallets.read().await;
         for wlt in wlts.iter() {
+            let wallet_id = wlt.read().await.id();
+            tracing::info!("Checking if alpha is rabid..");
             let is_rabid = wlt.read().await.is_wallet_mint_rabid().await?;
-            let substitute_url = wlt.read().await.mint_substitute().await?;
+            if is_rabid {
+                tracing::warn!("Alpha is rabid - finding substitute");
+                let substitute_url = wlt.read().await.mint_substitute().await?;
 
-            let wallet_name = wlt.read().await.name();
-            if is_rabid && let Some(substitute_url) = substitute_url {
-                tracing::info!(
-                    "Wallet {} is found rabid, migrating to substitute beta {}",
-                    wallet_name,
-                    substitute_url
-                );
-                let substitute_client = crate::mint::HttpClientExt::new(substitute_url);
-                wlt.write()
-                    .await
-                    .migrate_pockets_substitute(Box::new(substitute_client))
-                    .await?;
-                self.repo.store(wlt.read().await.config()?).await?;
+                let wallet_name = wlt.read().await.name();
+                if let Some(substitute_url) = substitute_url {
+                    tracing::info!(
+                        "Wallet {} is found rabid, migrating to substitute beta {}",
+                        wallet_name,
+                        substitute_url
+                    );
+                    let substitute_client = crate::mint::HttpClientExt::new(substitute_url);
+                    let new_mint_url = wlt
+                        .write()
+                        .await
+                        .migrate_pockets_substitute(Box::new(substitute_client))
+                        .await?;
+                    res.insert(wallet_id, new_mint_url);
+                    self.repo.store(wlt.read().await.config()?).await?;
+                }
+            } else {
+                tracing::info!("Alpha is not rabid - nothing to migrate.");
             }
         }
 
-        Ok(())
+        Ok(res)
     }
 
     pub async fn prepare_pay_by_token(

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -1,5 +1,5 @@
 use bitcoin::address::NetworkUnchecked;
-use cashu::{Amount, CurrencyUnit, MintUrl};
+use cashu::{Amount, CurrencyUnit, KeySetInfo, MintUrl};
 use std::{collections::HashMap, str::FromStr};
 use uuid::Uuid;
 
@@ -31,11 +31,13 @@ pub struct WalletConfig {
     pub wallet_id: String,
     pub name: String,
     pub network: bitcoin::Network,
-
     pub mint: MintUrl,
+    pub mint_keyset_infos: Vec<KeySetInfo>,
+    pub clowder_id: bitcoin::secp256k1::PublicKey,
     pub debit: CurrencyUnit,
-    pub credit: Option<CurrencyUnit>,
+    pub credit: CurrencyUnit,
     pub pub_key: secp256k1::PublicKey,
+    pub betas: Vec<MintUrl>,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/crates/bcr-wallet-core/src/utils.rs
+++ b/crates/bcr-wallet-core/src/utils.rs
@@ -1,8 +1,10 @@
 use crate::{
     MintConnector, TStamp,
     error::{Error, Result},
+    wallet::SafeMode,
 };
 use bcr_common::wire::keys::ProofFingerprint;
+use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::secp256k1::PublicKey;
 use cashu::{HTLCWitness, Proof};
 use cdk::Error as CdkError;
@@ -132,6 +134,74 @@ pub fn sign_htlc_proof(
     }));
 
     Ok(())
+}
+
+pub async fn htlc_lock(
+    unit: cashu::CurrencyUnit,
+    tstamp: u64,
+    client: &dyn MintConnector,
+    is_credit: bool,
+    proofs: Vec<cashu::Proof>,
+    hash_lock: Sha256,
+    key_locks: Vec<bitcoin::secp256k1::PublicKey>,
+    wallet_pubkey: bitcoin::secp256k1::PublicKey,
+    safe_mode: SafeMode,
+) -> Result<Vec<cashu::Proof>> {
+    tracing::debug!("HTLC-locking proofs");
+    let amount = proofs
+        .iter()
+        .fold(cashu::Amount::ZERO, |acc, x| acc + x.amount);
+
+    let key_locks: Vec<cashu::PublicKey> = key_locks.into_iter().map(|k| k.into()).collect();
+
+    // total hops * time per hop + 2 hops buffer
+    let lock_time =
+        tstamp + (key_locks.len() as u64 + 2) * crate::config::LOCK_REDUCTION_SECONDS_PER_HOP;
+
+    // fetch keysets infos for the given client
+    let infos = client.get_mint_keysets().await?.keysets;
+
+    let active_keyset_id = if is_credit {
+        proofs.first().ok_or(Error::NoActiveKeyset)?.keyset_id
+    } else {
+        infos
+            .iter()
+            .find(|info| info.active && info.unit == unit)
+            .ok_or(Error::NoActiveKeyset)?
+            .id
+    };
+
+    let n = key_locks.len() as u64;
+    let p2pk = cashu::Conditions::new(
+        Some(lock_time),
+        Some(key_locks),
+        Some(vec![wallet_pubkey.into()]),
+        Some(n),
+        None,
+        Some(1),
+    )?;
+    let htlc = cashu::SpendingConditions::new_htlc_hash(&hash_lock.to_string(), Some(p2pk))?;
+    let split_target = cashu::amount::SplitTarget::None;
+    let premints =
+        cashu::PreMintSecrets::with_conditions(active_keyset_id, amount, &split_target, &htlc)?;
+
+    if let SafeMode::Enabled { expire, alpha_pk } = safe_mode {
+        crate::utils::compel_commitment(
+            proofs.clone(),
+            premints.blinded_messages(),
+            expire,
+            alpha_pk,
+            client,
+        )
+        .await?;
+    }
+    let swap_request = cashu::SwapRequest::new(proofs, premints.blinded_messages());
+    let swap = client.post_swap(swap_request).await?;
+
+    let keyset = client.get_mint_keyset(active_keyset_id).await?;
+    let proofs = crate::pocket::unblind_proofs(&keyset, swap.signatures, premints);
+
+    Ok(proofs)
 }
 
 #[cfg(test)]

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -19,7 +19,11 @@ use bcr_common::wire::{
 use bcr_common::{wallet::Token, wire::clowder::ConnectedMintsResponse};
 use bitcoin::hashes::{Hash, sha256::Hash as Sha256};
 use cashu::{Amount, CurrencyUnit, KeySetInfo, MintUrl, Proof};
-use cdk::wallet::types::{Transaction, TransactionDirection, TransactionId};
+use cdk::{
+    StreamExt,
+    wallet::types::{Transaction, TransactionDirection, TransactionId},
+};
+use futures::stream::FuturesUnordered;
 use nostr_sdk::nips::nip19::{FromBech32, Nip19Profile};
 use std::{collections::HashMap, str::FromStr, sync::Mutex};
 use uuid::Uuid;
@@ -73,11 +77,22 @@ pub trait Pocket: sync::SendSync {
         client: &dyn MintConnector,
     ) -> Result<usize>;
     async fn delete_proofs(&self) -> Result<HashMap<cashu::Id, Vec<cashu::Proof>>>;
+    async fn return_proofs_to_send_for_offline_payment(
+        &self,
+        rid: Uuid,
+    ) -> Result<(Amount, HashMap<cashu::PublicKey, cashu::Proof>)>;
+    /// WARN: Only used for hacky offline pay by token - will be removed
+    async fn swap_to_unlocked_substitute_proofs(
+        &self,
+        proofs: Vec<cashu::Proof>,
+        keysets_info: &[KeySetInfo],
+        client: &dyn MintConnector,
+        send_amount: Amount,
+    ) -> Result<Vec<cashu::Proof>>;
 }
 
 #[async_trait]
 pub trait CreditPocket: Pocket {
-    fn maybe_unit(&self) -> Option<CurrencyUnit>;
     /// Reclaims the proofs for the given ys
     /// returns the amount reclaimed and the proofs that can be redeemed (i.e. unspent proofs with
     /// inactive keysets)
@@ -180,6 +195,7 @@ pub struct PayReference {
 pub struct Wallet<DebtPck> {
     network: bitcoin::Network,
     client: Box<dyn MintConnector>,
+    mint_keyset_infos: Vec<cashu::KeySetInfo>,
     beta_clients: HashMap<cashu::MintUrl, Box<dyn MintConnector>>,
     tx_repo: Box<dyn TransactionRepository>,
     debit: DebtPck,
@@ -203,19 +219,21 @@ impl<DebtPck> Wallet<DebtPck> {
     pub async fn new(
         network: bitcoin::Network,
         client: Box<dyn MintConnector>,
+        mint_keyset_infos: Vec<cashu::KeySetInfo>,
         tx_repo: Box<dyn TransactionRepository>,
         (debit, credit): (DebtPck, Box<dyn CreditPocket>),
         name: String,
         id: String,
         pub_key: secp256k1::PublicKey,
+        clowder_id: bitcoin::secp256k1::PublicKey,
         beta_clients: HashMap<cashu::MintUrl, Box<dyn MintConnector>>,
         client_factory: Box<dyn Fn(cashu::MintUrl) -> Box<dyn MintConnector> + Send + Sync>,
         safe_mode: SameMintSafeMode,
     ) -> Result<Self> {
-        let clowder_id = client.get_clowder_id().await?;
         Ok(Self {
             network,
             client,
+            mint_keyset_infos,
             tx_repo,
             debit,
             credit,
@@ -241,7 +259,7 @@ impl<DebtPck> Wallet<DebtPck> {
         &self,
         payment_window: std::time::Duration,
     ) -> Result<Vec<RedemptionSummary>> {
-        let keysets_info = self.client.get_mint_keysets().await?.keysets;
+        let keysets_info = self.get_wallet_mint_keyset_infos().await?;
         self.credit
             .list_redemptions(&keysets_info, payment_window)
             .await
@@ -253,6 +271,80 @@ impl<DebtPck> Wallet<DebtPck> {
 
     pub async fn list_txs(&self) -> Result<Vec<Transaction>> {
         self.tx_repo.list_txs().await
+    }
+
+    // Returns (Option<(clowder_path, intermint_alpha_keyset)>, local_alpha_keyset)
+    async fn get_clowder_path_and_keysets_info(
+        &self,
+        mint_url: MintUrl,
+    ) -> Result<(
+        Option<(ConnectedMintsResponse, Vec<KeySetInfo>)>,
+        Vec<KeySetInfo>,
+    )> {
+        let local_keysets_info = self.get_wallet_mint_keyset_infos().await?;
+        if mint_url == self.client.mint_url() {
+            Ok((None, local_keysets_info))
+        } else {
+            // Intermint Exchange
+            let path = self.client.post_clowder_path(mint_url).await?;
+            tracing::debug!(
+                "Received intermint proofs path {:?}",
+                path.mints
+                    .iter()
+                    .map(|m| (m.mint.to_string(), m.node_id.to_string()))
+                    .collect::<Vec<_>>()
+            );
+            if path.mints.len() < 2 {
+                return Err(Error::InvalidClowderPath);
+            }
+
+            let alpha_id = path.mints[0].node_id;
+            // The path goes through the substitute Beta if the Alpha origin mint is offline
+            let beta_mint = path.mints[1].mint.clone();
+            tracing::debug!(
+                "Intermint Exchange - Alpha: {alpha_id}, Substitute Beta: {}",
+                beta_mint.to_string()
+            );
+            // In the direct exchange case this is the same as the Wallet's mint
+            let substitute_client = if beta_mint == self.client.mint_url() {
+                &self.client
+            } else {
+                self.beta_clients
+                    .get(&beta_mint)
+                    .ok_or(Error::BetaNotFound(beta_mint))?
+            };
+
+            // In the offline case we can only ask the substitute, in the online case we can ask the mint
+            // The Beta mint (after Alpha in the path) should have it in any case
+            // This can be revised based on some criteria ?
+            let alpha_keysets = substitute_client.get_alpha_keysets(alpha_id).await?;
+
+            // The endpoint only returns active keysets and Clowder/Wildcat don't have fees
+            let intermint_alpha_infos: Vec<cashu::KeySetInfo> = alpha_keysets
+                .iter()
+                .map(|keyset| cashu::KeySetInfo {
+                    id: keyset.id,
+                    unit: keyset.unit.clone(),
+                    active: true,
+                    input_fee_ppk: 0,
+                    final_expiry: keyset.final_expiry,
+                })
+                .collect();
+            Ok((Some((path, intermint_alpha_infos)), local_keysets_info))
+        }
+    }
+
+    async fn get_wallet_mint_keyset_infos(&self) -> Result<Vec<KeySetInfo>> {
+        Ok(match self.client.get_mint_keysets().await {
+            Ok(infos) => infos.keysets,
+            Err(e) => {
+                tracing::warn!(
+                    "Couldn't fetch mint keysets for wallet mint - falling back to config: {:?}, {e}",
+                    &self.mint_keyset_infos
+                );
+                self.mint_keyset_infos.clone()
+            }
+        })
     }
 }
 
@@ -316,7 +408,7 @@ where
     }
 
     pub async fn redeem_credit(&self) -> Result<Amount> {
-        let keysets_info = self.client.get_mint_keysets().await?.keysets;
+        let keysets_info = self.get_wallet_mint_keyset_infos().await?;
         let credit_proofs: Vec<cashu::Proof> = self
             .credit
             .get_redeemable_proofs(&keysets_info, self.client.as_ref())
@@ -349,7 +441,7 @@ where
     }
 
     pub async fn restore_local_proofs(&self) -> Result<()> {
-        let keysets_info = self.client.get_mint_keysets().await?.keysets;
+        let keysets_info = self.get_wallet_mint_keyset_infos().await?;
         let (debit, credit) = futures::join!(
             self.debit
                 .restore_local_proofs(&keysets_info, self.client.as_ref()),
@@ -395,7 +487,7 @@ where
     }
 
     pub async fn reclaim_tx(&self, tx_id: TransactionId) -> Result<Amount> {
-        let infos = self.client.get_mint_keysets().await?.keysets;
+        let infos = self.get_wallet_mint_keyset_infos().await?;
         self.refresh_tx(tx_id).await?;
         let tx = self.load_tx(tx_id).await?;
 
@@ -588,73 +680,6 @@ where
         Ok(txid)
     }
 
-    async fn htlc_lock(
-        unit: CurrencyUnit,
-        tstamp: u64,
-        client: &dyn MintConnector,
-        is_credit: bool,
-        proofs: Vec<cashu::Proof>,
-        hash_lock: Sha256,
-        key_locks: Vec<bitcoin::secp256k1::PublicKey>,
-        wallet_pubkey: bitcoin::secp256k1::PublicKey,
-        safe_mode: SafeMode,
-    ) -> Result<Vec<cashu::Proof>> {
-        tracing::debug!("HTLC-locking proofs");
-        let amount = proofs
-            .iter()
-            .fold(cashu::Amount::ZERO, |acc, x| acc + x.amount);
-
-        let key_locks: Vec<cashu::PublicKey> = key_locks.into_iter().map(|k| k.into()).collect();
-
-        // total hops * time per hop + 2 hops buffer
-        let lock_time =
-            tstamp + (key_locks.len() as u64 + 2) * crate::config::LOCK_REDUCTION_SECONDS_PER_HOP;
-
-        let infos = client.get_mint_keysets().await?.keysets;
-
-        let active_keyset_id = if is_credit {
-            proofs.first().ok_or(Error::NoActiveKeyset)?.keyset_id
-        } else {
-            infos
-                .iter()
-                .find(|info| info.active && info.unit == unit)
-                .ok_or(Error::NoActiveKeyset)?
-                .id
-        };
-
-        let n = key_locks.len() as u64;
-        let p2pk = cashu::Conditions::new(
-            Some(lock_time),
-            Some(key_locks),
-            Some(vec![wallet_pubkey.into()]),
-            Some(n),
-            None,
-            Some(1),
-        )?;
-        let htlc = cashu::SpendingConditions::new_htlc_hash(&hash_lock.to_string(), Some(p2pk))?;
-        let split_target = cashu::amount::SplitTarget::None;
-        let premints =
-            cashu::PreMintSecrets::with_conditions(active_keyset_id, amount, &split_target, &htlc)?;
-
-        if let SafeMode::Enabled { expire, alpha_pk } = safe_mode {
-            crate::utils::compel_commitment(
-                proofs.clone(),
-                premints.blinded_messages(),
-                expire,
-                alpha_pk,
-                client,
-            )
-            .await?;
-        }
-        let swap_request = cashu::SwapRequest::new(proofs, premints.blinded_messages());
-        let swap = client.post_swap(swap_request).await?;
-
-        let keyset = client.get_mint_keyset(active_keyset_id).await?;
-        let proofs = crate::pocket::unblind_proofs(&keyset, swap.signatures, premints);
-
-        Ok(proofs)
-    }
-
     async fn offline_exchange(
         &self,
         substitute_client: &dyn MintConnector,
@@ -726,7 +751,7 @@ where
 
         let is_credit = unit == self.credit.unit();
 
-        let locked_alpha_proofs = Self::htlc_lock(
+        let locked_alpha_proofs = utils::htlc_lock(
             unit,
             tstamp,
             alpha_client,
@@ -903,67 +928,6 @@ where
         let txid = self.tx_repo.store_tx(partial_tx).await?;
         Ok(txid)
     }
-
-    // Returns (Option<(clowder_path, intermint_alpha_keyset)>, local_alpha_keyset)
-    async fn get_clowder_path_and_keysets_info(
-        &self,
-        mint_url: MintUrl,
-    ) -> Result<(
-        Option<(ConnectedMintsResponse, Vec<KeySetInfo>)>,
-        Vec<KeySetInfo>,
-    )> {
-        let local_keysets_info = self.client.get_mint_keysets().await?.keysets;
-        if mint_url == self.client.mint_url() {
-            Ok((None, local_keysets_info))
-        } else {
-            // Intermint Exchange
-            let path = self.client.post_clowder_path(mint_url).await?;
-            tracing::debug!(
-                "Received intermint proofs path {:?}",
-                path.mints
-                    .iter()
-                    .map(|m| (m.mint.to_string(), m.node_id.to_string()))
-                    .collect::<Vec<_>>()
-            );
-            if path.mints.len() < 2 {
-                return Err(Error::InvalidClowderPath);
-            }
-
-            let alpha_id = path.mints[0].node_id;
-            // The path goes through the substitute Beta if the Alpha origin mint is offline
-            let beta_mint = path.mints[1].mint.clone();
-            tracing::debug!(
-                "Intermint Exchange - Alpha: {alpha_id}, Substitute Beta: {}",
-                beta_mint.to_string()
-            );
-            // In the direct exchange case this is the same as the Wallet's mint
-            let substitute_client = if beta_mint == self.client.mint_url() {
-                &self.client
-            } else {
-                self.beta_clients
-                    .get(&beta_mint)
-                    .ok_or(Error::BetaNotFound(beta_mint))?
-            };
-
-            // In the offline case we can only ask the substitute, in the online case we can ask the mint
-            // The Beta mint (after Alpha in the path) should have it in any case
-            // This can be revised based on some criteria ?
-            let alpha_keysets = substitute_client.get_alpha_keysets(alpha_id).await?;
-
-            // The endpoint only returns active keysets and Clowder/Wildcat don't have fees
-            let intermint_alpha_infos: Vec<cashu::KeySetInfo> = alpha_keysets
-                .iter()
-                .map(|keyset| cashu::KeySetInfo {
-                    id: keyset.id,
-                    unit: keyset.unit.clone(),
-                    active: true,
-                    input_fee_ppk: 0,
-                    final_expiry: keyset.final_expiry,
-                })
-                .collect();
-            Ok((Some((path, intermint_alpha_infos)), local_keysets_info))
-        }
-    }
 }
 
 #[async_trait]
@@ -977,9 +941,12 @@ where
             name: self.name.clone(),
             network: self.network,
             debit: self.debit.unit(),
-            credit: self.credit.maybe_unit(),
+            credit: self.credit.unit(),
             mint: self.client.mint_url(),
+            mint_keyset_infos: self.mint_keyset_infos.clone(),
+            clowder_id: self.clowder_id,
             pub_key: self.pub_key,
+            betas: self.betas(),
         })
     }
 
@@ -1001,7 +968,7 @@ where
         address: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
         description: Option<String>,
     ) -> Result<PaymentSummary> {
-        let infos = self.client.get_mint_keysets().await?.keysets;
+        let infos = self.get_wallet_mint_keyset_infos().await?;
 
         let invoice = wire_melt::OnchainInvoice { address, amount };
 
@@ -1022,7 +989,7 @@ where
     }
 
     async fn prepare_pay(&self, input: String) -> Result<PaymentSummary> {
-        let infos = self.client.get_mint_keysets().await?.keysets;
+        let infos = self.get_wallet_mint_keyset_infos().await?;
 
         if let Ok(request) = cashu::PaymentRequest::from_str(&input) {
             let (amount, unit, transport) = self.check_nut18_request(&request).await?;
@@ -1072,7 +1039,7 @@ where
             );
             return Err(Error::NoPrepareRef(p_id));
         }
-        let infos = self.client.get_mint_keysets().await?.keysets;
+        let infos = self.get_wallet_mint_keyset_infos().await?;
         let PayReference {
             request_id,
             unit,
@@ -1137,6 +1104,22 @@ where
                 Ok((tx_id, None))
             }
             PaymentType::Token => {
+                // Handle Wallet Mint Offline Case
+                match self.is_wallet_mint_offline().await {
+                    Ok(is_offline) => {
+                        if is_offline {
+                            return self
+                                .offline_pay_by_token(request_id, unit, fees, memo, now)
+                                .await;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Pay by Token: Error during online check - attempting without offline mode: {e}"
+                        );
+                    }
+                };
+
                 let (proofs, token) = if unit == self.credit.unit() {
                     let p = self
                         .credit
@@ -1266,7 +1249,7 @@ where
 
     async fn check_pending_mints(&self) -> Result<Vec<TransactionId>> {
         let mut res = Vec::new();
-        let keysets_info = self.client.get_mint_keysets().await?.keysets;
+        let keysets_info = self.get_wallet_mint_keyset_infos().await?;
         let now = chrono::Utc::now();
         let pending_mints_result = self
             .debit
@@ -1332,25 +1315,71 @@ where
     }
 
     async fn is_wallet_mint_rabid(&self) -> Result<bool> {
-        let mut rabid_count = 0;
+        let betas_count = self.betas().len();
+        let mut futures = FuturesUnordered::new();
+
         for beta in self.betas() {
             let beta_client = self
                 .beta_clients
                 .get(&beta)
                 .ok_or(Error::BetaNotFound(beta))?;
 
-            let status = beta_client.get_alpha_status(self.clowder_id).await?.state;
-            if matches!(status, wire_clowder::SimpleAlphaState::Rabid(..)) {
+            futures.push(async move {
+                let status = beta_client.get_alpha_status(self.clowder_id).await?.state;
+                Ok::<bool, Error>(matches!(status, wire_clowder::SimpleAlphaState::Rabid(..)))
+            });
+        }
+
+        let mut rabid_count = 0;
+        while let Some(is_rabid) = futures.next().await {
+            if let Ok(true) = is_rabid {
                 rabid_count += 1;
+                if rabid_count > betas_count / 2 {
+                    return Ok(true);
+                }
             }
         }
-        Ok(rabid_count > self.beta_clients.len() / 2)
+
+        Ok(rabid_count > betas_count / 2)
+    }
+
+    async fn is_wallet_mint_offline(&self) -> Result<bool> {
+        let betas_count = self.betas().len();
+        let mut futures = FuturesUnordered::new();
+
+        for beta in self.betas() {
+            let beta_client = self
+                .beta_clients
+                .get(&beta)
+                .ok_or(Error::BetaNotFound(beta))?;
+
+            futures.push(async move {
+                let status = beta_client.get_alpha_status(self.clowder_id).await?.state;
+                Ok::<bool, Error>(matches!(
+                    status,
+                    wire_clowder::SimpleAlphaState::Offline(..)
+                ))
+            });
+        }
+
+        let mut offline_count = 0;
+        while let Some(is_offline) = futures.next().await {
+            if let Ok(true) = is_offline {
+                offline_count += 1;
+                if offline_count > betas_count / 2 {
+                    return Ok(true);
+                }
+            }
+        }
+
+        Ok(offline_count > betas_count / 2)
     }
 
     async fn mint_substitute(&self) -> Result<Option<MintUrl>> {
         let mint_id = self.clowder_id;
-
-        let mut substitute_counts = HashMap::<MintUrl, usize>::new();
+        let betas_count = self.betas().len();
+        let threshold = betas_count / 2;
+        let mut futures = FuturesUnordered::new();
 
         for beta in self.betas() {
             let beta_client = self
@@ -1358,14 +1387,21 @@ where
                 .get(&beta)
                 .ok_or(Error::BetaNotFound(beta))?;
 
-            let substitute_vote = beta_client.get_alpha_substitute(mint_id).await?.mint;
-            *substitute_counts.entry(substitute_vote).or_default() += 1;
+            futures.push(async move {
+                let mint = beta_client.get_alpha_substitute(mint_id).await?.mint;
+                Ok::<MintUrl, Error>(mint)
+            });
         }
 
-        let threshold = self.beta_clients.len() / 2;
-        for (beta_mint, &count) in substitute_counts.iter() {
-            if count > threshold {
-                return Ok(Some(beta_mint.clone()));
+        let mut substitute_counts = HashMap::<MintUrl, usize>::new();
+
+        while let Some(vote) = futures.next().await {
+            let mint = vote?;
+            let count = substitute_counts.entry(mint.clone()).or_default();
+            *count += 1;
+
+            if *count > threshold {
+                return Ok(Some(mint));
             }
         }
 
@@ -1389,7 +1425,7 @@ where
     async fn migrate_pockets_substitute(
         &mut self,
         substitute: Box<dyn MintConnector>,
-    ) -> Result<()> {
+    ) -> Result<MintUrl> {
         let debit_proofs = self.debit.delete_proofs().await?;
         let credit_proofs = self.credit.delete_proofs().await?;
 
@@ -1427,7 +1463,7 @@ where
 
         // Swap intermint exchanged proofs
         tracing::info!("Swapping exchanged proofs");
-        let keysets_info = self.client.get_mint_keysets().await?.keysets;
+        let keysets_info = self.get_wallet_mint_keyset_infos().await?;
         self.debit
             .receive_proofs(
                 self.client.as_ref(),
@@ -1452,7 +1488,7 @@ where
             "Migration successful balance credit {credit_balance} debit {debit_balance}"
         );
 
-        Ok(())
+        Ok(self.client.mint_url())
     }
 
     async fn prepare_pay_by_token(
@@ -1461,7 +1497,7 @@ where
         unit: CurrencyUnit,
         description: Option<String>,
     ) -> Result<PaymentSummary> {
-        let infos = self.client.get_mint_keysets().await?.keysets;
+        let infos = self.get_wallet_mint_keyset_infos().await?;
 
         let s_summary = if self.credit.unit() == unit {
             self.credit.prepare_send(amount, &infos).await?
@@ -1480,5 +1516,139 @@ where
         };
         *self.current_payment.lock().unwrap() = Some(pref);
         Ok(summary)
+    }
+
+    // This is a temporary solution for demoing the concept, which has some gaping holes
+    // The process is:
+    // * Check if our alpha is offline
+    // * If it is, determine the substitute
+    // * Get proofs for the given amount (including the swap proof), mark them as pendingspent
+    // * Do an offline-exchange from our alpha to the substitute (for all the fetched proofs)
+    // * Swap the substitute proofs against the substitute beta, to the target amount
+    //   * => This means, that overlap from swapping to target is currently lost, since there's no good way to store other-mint-proofs in the Wallet for now
+    //   * => In the future, we could persist them in a special storage and, once our alpha is back online, attempt to swap them back
+    // * Create Token from swapped target proofs and return Token
+    async fn offline_pay_by_token(
+        &self,
+        request_id: Uuid,
+        unit: CurrencyUnit,
+        fees: Amount,
+        memo: Option<String>,
+        now: u64,
+    ) -> Result<(TransactionId, Option<Token>)> {
+        tracing::warn!(
+            "Pay by Token: Wallet mint is offline - find substitute and attempt offline exchange for tokens"
+        );
+        if let Some(substitute) = self.mint_substitute().await? {
+            tracing::info!("Substitute found: {}", substitute.to_string());
+            // Create substitute client
+            let substitute_client = self
+                .beta_clients
+                .get(&substitute)
+                .ok_or(Error::BetaNotFound(substitute.clone()))?;
+            // Get keyset infos from substitute
+            // Get local proofs
+            tracing::debug!("Offline Pay by Token: Get Local Proofs");
+            let (send_amount, local_proofs) = if unit == self.credit.unit() {
+                self.credit
+                    .return_proofs_to_send_for_offline_payment(request_id)
+                    .await?
+            } else if unit == self.debit.unit() {
+                self.debit
+                    .return_proofs_to_send_for_offline_payment(request_id)
+                    .await?
+            } else {
+                return Err(Error::CurrencyUnitMismatch(self.debit.unit(), unit));
+            };
+            tracing::debug!("Offline Pay by Token: Offline Exchange");
+            // Do offline exchange
+            let substitute_proofs = self
+                .offline_exchange(
+                    substitute_client.as_ref(),
+                    local_proofs.into_values().collect(),
+                )
+                .await?;
+
+            // Fetch keyset infos
+            let keysets_info = substitute_client.get_mint_keysets().await?.keysets;
+            tracing::debug!("Offline Pay by Token: Swap to unlocked substitute proofs to target.");
+            // Swap to unlocked substitute proofs to target
+            let unlocked_sending_proofs = if unit == self.credit.unit() {
+                self.credit
+                    .swap_to_unlocked_substitute_proofs(
+                        substitute_proofs,
+                        &keysets_info,
+                        substitute_client.as_ref(),
+                        send_amount,
+                    )
+                    .await?
+            } else if unit == self.debit.unit() {
+                self.debit
+                    .swap_to_unlocked_substitute_proofs(
+                        substitute_proofs,
+                        &keysets_info,
+                        substitute_client.as_ref(),
+                        send_amount,
+                    )
+                    .await?
+            } else {
+                return Err(Error::CurrencyUnitMismatch(self.debit.unit(), unit));
+            };
+
+            // Create Token
+            let (ys, proofs): (Vec<cashu::PublicKey>, Vec<cashu::Proof>) = unlocked_sending_proofs
+                .into_iter()
+                .map(|proof| (proof.y().expect("Hash to curve should not fail"), proof))
+                .unzip();
+            tracing::debug!("Offline Pay by Token: Create Token");
+            let token = if unit == self.credit.unit() {
+                Token::new_bitcr(
+                    substitute.clone(),
+                    proofs.clone(),
+                    memo.clone(),
+                    self.credit.unit(),
+                )
+            } else if unit == self.debit.unit() {
+                Token::new_cashu(
+                    substitute.clone(),
+                    proofs.clone(),
+                    memo.clone(),
+                    self.debit.unit(),
+                )
+            } else {
+                return Err(Error::CurrencyUnitMismatch(self.debit.unit(), unit));
+            };
+
+            let amount = proofs
+                .iter()
+                .fold(Amount::ZERO, |acc, proof| acc + proof.amount);
+            let mut metadata = HashMap::default();
+            metadata.insert(
+                PAYMENT_TYPE_METADATA_KEY.to_owned(),
+                types::PaymentType::Token.to_string(),
+            );
+            metadata.insert(
+                TRANSACTION_STATUS_METADATA_KEY.to_owned(),
+                types::TransactionStatus::Pending.to_string(),
+            );
+
+            // Create Transaction
+            let partial_tx = Transaction {
+                mint_url: substitute,
+                fee: fees,
+                direction: TransactionDirection::Outgoing,
+                memo,
+                timestamp: now,
+                unit: unit.clone(),
+                ys,
+                amount,
+                metadata,
+                quote_id: None,
+            };
+            let tx_id = self.tx_repo.store_tx(partial_tx).await?;
+            Ok((tx_id, Some(token)))
+        } else {
+            Err(Error::NoSubstitute)
+        }
     }
 }


### PR DESCRIPTION
* Add `clowder_id`, `betas` and `mint_keysets` to `WalletConfig` (breaking DB change)
* Improve Offline functionality and performance
    * Clowder ID is fetched at wallet initialization and cached in DB
    * Betas are fetched at wallet initialization and cached in DB
    * Mint keysets are fetched at wallet initialization and cached in DB / refetched on-demand
* We always initialize Credit Sat Pocket now with `crsat`, even if the Mint doesn't have a credit keyset
* Add endpoints `wallet_mint_is_rabid` and `wallet_mint_is_offline` to check whether a wallet mint 
* Removed `purse_migrate_rabid` from daily jobs - it now has to be called directly and returns a map of migrated wallets with their new mints
* Removed the check for `default_mint_url` to have to match the wallet - it's just logged now
* Implement a hacky demo-version of `offline_pay_by_token`, where the wallet can create a token even if it's alpha mint is offline
