### PR TITLE
remove explicit impor of cashu and cdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,10 @@ members = ["crates/bcr-wallet-core", "crates/bcr-wallet-cli"]
 [workspace.dependencies]
 anyhow = {version = "1"}
 async-trait = {version = "0.1"}
-bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "fc6d54d6e8fdcdb3409c53c899594259c2c3bd18"}
+bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "98d70fd"}
 bip39 = {version = "2.1", features = ["rand"]}
 bitcoin = {version = "0.32"}
 borsh = {version = "1"}
-cashu = {version = "=0.13.1", default-features = false}
-cdk = {version = "=0.13.1", default-features = false}
-cdk-common = {version = "=0.13.1", default-features = false}
 chrono = {version  = "0.4"}
 ciborium = {version="0.2"}
 futures = {version = "0.3"}

--- a/crates/bcr-wallet-cli/Cargo.toml
+++ b/crates/bcr-wallet-cli/Cargo.toml
@@ -6,10 +6,10 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+bcr-common.workspace = true
 bcr-wallet-core = {path = "../bcr-wallet-core"}
 bip39.workspace = true
 bitcoin.workspace = true
-cashu.workspace = true
 chrono.workspace = true
 clap = {version = "4.0", features = ["derive"]}
 config = {version="0.15"}

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -19,7 +19,7 @@ mod command;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletSettings {
-    pub mint_url: cashu::MintUrl,
+    pub mint_url: bcr_common::cashu::MintUrl,
     pub mnemonic: bip39::Mnemonic,
     pub log_level: String,
     pub db_path: PathBuf,

--- a/crates/bcr-wallet-core/Cargo.toml
+++ b/crates/bcr-wallet-core/Cargo.toml
@@ -15,8 +15,6 @@ bcr-common = {workspace = true}
 bip39.workspace = true
 bitcoin.workspace = true
 borsh.workspace = true
-cashu = { workspace = true, features = ["wallet"] }
-cdk = { workspace = true, features = ["wallet"] }
 chrono = {workspace = true}
 ciborium = {workspace = true}
 futures = {workspace = true}
@@ -37,7 +35,6 @@ uuid = {workspace = true }
 
 [dev-dependencies]
 bcr-common = {workspace = true, features = ["test-utils"]}
-cdk-common.workspace = true
 mockall = { workspace = true}
 rand = {workspace = true}
 tokio = {workspace = true}

--- a/crates/bcr-wallet-core/src/config.rs
+++ b/crates/bcr-wallet-core/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::error::Result;
-use cashu::MintUrl;
+use bcr_common::cashu::MintUrl;
 use nostr_sdk::{Keys, RelayUrl, nips::nip06::FromMnemonic, nips::nip19::Nip19Profile};
 
 pub const LOCK_REDUCTION_SECONDS_PER_HOP: u64 = 600;

--- a/crates/bcr-wallet-core/src/db.rs
+++ b/crates/bcr-wallet-core/src/db.rs
@@ -1,4 +1,4 @@
-use cashu::CurrencyUnit;
+use bcr_common::cashu::CurrencyUnit;
 
 use super::*;
 

--- a/crates/bcr-wallet-core/src/error.rs
+++ b/crates/bcr-wallet-core/src/error.rs
@@ -1,6 +1,9 @@
 use anyhow::Error as AnyError;
+use bcr_common::{
+    cashu::{self, MintUrl, nut02 as cdk02},
+    cdk,
+};
 use bitcoin::hashes::sha256::Hash as Sha256;
-use cashu::{MintUrl, nut02 as cdk02};
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -9,13 +9,18 @@ use crate::{
     types::{PaymentSummary, RedemptionSummary},
     wallet::{CreditPocket, WalletBalance},
 };
-use bcr_common::wallet::Token;
+use bcr_common::{
+    cashu::{self, CurrencyUnit, KeySetInfo, MintInfo, MintUrl},
+    cdk::{
+        self,
+        wallet::{MintConnector as MintCon, types::TransactionId},
+    },
+    wallet::Token,
+};
 use bitcoin::{
     hashes::{Hash, HashEngine, sha256},
     hex::DisplayHex,
 };
-use cashu::{CurrencyUnit, KeySetInfo, MintInfo, MintUrl};
-use cdk::wallet::{MintConnector as MintCon, types::TransactionId};
 use chrono::Utc;
 use error::{Error, Result};
 use secp256k1::{Keypair, SECP256K1};

--- a/crates/bcr-wallet-core/src/mint.rs
+++ b/crates/bcr-wallet-core/src/mint.rs
@@ -1,6 +1,8 @@
 use crate::{TStamp, error::Result, sync};
 use async_trait::async_trait;
 use bcr_common::{
+    cashu::{self, Proof},
+    cdk::{self, Error as CdkError},
     client::clowder::Client as ClowderClient,
     wire::{
         clowder::{self as wire_clowder, ConnectedMintsResponse},
@@ -9,8 +11,6 @@ use bcr_common::{
     },
 };
 use bitcoin::base64::prelude::*;
-use cashu::Proof;
-use cdk::Error as CdkError;
 use rand::seq::IndexedRandom;
 use std::str::FromStr;
 use tracing::debug;

--- a/crates/bcr-wallet-core/src/persistence/mod.rs
+++ b/crates/bcr-wallet-core/src/persistence/mod.rs
@@ -1,5 +1,6 @@
 pub mod redb;
 use crate::TStamp;
+use bcr_common::cashu;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 struct Commitment {

--- a/crates/bcr-wallet-core/src/persistence/redb.rs
+++ b/crates/bcr-wallet-core/src/persistence/redb.rs
@@ -9,12 +9,14 @@ use crate::{
     wallet::TransactionRepository,
 };
 use async_trait::async_trait;
-use bitcoin::address::NetworkUnchecked;
-use cashu::{
-    Amount, CurrencyUnit, MintUrl, nut00 as cdk00, nut01 as cdk01, nut02 as cdk02, nut07 as cdk07,
-    nut12 as cdk12, secret::Secret,
+use bcr_common::{
+    cashu::{
+        self, Amount, CurrencyUnit, MintUrl, nut00 as cdk00, nut01 as cdk01, nut02 as cdk02,
+        nut07 as cdk07, nut12 as cdk12, secret::Secret,
+    },
+    cdk::wallet::types::{Transaction, TransactionDirection, TransactionId},
 };
-use cdk::wallet::types::{Transaction, TransactionDirection, TransactionId};
+use bitcoin::address::NetworkUnchecked;
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, TableError};
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 use tokio::task::spawn_blocking;

--- a/crates/bcr-wallet-core/src/pocket/credit.rs
+++ b/crates/bcr-wallet-core/src/pocket/credit.rs
@@ -8,9 +8,9 @@ use crate::{
 };
 use anyhow::Error as AnyError;
 use async_trait::async_trait;
-use cashu::{
-    Amount, CurrencyUnit, KeySet, KeySetInfo, amount::SplitTarget, nut00 as cdk00, nut01 as cdk01,
-    nut07 as cdk07,
+use bcr_common::cashu::{
+    self, Amount, CurrencyUnit, KeySet, KeySetInfo, amount::SplitTarget, nut00 as cdk00,
+    nut01 as cdk01, nut07 as cdk07,
 };
 use std::{
     collections::HashMap,

--- a/crates/bcr-wallet-core/src/pocket/debit.rs
+++ b/crates/bcr-wallet-core/src/pocket/debit.rs
@@ -8,10 +8,12 @@ use crate::{
     wallet,
 };
 use async_trait::async_trait;
-use bcr_common::wire::{melt as wire_melt, mint as wire_mint};
-use cashu::{
-    Amount, CurrencyUnit, KeySet, KeySetInfo, amount::SplitTarget, nut00 as cdk00, nut01 as cdk01,
-    nut05 as cdk05,
+use bcr_common::{
+    cashu::{
+        self, Amount, CurrencyUnit, KeySet, KeySetInfo, amount::SplitTarget, nut00 as cdk00,
+        nut01 as cdk01, nut05 as cdk05,
+    },
+    wire::{melt as wire_melt, mint as wire_mint},
 };
 use std::{
     collections::HashMap,

--- a/crates/bcr-wallet-core/src/pocket/mod.rs
+++ b/crates/bcr-wallet-core/src/pocket/mod.rs
@@ -5,9 +5,9 @@ use crate::{
     wallet::SafeMode,
 };
 use async_trait::async_trait;
-use cashu::{
-    Amount, CurrencyUnit, KeySet, KeySetInfo, amount::SplitTarget, nut00 as cdk00, nut01 as cdk01,
-    nut03 as cdk03, nut07 as cdk07,
+use bcr_common::cashu::{
+    self, Amount, CurrencyUnit, KeySet, KeySetInfo, amount::SplitTarget, nut00 as cdk00,
+    nut01 as cdk01, nut03 as cdk03, nut07 as cdk07,
 };
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;

--- a/crates/bcr-wallet-core/src/purse.rs
+++ b/crates/bcr-wallet-core/src/purse.rs
@@ -9,9 +9,11 @@ use crate::{
     },
 };
 use async_trait::async_trait;
-use bcr_common::wallet::Token;
-use cashu::{Amount, CurrencyUnit, MintUrl, PaymentRequest, nut00 as cdk00, nut18 as cdk18};
-use cdk::wallet::types::TransactionId;
+use bcr_common::{
+    cashu::{Amount, CurrencyUnit, MintUrl, PaymentRequest, nut00 as cdk00, nut18 as cdk18},
+    cdk::wallet::types::TransactionId,
+    wallet::Token,
+};
 use nostr::{nips::nip59::UnwrappedGift, signer::NostrSigner};
 use nostr_sdk::nips::nip19::{Nip19Profile, ToBech32};
 use std::{collections::HashMap, sync::Arc};

--- a/crates/bcr-wallet-core/src/restore.rs
+++ b/crates/bcr-wallet-core/src/restore.rs
@@ -1,5 +1,5 @@
 use crate::{MintConnector, error::Result, pocket::PocketRepository};
-use cashu::{nut00 as cdk00, nut01 as cdk01, nut07 as cdk07, nut09 as cdk09};
+use bcr_common::cashu::{self, nut00 as cdk00, nut01 as cdk01, nut07 as cdk07, nut09 as cdk09};
 use std::collections::HashMap;
 
 // as recommended by NUT13

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -1,5 +1,5 @@
+use bcr_common::cashu::{Amount, CurrencyUnit, KeySetInfo, MintUrl};
 use bitcoin::address::NetworkUnchecked;
-use cashu::{Amount, CurrencyUnit, KeySetInfo, MintUrl};
 use std::{collections::HashMap, str::FromStr};
 use uuid::Uuid;
 

--- a/crates/bcr-wallet-core/src/utils.rs
+++ b/crates/bcr-wallet-core/src/utils.rs
@@ -3,11 +3,13 @@ use crate::{
     error::{Error, Result},
     wallet::SafeMode,
 };
-use bcr_common::wire::keys::ProofFingerprint;
+use bcr_common::{
+    cashu::{self, HTLCWitness, Proof},
+    cdk::{self, Error as CdkError},
+    wire::keys::ProofFingerprint,
+};
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::secp256k1::PublicKey;
-use cashu::{HTLCWitness, Proof};
-use cdk::Error as CdkError;
 use secp256k1::schnorr::Signature;
 
 type CdkResult<T> = std::result::Result<T, cdk::Error>;
@@ -206,15 +208,18 @@ pub async fn htlc_lock(
 
 #[cfg(test)]
 pub mod tests {
+    use super::*;
     use crate::TStamp;
     use crate::error::Result;
     use async_trait::async_trait;
-    use bcr_common::wire::{keys as wire_keys, melt as wire_melt, mint as wire_mint};
-    use cashu::{
-        nut02 as cdk02, nut03 as cdk03, nut04 as cdk04, nut05 as cdk05, nut06 as cdk06,
-        nut07 as cdk07, nut09 as cdk09, nut23 as cdk23,
+    use bcr_common::{
+        cashu::{
+            nut02 as cdk02, nut03 as cdk03, nut04 as cdk04, nut05 as cdk05, nut06 as cdk06,
+            nut07 as cdk07, nut09 as cdk09, nut23 as cdk23,
+        },
+        cdk_common::Error as CDKError,
+        wire::{keys as wire_keys, melt as wire_melt, mint as wire_mint},
     };
-    use cdk_common::Error as CDKError;
 
     use bcr_common::wire::clowder::{AlphaStateResponse, ConnectedMintResponse};
     type CdkResult<T> = std::result::Result<T, CDKError>;

--- a/crates/bcr-wallet-core/src/wallet.rs
+++ b/crates/bcr-wallet-core/src/wallet.rs
@@ -12,17 +12,19 @@ use crate::{
     utils::{self, tx_can_be_refreshed},
 };
 use async_trait::async_trait;
-use bcr_common::wire::{
-    clowder::{self as wire_clowder, ConnectedMintResponse},
-    melt as wire_melt,
+use bcr_common::{
+    cashu::{self, Amount, CurrencyUnit, KeySetInfo, MintUrl, Proof},
+    cdk::{
+        StreamExt,
+        wallet::types::{Transaction, TransactionDirection, TransactionId},
+    },
+    wallet::Token,
+    wire::{
+        clowder::{self as wire_clowder, ConnectedMintResponse, ConnectedMintsResponse},
+        melt as wire_melt,
+    },
 };
-use bcr_common::{wallet::Token, wire::clowder::ConnectedMintsResponse};
 use bitcoin::hashes::{Hash, sha256::Hash as Sha256};
-use cashu::{Amount, CurrencyUnit, KeySetInfo, MintUrl, Proof};
-use cdk::{
-    StreamExt,
-    wallet::types::{Transaction, TransactionDirection, TransactionId},
-};
 use futures::stream::FuturesUnordered;
 use nostr_sdk::nips::nip19::{FromBech32, Nip19Profile};
 use std::{collections::HashMap, str::FromStr, sync::Mutex};


### PR DESCRIPTION
and rely on re-exports from bcr-common