### PR TITLE
Improve Cdk-18 / Nostr Payment Request Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # 0.8.2
 
 * Change default mint and relays
+* Improve Payment Request Reliability & Performance
+    * Remove `initial_delay` and `check_interval` parameters
+    * We now use a long-running subscription and listen to it when receiving payments only, which is much more efficient
+    * `check_received_payment` returns a `cancel_token` and takes a `result_callback`
+        * This way, the caller can control, when to cancel a payment request asynchronously
 
 # 0.8.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,27 +102,12 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -135,15 +120,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -374,6 +350,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
  "uuid",
@@ -395,6 +372,7 @@ dependencies = [
  "nostr-sdk",
  "serde",
  "tokio",
+ "tokio-util",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-log",
@@ -921,7 +899,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -986,7 +964,7 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml 1.0.7+spec-1.1.0",
+ "toml 1.1.0+spec-1.1.0",
  "winnow 1.0.0",
  "yaml-rust2",
 ]
@@ -1240,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -1250,13 +1228,13 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
- "env_filter 1.0.0",
+ "env_filter 1.0.1",
  "jiff",
  "log",
 ]
@@ -3142,9 +3120,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -3580,13 +3558,13 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
@@ -3602,39 +3580,39 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tower"

--- a/crates/bcr-wallet-api/Cargo.toml
+++ b/crates/bcr-wallet-api/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = {workspace = true}
+tokio-util = {workspace = true}
 tracing.workspace = true
 url = {workspace = true}
 uuid = {workspace = true }

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -13,7 +13,8 @@ use bcr_common::{
     wallet::Token,
 };
 use bcr_wallet_core::types::{
-    self, JobState, MintSummary, PaymentSummary, RedemptionSummary, Seed, WalletConfig,
+    self, JobState, MintSummary, PaymentResultCallback, PaymentSummary, RedemptionSummary, Seed,
+    WalletConfig,
 };
 use bcr_wallet_core::util::{build_wallet_id, keypair_from_mnemonic, seed_from_mnemonic};
 use bcr_wallet_persistence::redb::jobs::JobsDB;
@@ -29,6 +30,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 pub mod config;
@@ -63,11 +65,18 @@ impl AppState {
         let jobsdb = Arc::new(build_jobsdb(AppState::DB_VERSION, db.clone()).await?);
 
         let nostr_cfg = NostrConfig::new(cfg.mnemonic.clone(), cfg.nostr_relays.clone())?;
+        let nostr_filter = nostr_sdk::Filter::new()
+            .kind(nostr_sdk::Kind::GiftWrap)
+            .pubkey(nostr_cfg.nostr_signer.public_key());
         let nostr_cl = Arc::new(nostr_sdk::Client::new(nostr_cfg.nostr_signer));
-        for relay in &nostr_cfg.relays {
-            nostr_cl.add_relay(relay).await?;
+        for nostr_relay in &nostr_cfg.relays {
+            nostr_cl.add_relay(nostr_relay).await?;
         }
         nostr_cl.connect().await;
+
+        // create long-running subscription
+        nostr_cl.subscribe(nostr_filter, None).await?;
+
         let http_cl = Arc::new(reqwest::Client::new());
         let purse = purse::Purse::new(pursedb).await?;
         let mut appstate = Self {
@@ -512,32 +521,29 @@ impl AppState {
     pub async fn wallet_check_received_payment(
         &self,
         idx: usize,
-        initial_delay_sec: u64,
         max_wait_sec: u64,
-        check_interval_sec: u64,
         p_id: String,
-    ) -> Result<Option<TransactionId>> {
+        cancel_token: CancellationToken,
+        result_callback: PaymentResultCallback,
+    ) -> Result<()> {
         tracing::debug!("wallet_check_received_payment({p_id})");
 
         let p_id = Uuid::from_str(&p_id)?;
         let wallet = self.get_wallet(idx).await?;
 
-        let initial_delay = core::time::Duration::from_secs(initial_delay_sec);
         let max_wait = core::time::Duration::from_secs(max_wait_sec);
-        let check_interval = core::time::Duration::from_secs(check_interval_sec);
-        let tx_id = wallet
+        wallet
             .read()
             .await
             .check_received_payment(
-                initial_delay,
                 max_wait,
-                check_interval,
                 p_id,
                 &self.nostr_cl,
-                self.myself.public_key,
+                cancel_token,
+                result_callback,
             )
             .await?;
-        Ok(tx_id)
+        Ok(())
     }
 
     pub async fn wallet_list_tx_ids(&self, idx: usize) -> Result<Vec<TransactionId>> {

--- a/crates/bcr-wallet-api/src/pocket/debit.rs
+++ b/crates/bcr-wallet-api/src/pocket/debit.rs
@@ -912,7 +912,6 @@ mod tests {
         let (info, keyset) = core_tests::generate_random_ecash_keyset();
         let kid = info.id;
         let k_infos = vec![KeySetInfo::from(info)];
-        let amount = bitcoin::Amount::from_sat(24);
 
         let mdb = MockMintMeltRepository::new();
         let pdb = MockPocketRepository::new();

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -23,14 +23,15 @@ use bcr_common::{
 use bcr_wallet_core::{
     SendSync,
     types::{
-        BTC_ALPHA_TX_ID_TYPE_METADATA_KEY, BTC_BETA_TX_ID_TYPE_METADATA_KEY, PaymentType,
-        TransactionStatus,
+        BTC_ALPHA_TX_ID_TYPE_METADATA_KEY, BTC_BETA_TX_ID_TYPE_METADATA_KEY, PaymentResultCallback,
+        PaymentType, TransactionStatus,
     },
 };
 use bitcoin::secp256k1;
 use futures::stream::FuturesUnordered;
-use std::{collections::HashMap, str::FromStr, sync::Arc, time::Instant};
-use tokio::time;
+use nostr_sdk::RelayPoolNotification;
+use std::{collections::HashMap, str::FromStr, sync::Arc};
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 #[cfg_attr(test, mockall::automock)]
@@ -60,13 +61,12 @@ pub trait WalletApi: SendSync {
     ) -> Result<cdk18::PaymentRequest>;
     async fn check_received_payment(
         &self,
-        initial_delay: core::time::Duration,
         max_wait: core::time::Duration,
-        check_interval: core::time::Duration,
         p_id: Uuid,
         nostr_cl: &nostr_sdk::Client,
-        public_key: nostr::PublicKey,
-    ) -> Result<Option<TransactionId>>;
+        cancel_token: CancellationToken,
+        result_callback: PaymentResultCallback,
+    ) -> Result<()>;
     async fn is_wallet_mint_rabid(&self) -> Result<bool>;
     async fn is_wallet_mint_offline(&self) -> Result<bool>;
     async fn mint_substitute(&self) -> Result<Option<MintUrl>>;
@@ -219,13 +219,12 @@ impl WalletApi for super::Wallet {
 
     async fn check_received_payment(
         &self,
-        initial_delay: core::time::Duration,
         max_wait: core::time::Duration,
-        check_interval: core::time::Duration,
         p_id: Uuid,
         nostr_cl: &nostr_sdk::Client,
-        public_key: nostr::PublicKey,
-    ) -> Result<Option<TransactionId>> {
+        cancel_token: CancellationToken,
+        result_callback: PaymentResultCallback,
+    ) -> Result<()> {
         let current_request = self.current_payment_request.lock().await.take();
         let Some(req) = current_request else {
             return Err(Error::NoPrepareRef(p_id));
@@ -234,59 +233,53 @@ impl WalletApi for super::Wallet {
             return Err(Error::NoPrepareRef(p_id));
         }
 
-        let filter = nostr_sdk::Filter::new()
-            .kind(nostr_sdk::Kind::GiftWrap)
-            .pubkey(public_key);
-
+        let start = tokio::time::Instant::now();
         let signer = nostr_cl.signer().await?;
 
-        // wait for initial delay before checking
-        time::sleep(initial_delay).await;
-        let start = Instant::now();
-        // timeout a bit less than check interval, so it finishes before the next tick
-        let fetch_timeout = check_interval
-            .checked_sub(std::time::Duration::from_millis(50))
-            .expect("valid duration");
-        let mut interval = time::interval(check_interval);
+        tracing::debug!("Subscribing to events from Nostr...");
+        let mut events = nostr_cl.notifications();
+        let deadline = start + max_wait;
 
         loop {
-            interval.tick().await;
-
-            tracing::debug!("Checking events from Nostr...");
-            let events = match nostr_cl.fetch_events(filter.clone(), fetch_timeout).await {
-                Ok(e) => e,
-                Err(e) => {
-                    tracing::error!("Error while fetching events from nostr: {e}");
-                    continue;
+            tokio::select! {
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("check_received_payment cancelled: {p_id}");
+                    result_callback(None);
+                    return Ok(());
+                },
+                _ = tokio::time::sleep_until(deadline) => {
+                    tracing::warn!("check_received_payment timed out: {p_id}");
+                    result_callback(None);
+                    return Ok(());
+                },
+                evt = events.recv() => {
+                    let Ok(received_evt) = evt else {
+                        tracing::warn!("check_received_payment channel closed: {p_id}");
+                        result_callback(None);
+                        return Ok(());
+                    };
+                    if let RelayPoolNotification::Event { event, .. } = received_evt {
+                    match self
+                        .handle_event(*event, signer.clone(), p_id, req.amount.unwrap_or_default())
+                        .await
+                        {
+                            Ok(None) => {
+                                // do nothing
+                                continue;
+                            }
+                            Ok(Some(tx_id)) => {
+                                result_callback(Some(tx_id));
+                                return Ok(());
+                            }
+                            Err(e) => {
+                                tracing::error!("Error while handling Nostr event: {e}");
+                                continue;
+                            }
+                        };
+                    }
                 }
-            };
-
-            for event in events {
-                match self
-                    .handle_event(event, signer.clone(), p_id, req.amount.unwrap_or_default())
-                    .await
-                {
-                    Ok(None) => {
-                        // do nothing
-                        continue;
-                    }
-                    Ok(Some(tx_id)) => {
-                        return Ok(Some(tx_id));
-                    }
-                    Err(e) => {
-                        tracing::error!("Error while handling Nostr event: {e}");
-                        continue;
-                    }
-                };
-            }
-
-            if start.elapsed() >= max_wait {
-                tracing::warn!("check_received_payment timed out");
-                break;
             }
         }
-
-        Ok(None)
     }
 
     async fn pay(

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -830,12 +830,13 @@ impl Wallet {
 #[cfg(test)]
 mod tests {
     use bcr_common::wire::clowder as wire_clowder;
-    use bcr_wallet_core::types::MintSummary;
+    use bcr_wallet_core::types::{MintSummary, PaymentResultCallback};
     use bcr_wallet_persistence::{
         MockTransactionRepository,
         test_utils::tests::{test_pub_key, valid_payment_address_testnet},
     };
     use nostr::nips::nip19::ToBech32;
+    use tokio_util::sync::CancellationToken;
 
     use super::*;
     use crate::{
@@ -1070,15 +1071,17 @@ mod tests {
 
         let nostr_cl = nostr_sdk::Client::new(nostr_sdk::Keys::generate());
 
+        let callback: PaymentResultCallback = Arc::new(move |_| {});
+        let cancel_token = CancellationToken::new();
+
         let pid = Uuid::new_v4();
         let err = wlt
             .check_received_payment(
-                std::time::Duration::from_millis(0),
-                std::time::Duration::from_millis(1),
                 std::time::Duration::from_millis(1),
                 pid,
                 &nostr_cl,
-                nostr::PublicKey::from(test_pub_key().x_only_public_key().0),
+                cancel_token,
+                callback,
             )
             .await
             .unwrap_err();

--- a/crates/bcr-wallet-cli/Cargo.toml
+++ b/crates/bcr-wallet-cli/Cargo.toml
@@ -17,6 +17,7 @@ config = {version="0.15"}
 nostr-sdk = {workspace = true, features = ["nip06"]}
 serde.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 toml = "0.9"
 tracing-log.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/bcr-wallet-cli/alice.toml
+++ b/crates/bcr-wallet-cli/alice.toml
@@ -1,6 +1,6 @@
 # mint_url = "http://localhost:8080"
-# mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
-mint_url = "https://mint.wildcat0.clowder-dev.minibill.tech"
+mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
+# mint_url = "https://mint.wildcat0.clowder-dev.minibill.tech"
 mnemonic = "royal scheme canoe flame sell jewel valve citizen deal patch stereo walk"
 log_level = "DEBUG"
 db_path = "./alice.db"

--- a/crates/bcr-wallet-cli/bob.toml
+++ b/crates/bcr-wallet-cli/bob.toml
@@ -1,4 +1,5 @@
-mint_url = "https://mint.wildcat1.clowder-dev.minibill.tech"
+#mint_url = "https://mint.wildcat1.clowder-dev.minibill.tech"
+mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
 mnemonic = "spoil frost juice sketch spirit fine trophy puzzle crater roast holiday payment"
 log_level = "DEBUG"
 db_path = "./bob.db"

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -1,9 +1,15 @@
+use std::sync::Arc;
+
 use anyhow::Result;
+use bcr_common::cdk_common::wallet::TransactionId;
 use bcr_wallet_api::AppState;
 use bcr_wallet_core::types::{
-    get_btc_alpha_tx_id, get_btc_beta_tx_id, get_payment_type, get_transaction_status,
+    PaymentResultCallback, get_btc_alpha_tx_id, get_btc_beta_tx_id, get_payment_type,
+    get_transaction_status,
 };
 use chrono::{DateTime, Utc};
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 pub async fn cmd_info(app_state: &AppState) -> Result<String> {
@@ -149,25 +155,41 @@ pub async fn cmd_request_payment(
     id: usize,
     description: Option<String>,
 ) -> Result<String> {
-    let mut res = String::new();
     let req = app_state
         .wallet_prepare_payment_request(id, amount, unit.to_string(), description)
         .await?;
-
     info!("Payment Request: {}, {}", &req.request, &req.p_id);
-    let tx_id = app_state
-        .wallet_check_received_payment(id, 2, 60, 1, req.p_id.clone())
+
+    let cancel_token = CancellationToken::new();
+    // Uncomment to test cancellation
+    // let cancel_token_clone = cancel_token.clone();
+    // tokio::spawn(async move {
+    //     tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+    //     cancel_token_clone.cancel();
+    // });
+    let (tx, rx) = oneshot::channel::<Option<TransactionId>>();
+
+    let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
+
+    let res_cb: PaymentResultCallback = Arc::new(move |tx_id| {
+        if let Some(sender) = tx.lock().unwrap().take() {
+            let _ = sender.send(tx_id);
+        }
+    });
+
+    app_state
+        .wallet_check_received_payment(id, 60, req.p_id.clone(), cancel_token, res_cb)
         .await?;
 
+    let Ok(tx_id) = rx.await else {
+        return Ok("Cancelled".to_string());
+    };
+
+    let mut res = String::new();
     push_break(&mut res);
     push_break(&mut res);
     res.push_str(&format!(
         "Request Payment for {name}, Amount: {amount} - Wallet ID: {id}.\n"
-    ));
-    push_break(&mut res);
-    res.push_str(&format!(
-        "Payment request: {}, p_id: {}",
-        &req.request, &req.p_id
     ));
     push_break(&mut res);
     res.push_str(&format!(

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -1,10 +1,15 @@
-use bcr_common::cashu::{Amount, CurrencyUnit, KeySetInfo, MintUrl};
+use bcr_common::{
+    cashu::{Amount, CurrencyUnit, KeySetInfo, MintUrl},
+    cdk_common::wallet::TransactionId,
+};
 use bitcoin::{address::NetworkUnchecked, secp256k1};
-use std::{collections::HashMap, str::FromStr};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 use uuid::Uuid;
 
 pub type TStamp = chrono::DateTime<chrono::Utc>;
 pub type Seed = [u8; 64];
+
+pub type PaymentResultCallback = Arc<dyn Fn(Option<TransactionId>) + Send + Sync + 'static>;
 
 #[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct JobState {

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -1,5 +1,6 @@
 use bcr_wallet_core::types::{
-    get_btc_alpha_tx_id, get_btc_beta_tx_id, get_payment_type, get_transaction_status,
+    PaymentResultCallback, get_btc_alpha_tx_id, get_btc_beta_tx_id, get_payment_type,
+    get_transaction_status,
 };
 use nostr_sdk::RelayUrl;
 use once_cell::sync::Lazy;
@@ -17,7 +18,7 @@ use bcr_wallet_api::{
     config::{AppStateConfig, SameMintSafeMode},
     error::Error as BcrWalletError,
 };
-use flutter_rust_bridge::{JoinHandle, frb};
+use flutter_rust_bridge::{DartFnFuture, JoinHandle, frb};
 use log::{error, info};
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -507,20 +508,44 @@ pub async fn wallet_prepare_payment_request(
 #[frb]
 pub async fn wallet_check_received_payment(
     req: WalletCheckReceivedPaymentRequest,
-) -> Result<WalletMaybeTransactionIdResponse, WalletError> {
+    result_callback: impl Fn(WalletMaybeTransactionIdResponse) -> DartFnFuture<()>
+    + Send
+    + Sync
+    + 'static,
+) -> Result<WalletPaymentCheckHandle, WalletError> {
     let app_state = get_app_state().await;
-    let tx_id = app_state
-        .wallet_check_received_payment(
-            req.wallet_id,
-            req.initial_delay_sec,
-            req.max_wait_sec,
-            req.check_interval_sec,
-            req.p_id,
-        )
-        .await?;
-    Ok(WalletMaybeTransactionIdResponse {
-        tx_id: tx_id.map(|t| t.to_string()),
-    })
+
+    let dart_callback = Arc::new(result_callback);
+    let callback: PaymentResultCallback = Arc::new(move |tx_id| {
+        let dart_callback = dart_callback.clone();
+        flutter_rust_bridge::spawn(async move {
+            let _ = dart_callback(WalletMaybeTransactionIdResponse {
+                tx_id: tx_id.map(|t| t.to_string()),
+            })
+            .await;
+        });
+    });
+
+    let cancel_token = CancellationToken::new();
+    let handle = WalletPaymentCheckHandle {
+        cancel_token: cancel_token.clone(),
+    };
+    flutter_rust_bridge::spawn(async move {
+        if let Err(e) = app_state
+            .wallet_check_received_payment(
+                req.wallet_id,
+                req.max_wait_sec,
+                req.p_id,
+                cancel_token,
+                callback.clone(),
+            )
+            .await
+        {
+            error!("Error during wallet_check_received_payment: {e}");
+            callback(None);
+        }
+    });
+    Ok(handle)
 }
 
 #[frb]
@@ -718,8 +743,27 @@ pub struct WalletTransactionsResponse {
 }
 
 #[derive(Debug, Clone)]
+pub struct WalletCheckReceivedPaymentRequest {
+    pub wallet_id: usize,
+    pub max_wait_sec: u64,
+    pub p_id: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct WalletMaybeTransactionIdResponse {
     pub tx_id: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct WalletPaymentCheckHandle {
+    cancel_token: CancellationToken,
+}
+
+#[frb]
+impl WalletPaymentCheckHandle {
+    pub fn cancel(&self) {
+        self.cancel_token.cancel();
+    }
 }
 
 #[derive(Clone, Copy, Default, Debug)]
@@ -883,15 +927,6 @@ pub struct WalletMintSummaryResponse {
 pub struct WalletPreparePaymentRequest {
     pub wallet_id: usize,
     pub input: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct WalletCheckReceivedPaymentRequest {
-    pub wallet_id: usize,
-    pub initial_delay_sec: u64,
-    pub max_wait_sec: u64,
-    pub check_interval_sec: u64,
-    pub p_id: String,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -25,6 +25,7 @@
 
 // Section: imports
 
+use crate::api::*;
 use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
 use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
 use flutter_rust_bridge::{Handler, IntoIntoDart};
@@ -37,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -860273285;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 892815454;
 
 // Section: executor
 
@@ -45,6 +46,57 @@ flutter_rust_bridge::frb_generated_default_handler!();
 
 // Section: wire_funcs
 
+fn wire__crate__api__WalletPaymentCheckHandle_cancel_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "WalletPaymentCheckHandle_cancel",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::WalletPaymentCheckHandle::cancel(&*api_that_guard);
+                    })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__generate_random_mnemonic_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -363,36 +415,15 @@ fn wire__crate__api__wallet_check_received_payment_impl(
     rust_vec_len_: i32,
     data_len_: i32,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "wallet_check_received_payment",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_req =
-                <crate::api::WalletCheckReceivedPaymentRequest>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, crate::api::WalletError>(
-                    (move || async move {
-                        let output_ok = crate::api::wallet_check_received_payment(api_req).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "wallet_check_received_payment", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { 
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::WalletCheckReceivedPaymentRequest>::sse_decode(&mut deserializer);
+let api_result_callback = decode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(<flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer));deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, crate::api::WalletError>((move || async move {
+                         let output_ok = crate::api::wallet_check_received_payment(api_req, api_result_callback).await?;   Ok(output_ok)
+                    })().await)
+                } })
 }
 fn wire__crate__api__wallet_delete_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
@@ -1536,7 +1567,87 @@ fn wire__crate__api__wallet_restore_impl(
     )
 }
 
+// Section: related_funcs
+
+fn decode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+    dart_opaque: flutter_rust_bridge::DartOpaque,
+) -> impl Fn(crate::api::WalletMaybeTransactionIdResponse) -> flutter_rust_bridge::DartFnFuture<()>
+{
+    use flutter_rust_bridge::IntoDart;
+
+    async fn body(
+        dart_opaque: flutter_rust_bridge::DartOpaque,
+        arg0: crate::api::WalletMaybeTransactionIdResponse,
+    ) -> () {
+        let args = vec![arg0.into_into_dart().into_dart()];
+        let message = FLUTTER_RUST_BRIDGE_HANDLER
+            .dart_fn_invoke(dart_opaque, args)
+            .await;
+
+        let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+        let action = deserializer.cursor.read_u8().unwrap();
+        let ans = match action {
+            0 => std::result::Result::Ok(<()>::sse_decode(&mut deserializer)),
+            1 => std::result::Result::Err(
+                <flutter_rust_bridge::for_generated::anyhow::Error>::sse_decode(&mut deserializer),
+            ),
+            _ => unreachable!(),
+        };
+        deserializer.end();
+        let ans = ans.expect("Dart throws exception but Rust side assume it is not failable");
+        ans
+    }
+
+    move |arg0: crate::api::WalletMaybeTransactionIdResponse| {
+        flutter_rust_bridge::for_generated::convert_into_dart_fn_future(body(
+            dart_opaque.clone(),
+            arg0,
+        ))
+    }
+}
+flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
+    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>
+);
+
 // Section: dart2rust
+
+impl SseDecode for flutter_rust_bridge::for_generated::anyhow::Error {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <String>::sse_decode(deserializer);
+        return flutter_rust_bridge::for_generated::anyhow::anyhow!("{}", inner);
+    }
+}
+
+impl SseDecode for WalletPaymentCheckHandle {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <RustOpaqueMoi<
+            flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>,
+        >>::sse_decode(deserializer);
+        return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
+    }
+}
+
+impl SseDecode for flutter_rust_bridge::DartOpaque {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <usize>::sse_decode(deserializer);
+        return unsafe { flutter_rust_bridge::for_generated::sse_decode_dart_opaque(inner) };
+    }
+}
+
+impl SseDecode
+    for RustOpaqueMoi<
+        flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <usize>::sse_decode(deserializer);
+        return decode_rust_opaque_moi(inner);
+    }
+}
 
 impl SseDecode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -1591,6 +1702,13 @@ impl SseDecode for crate::api::IsValidTokenResponse {
             mint_url: var_mintUrl,
             unit: var_unit,
         };
+    }
+}
+
+impl SseDecode for isize {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        deserializer.cursor.read_i64::<NativeEndian>().unwrap() as _
     }
 }
 
@@ -1916,15 +2034,11 @@ impl SseDecode for crate::api::WalletCheckReceivedPaymentRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_walletId = <usize>::sse_decode(deserializer);
-        let mut var_initialDelaySec = <u64>::sse_decode(deserializer);
         let mut var_maxWaitSec = <u64>::sse_decode(deserializer);
-        let mut var_checkIntervalSec = <u64>::sse_decode(deserializer);
         let mut var_pId = <String>::sse_decode(deserializer);
         return crate::api::WalletCheckReceivedPaymentRequest {
             wallet_id: var_walletId,
-            initial_delay_sec: var_initialDelaySec,
             max_wait_sec: var_maxWaitSec,
-            check_interval_sec: var_checkIntervalSec,
             p_id: var_pId,
         };
     }
@@ -2333,54 +2447,60 @@ fn pde_ffi_dispatcher_primary_impl(
 ) {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        1 => wire__crate__api__generate_random_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-        2 => wire__crate__api__init_app_impl(port, ptr, rust_vec_len, data_len),
-        3 => wire__crate__api__init_wallet_ffi_impl(port, ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__is_valid_token_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__payment_type_default_impl(port, ptr, rust_vec_len, data_len),
-        6 => {
+        1 => wire__crate__api__WalletPaymentCheckHandle_cancel_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        2 => wire__crate__api__generate_random_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+        3 => wire__crate__api__init_app_impl(port, ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__init_wallet_ffi_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__is_valid_token_impl(port, ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__payment_type_default_impl(port, ptr, rust_vec_len, data_len),
+        7 => {
             wire__crate__api__transaction_direction_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        7 => wire__crate__api__transaction_status_default_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__wallet_add_impl(port, ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__wallet_check_pending_mints_impl(port, ptr, rust_vec_len, data_len),
-        10 => {
+        8 => wire__crate__api__transaction_status_default_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__wallet_add_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__wallet_check_pending_mints_impl(port, ptr, rust_vec_len, data_len),
+        11 => {
             wire__crate__api__wallet_check_received_payment_impl(port, ptr, rust_vec_len, data_len)
         }
-        11 => wire__crate__api__wallet_delete_impl(port, ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__wallet_error_bad_request_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__wallet_error_internal_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__wallet_error_network_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__wallet_error_not_found_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__wallet_get_balance_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__wallet_get_currency_unit_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__wallet_get_ids_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__wallet_get_mint_url_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__wallet_get_name_impl(port, ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__wallet_get_status_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__wallet_get_transaction_ids_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__wallet_get_transactions_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__wallet_list_redemptions_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__wallet_load_transaction_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__wallet_melt_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__wallet_migrate_rabid_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__wallet_mint_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__wallet_mint_is_offline_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__wallet_mint_is_rabid_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__wallet_pay_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__wallet_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__wallet_prepare_melt_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__wallet_prepare_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__wallet_prepare_payment_impl(port, ptr, rust_vec_len, data_len),
-        36 => {
+        12 => wire__crate__api__wallet_delete_impl(port, ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__wallet_error_bad_request_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__wallet_error_internal_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__wallet_error_network_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__wallet_error_not_found_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__wallet_get_balance_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__wallet_get_currency_unit_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__wallet_get_ids_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__wallet_get_mint_url_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__wallet_get_name_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__wallet_get_status_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__wallet_get_transaction_ids_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__wallet_get_transactions_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__wallet_list_redemptions_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__wallet_load_transaction_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__wallet_melt_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__wallet_migrate_rabid_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__wallet_mint_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__wallet_mint_is_offline_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__wallet_mint_is_rabid_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__wallet_pay_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__wallet_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__wallet_prepare_melt_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__wallet_prepare_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__wallet_prepare_payment_impl(port, ptr, rust_vec_len, data_len),
+        37 => {
             wire__crate__api__wallet_prepare_payment_request_impl(port, ptr, rust_vec_len, data_len)
         }
-        37 => wire__crate__api__wallet_receive_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__wallet_reclaim_transaction_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__wallet_redeem_credit_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__wallet_receive_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__wallet_reclaim_transaction_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__wallet_redeem_credit_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -2398,6 +2518,26 @@ fn pde_ffi_dispatcher_sync_impl(
 }
 
 // Section: rust2dart
+
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<WalletPaymentCheckHandle> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
+            .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<WalletPaymentCheckHandle>
+{
+}
+
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<WalletPaymentCheckHandle>>
+    for WalletPaymentCheckHandle
+{
+    fn into_into_dart(self) -> FrbWrapper<WalletPaymentCheckHandle> {
+        self.into()
+    }
+}
 
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::AddWalletResponse {
@@ -2759,9 +2899,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::WalletCheckReceivedPaymentReq
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.wallet_id.into_into_dart().into_dart(),
-            self.initial_delay_sec.into_into_dart().into_dart(),
             self.max_wait_sec.into_into_dart().into_dart(),
-            self.check_interval_sec.into_into_dart().into_dart(),
             self.p_id.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -3426,6 +3564,45 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletsIdsResponse>
     }
 }
 
+impl SseEncode for flutter_rust_bridge::for_generated::anyhow::Error {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(format!("{:?}", self), serializer);
+    }
+}
+
+impl SseEncode for WalletPaymentCheckHandle {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <RustOpaqueMoi<
+            flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>,
+        >>::sse_encode(
+            flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self),
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for flutter_rust_bridge::DartOpaque {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <usize>::sse_encode(self.encode(), serializer);
+    }
+}
+
+impl SseEncode
+    for RustOpaqueMoi<
+        flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        let (ptr, size) = self.sse_encode_raw();
+        <usize>::sse_encode(ptr, serializer);
+        <i32>::sse_encode(size, serializer);
+    }
+}
+
 impl SseEncode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3468,6 +3645,16 @@ impl SseEncode for crate::api::IsValidTokenResponse {
         <Option<String>>::sse_encode(self.memo, serializer);
         <String>::sse_encode(self.mint_url, serializer);
         <Option<String>>::sse_encode(self.unit, serializer);
+    }
+}
+
+impl SseEncode for isize {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        serializer
+            .cursor
+            .write_i64::<NativeEndian>(self as _)
+            .unwrap();
     }
 }
 
@@ -3741,9 +3928,7 @@ impl SseEncode for crate::api::WalletCheckReceivedPaymentRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <usize>::sse_encode(self.wallet_id, serializer);
-        <u64>::sse_encode(self.initial_delay_sec, serializer);
         <u64>::sse_encode(self.max_wait_sec, serializer);
-        <u64>::sse_encode(self.check_interval_sec, serializer);
         <String>::sse_encode(self.p_id, serializer);
     }
 }
@@ -4039,6 +4224,7 @@ mod io {
     // Section: imports
 
     use super::*;
+    use crate::api::*;
     use flutter_rust_bridge::for_generated::byteorder::{
         NativeEndian, ReadBytesExt, WriteBytesExt,
     };
@@ -4048,6 +4234,20 @@ mod io {
     // Section: boilerplate
 
     flutter_rust_bridge::frb_generated_boilerplate_io!();
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_wallet_ffi_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>>::increment_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_wallet_ffi_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>>::decrement_strong_count(ptr as _);
+    }
 }
 #[cfg(not(target_family = "wasm"))]
 pub use io::*;
@@ -4061,6 +4261,7 @@ mod web {
     // Section: imports
 
     use super::*;
+    use crate::api::*;
     use flutter_rust_bridge::for_generated::byteorder::{
         NativeEndian, ReadBytesExt, WriteBytesExt,
     };
@@ -4072,6 +4273,20 @@ mod web {
     // Section: boilerplate
 
     flutter_rust_bridge::frb_generated_boilerplate_web!();
+
+    #[wasm_bindgen]
+    pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>>::increment_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>>::decrement_strong_count(ptr as _);
+    }
 }
 #[cfg(target_family = "wasm")]
 pub use web::*;

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `get_app_state`, `init_logging`, `init_panic_hook`, `new`, `reset_runtime`, `start_jobs`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `CurrencyUnit`, `WalletCleanLocalDbResponse`, `WalletRuntime`, `WalletsNamesResponse`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`
 
 Future<void> initWalletFfi({required WalletFfiConfig conf}) =>
     RustLib.instance.api.crateApiInitWalletFfi(conf: conf);
@@ -91,9 +91,14 @@ Future<WalletPreparePaymentReqResponse> walletPreparePaymentRequest({
   required WalletPreparePaymentReqRequest req,
 }) => RustLib.instance.api.crateApiWalletPreparePaymentRequest(req: req);
 
-Future<WalletMaybeTransactionIdResponse> walletCheckReceivedPayment({
+Future<WalletPaymentCheckHandle> walletCheckReceivedPayment({
   required WalletCheckReceivedPaymentRequest req,
-}) => RustLib.instance.api.crateApiWalletCheckReceivedPayment(req: req);
+  required FutureOr<void> Function(WalletMaybeTransactionIdResponse)
+  resultCallback,
+}) => RustLib.instance.api.crateApiWalletCheckReceivedPayment(
+  req: req,
+  resultCallback: resultCallback,
+);
 
 Future<WalletCheckPendingMintsResponse> walletCheckPendingMints({
   required WalletRequest req,
@@ -133,6 +138,11 @@ Future<MintIsOfflineResponse> walletMintIsOffline({
 
 Future<MintIsRabidResponse> walletMintIsRabid({required WalletRequest req}) =>
     RustLib.instance.api.crateApiWalletMintIsRabid(req: req);
+
+// Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>>
+abstract class WalletPaymentCheckHandle implements RustOpaqueInterface {
+  Future<void> cancel();
+}
 
 class AddWalletResponse {
   final BigInt walletId;
@@ -526,26 +536,17 @@ class WalletCheckPendingMintsResponse {
 
 class WalletCheckReceivedPaymentRequest {
   final BigInt walletId;
-  final BigInt initialDelaySec;
   final BigInt maxWaitSec;
-  final BigInt checkIntervalSec;
   final String pId;
 
   const WalletCheckReceivedPaymentRequest({
     required this.walletId,
-    required this.initialDelaySec,
     required this.maxWaitSec,
-    required this.checkIntervalSec,
     required this.pId,
   });
 
   @override
-  int get hashCode =>
-      walletId.hashCode ^
-      initialDelaySec.hashCode ^
-      maxWaitSec.hashCode ^
-      checkIntervalSec.hashCode ^
-      pId.hashCode;
+  int get hashCode => walletId.hashCode ^ maxWaitSec.hashCode ^ pId.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -553,9 +554,7 @@ class WalletCheckReceivedPaymentRequest {
       other is WalletCheckReceivedPaymentRequest &&
           runtimeType == other.runtimeType &&
           walletId == other.walletId &&
-          initialDelaySec == other.initialDelaySec &&
           maxWaitSec == other.maxWaitSec &&
-          checkIntervalSec == other.checkIntervalSec &&
           pId == other.pId;
 }
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -66,7 +66,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -860273285;
+  int get rustContentHash => 892815454;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -77,6 +77,10 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
 }
 
 abstract class RustLibApi extends BaseApi {
+  Future<void> crateApiWalletPaymentCheckHandleCancel({
+    required WalletPaymentCheckHandle that,
+  });
+
   Future<MnemonicResponse> crateApiGenerateRandomMnemonic({
     required MnemonicRequest req,
   });
@@ -101,8 +105,10 @@ abstract class RustLibApi extends BaseApi {
     required WalletRequest req,
   });
 
-  Future<WalletMaybeTransactionIdResponse> crateApiWalletCheckReceivedPayment({
+  Future<WalletPaymentCheckHandle> crateApiWalletCheckReceivedPayment({
     required WalletCheckReceivedPaymentRequest req,
+    required FutureOr<void> Function(WalletMaybeTransactionIdResponse)
+    resultCallback,
   });
 
   Future<void> crateApiWalletDelete({required WalletRequest req});
@@ -214,6 +220,15 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<RestoreWalletResponse> crateApiWalletRestore();
+
+  RustArcIncrementStrongCountFnType
+  get rust_arc_increment_strong_count_WalletPaymentCheckHandle;
+
+  RustArcDecrementStrongCountFnType
+  get rust_arc_decrement_strong_count_WalletPaymentCheckHandle;
+
+  CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_WalletPaymentCheckHandlePtr;
 }
 
 class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
@@ -223,6 +238,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required super.generalizedFrbRustBinding,
     required super.portManager,
   });
+
+  @override
+  Future<void> crateApiWalletPaymentCheckHandleCancel({
+    required WalletPaymentCheckHandle that,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+            that,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 1,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiWalletPaymentCheckHandleCancelConstMeta,
+        argValues: [that],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletPaymentCheckHandleCancelConstMeta =>
+      const TaskConstMeta(
+        debugName: "WalletPaymentCheckHandle_cancel",
+        argNames: ["that"],
+      );
 
   @override
   Future<MnemonicResponse> crateApiGenerateRandomMnemonic({
@@ -236,7 +287,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 1,
+            funcId: 2,
             port: port_,
           );
         },
@@ -266,7 +317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 2,
+            funcId: 3,
             port: port_,
           );
         },
@@ -294,7 +345,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 3,
+            funcId: 4,
             port: port_,
           );
         },
@@ -324,7 +375,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 4,
+            funcId: 5,
             port: port_,
           );
         },
@@ -351,7 +402,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 6,
             port: port_,
           );
         },
@@ -378,7 +429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 7,
             port: port_,
           );
         },
@@ -408,7 +459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 8,
             port: port_,
           );
         },
@@ -438,7 +489,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 9,
             port: port_,
           );
         },
@@ -468,7 +519,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 10,
             port: port_,
           );
         },
@@ -490,8 +541,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<WalletMaybeTransactionIdResponse> crateApiWalletCheckReceivedPayment({
+  Future<WalletPaymentCheckHandle> crateApiWalletCheckReceivedPayment({
     required WalletCheckReceivedPaymentRequest req,
+    required FutureOr<void> Function(WalletMaybeTransactionIdResponse)
+    resultCallback,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -501,19 +554,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             req,
             serializer,
           );
+          sse_encode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+            resultCallback,
+            serializer,
+          );
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 11,
             port: port_,
           );
         },
         codec: SseCodec(
-          decodeSuccessData: sse_decode_wallet_maybe_transaction_id_response,
+          decodeSuccessData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle,
           decodeErrorData: sse_decode_wallet_error,
         ),
         constMeta: kCrateApiWalletCheckReceivedPaymentConstMeta,
-        argValues: [req],
+        argValues: [req, resultCallback],
         apiImpl: this,
       ),
     );
@@ -522,7 +580,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiWalletCheckReceivedPaymentConstMeta =>
       const TaskConstMeta(
         debugName: "wallet_check_received_payment",
-        argNames: ["req"],
+        argNames: ["req", "resultCallback"],
       );
 
   @override
@@ -535,7 +593,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 12,
             port: port_,
           );
         },
@@ -563,7 +621,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 13,
             port: port_,
           );
         },
@@ -593,7 +651,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 14,
             port: port_,
           );
         },
@@ -621,7 +679,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -649,7 +707,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -682,7 +740,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -712,7 +770,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -742,7 +800,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -772,7 +830,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 20,
             port: port_,
           );
         },
@@ -802,7 +860,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 21,
             port: port_,
           );
         },
@@ -829,7 +887,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 22,
             port: port_,
           );
         },
@@ -859,7 +917,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 23,
             port: port_,
           );
         },
@@ -892,7 +950,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 24,
             port: port_,
           );
         },
@@ -928,7 +986,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -961,7 +1019,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -994,7 +1052,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1021,7 +1079,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1051,7 +1109,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1081,7 +1139,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1114,7 +1172,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1144,7 +1202,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1177,7 +1235,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1207,7 +1265,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1240,7 +1298,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1276,7 +1334,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1312,7 +1370,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1345,7 +1403,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -1378,7 +1436,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1411,7 +1469,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1444,7 +1502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1477,7 +1535,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1507,7 +1565,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1524,6 +1582,103 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiWalletRestoreConstMeta =>
       const TaskConstMeta(debugName: "wallet_restore", argNames: []);
+
+  Future<void> Function(int, dynamic)
+  encode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+    FutureOr<void> Function(WalletMaybeTransactionIdResponse) raw,
+  ) {
+    return (callId, rawArg0) async {
+      final arg0 = dco_decode_wallet_maybe_transaction_id_response(rawArg0);
+
+      Box<void>? rawOutput;
+      Box<AnyhowException>? rawError;
+      try {
+        rawOutput = Box(await raw(arg0));
+      } catch (e, s) {
+        rawError = Box(AnyhowException("$e\n\n$s"));
+      }
+
+      final serializer = SseSerializer(generalizedFrbRustBinding);
+      assert((rawOutput != null) ^ (rawError != null));
+      if (rawOutput != null) {
+        serializer.buffer.putUint8(0);
+        sse_encode_unit(rawOutput.value, serializer);
+      } else {
+        serializer.buffer.putUint8(1);
+        sse_encode_AnyhowException(rawError!.value, serializer);
+      }
+      final output = serializer.intoRaw();
+
+      generalizedFrbRustBinding.dartFnDeliverOutput(
+        callId: callId,
+        ptr: output.ptr,
+        rustVecLen: output.rustVecLen,
+        dataLen: output.dataLen,
+      );
+    };
+  }
+
+  RustArcIncrementStrongCountFnType
+  get rust_arc_increment_strong_count_WalletPaymentCheckHandle => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle;
+
+  RustArcDecrementStrongCountFnType
+  get rust_arc_decrement_strong_count_WalletPaymentCheckHandle => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle;
+
+  @protected
+  AnyhowException dco_decode_AnyhowException(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return AnyhowException(raw as String);
+  }
+
+  @protected
+  WalletPaymentCheckHandle
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return WalletPaymentCheckHandleImpl.frbInternalDcoDecode(
+      raw as List<dynamic>,
+    );
+  }
+
+  @protected
+  WalletPaymentCheckHandle
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return WalletPaymentCheckHandleImpl.frbInternalDcoDecode(
+      raw as List<dynamic>,
+    );
+  }
+
+  @protected
+  FutureOr<void> Function(WalletMaybeTransactionIdResponse)
+  dco_decode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError('');
+  }
+
+  @protected
+  Object dco_decode_DartOpaque(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return decodeDartOpaque(raw, generalizedFrbRustBinding);
+  }
+
+  @protected
+  WalletPaymentCheckHandle
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return WalletPaymentCheckHandleImpl.frbInternalDcoDecode(
+      raw as List<dynamic>,
+    );
+  }
 
   @protected
   String dco_decode_String(dynamic raw) {
@@ -1691,6 +1846,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       mintUrl: dco_decode_String(arr[2]),
       unit: dco_decode_opt_String(arr[3]),
     );
+  }
+
+  @protected
+  PlatformInt64 dco_decode_isize(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeI64(raw);
   }
 
   @protected
@@ -1943,14 +2104,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   dco_decode_wallet_check_received_payment_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 5)
-      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return WalletCheckReceivedPaymentRequest(
       walletId: dco_decode_usize(arr[0]),
-      initialDelaySec: dco_decode_u_64(arr[1]),
-      maxWaitSec: dco_decode_u_64(arr[2]),
-      checkIntervalSec: dco_decode_u_64(arr[3]),
-      pId: dco_decode_String(arr[4]),
+      maxWaitSec: dco_decode_u_64(arr[1]),
+      pId: dco_decode_String(arr[2]),
     );
   }
 
@@ -2372,6 +2531,56 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_String(deserializer);
+    return AnyhowException(inner);
+  }
+
+  @protected
+  WalletPaymentCheckHandle
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return WalletPaymentCheckHandleImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
+  WalletPaymentCheckHandle
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return WalletPaymentCheckHandleImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
+  Object sse_decode_DartOpaque(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_isize(deserializer);
+    return decodeDartOpaque(inner, generalizedFrbRustBinding);
+  }
+
+  @protected
+  WalletPaymentCheckHandle
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return WalletPaymentCheckHandleImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_list_prim_u_8_strict(deserializer);
@@ -2567,6 +2776,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       mintUrl: var_mintUrl,
       unit: var_unit,
     );
+  }
+
+  @protected
+  PlatformInt64 sse_decode_isize(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getPlatformInt64();
   }
 
   @protected
@@ -2844,15 +3059,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_walletId = sse_decode_usize(deserializer);
-    var var_initialDelaySec = sse_decode_u_64(deserializer);
     var var_maxWaitSec = sse_decode_u_64(deserializer);
-    var var_checkIntervalSec = sse_decode_u_64(deserializer);
     var var_pId = sse_decode_String(deserializer);
     return WalletCheckReceivedPaymentRequest(
       walletId: var_walletId,
-      initialDelaySec: var_initialDelaySec,
       maxWaitSec: var_maxWaitSec,
-      checkIntervalSec: var_checkIntervalSec,
       pId: var_pId,
     );
   }
@@ -3228,6 +3439,84 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_AnyhowException(
+    AnyhowException self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.message, serializer);
+  }
+
+  @protected
+  void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    WalletPaymentCheckHandle self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as WalletPaymentCheckHandleImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
+  }
+
+  @protected
+  void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    WalletPaymentCheckHandle self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as WalletPaymentCheckHandleImpl).frbInternalSseEncode(move: false),
+      serializer,
+    );
+  }
+
+  @protected
+  void
+  sse_encode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+    FutureOr<void> Function(WalletMaybeTransactionIdResponse) self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_DartOpaque(
+      encode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+        self,
+      ),
+      serializer,
+    );
+  }
+
+  @protected
+  void sse_encode_DartOpaque(Object self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_isize(
+      PlatformPointerUtil.ptrToPlatformInt64(
+        encodeDartOpaque(
+          self,
+          portManager.dartHandlerPort,
+          generalizedFrbRustBinding,
+        ),
+      ),
+      serializer,
+    );
+  }
+
+  @protected
+  void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    WalletPaymentCheckHandle self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as WalletPaymentCheckHandleImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
+  }
+
+  @protected
   void sse_encode_String(String self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer);
@@ -3426,6 +3715,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_String(self.memo, serializer);
     sse_encode_String(self.mintUrl, serializer);
     sse_encode_opt_String(self.unit, serializer);
+  }
+
+  @protected
+  void sse_encode_isize(PlatformInt64 self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putPlatformInt64(self);
   }
 
   @protected
@@ -3691,9 +3986,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(self.walletId, serializer);
-    sse_encode_u_64(self.initialDelaySec, serializer);
     sse_encode_u_64(self.maxWaitSec, serializer);
-    sse_encode_u_64(self.checkIntervalSec, serializer);
     sse_encode_String(self.pId, serializer);
   }
 
@@ -4028,4 +4321,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_list_prim_usize_strict(self.ids, serializer);
   }
+}
+
+@sealed
+class WalletPaymentCheckHandleImpl extends RustOpaque
+    implements WalletPaymentCheckHandle {
+  // Not to be used by end users
+  WalletPaymentCheckHandleImpl.frbInternalDcoDecode(List<dynamic> wire)
+    : super.frbInternalDcoDecode(wire, _kStaticData);
+
+  // Not to be used by end users
+  WalletPaymentCheckHandleImpl.frbInternalSseDecode(
+    BigInt ptr,
+    int externalSizeOnNative,
+  ) : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+
+  static final _kStaticData = RustArcStaticData(
+    rustArcIncrementStrongCount: RustLib
+        .instance
+        .api
+        .rust_arc_increment_strong_count_WalletPaymentCheckHandle,
+    rustArcDecrementStrongCount: RustLib
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_WalletPaymentCheckHandle,
+    rustArcDecrementStrongCountPtr: RustLib
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_WalletPaymentCheckHandlePtr,
+  );
+
+  Future<void> cancel() =>
+      RustLib.instance.api.crateApiWalletPaymentCheckHandleCancel(that: this);
 }

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -18,6 +18,40 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     required super.portManager,
   });
 
+  CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_WalletPaymentCheckHandlePtr => wire
+      ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandlePtr;
+
+  @protected
+  AnyhowException dco_decode_AnyhowException(dynamic raw);
+
+  @protected
+  WalletPaymentCheckHandle
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    dynamic raw,
+  );
+
+  @protected
+  WalletPaymentCheckHandle
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    dynamic raw,
+  );
+
+  @protected
+  FutureOr<void> Function(WalletMaybeTransactionIdResponse)
+  dco_decode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+    dynamic raw,
+  );
+
+  @protected
+  Object dco_decode_DartOpaque(dynamic raw);
+
+  @protected
+  WalletPaymentCheckHandle
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    dynamic raw,
+  );
+
   @protected
   String dco_decode_String(dynamic raw);
 
@@ -102,6 +136,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   IsValidTokenResponse dco_decode_is_valid_token_response(dynamic raw);
+
+  @protected
+  PlatformInt64 dco_decode_isize(dynamic raw);
 
   @protected
   List<String> dco_decode_list_String(dynamic raw);
@@ -331,6 +368,30 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletsIdsResponse dco_decode_wallets_ids_response(dynamic raw);
 
   @protected
+  AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
+
+  @protected
+  WalletPaymentCheckHandle
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPaymentCheckHandle
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  Object sse_decode_DartOpaque(SseDeserializer deserializer);
+
+  @protected
+  WalletPaymentCheckHandle
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
@@ -446,6 +507,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   IsValidTokenResponse sse_decode_is_valid_token_response(
     SseDeserializer deserializer,
   );
+
+  @protected
+  PlatformInt64 sse_decode_isize(SseDeserializer deserializer);
 
   @protected
   List<String> sse_decode_list_String(SseDeserializer deserializer);
@@ -709,6 +773,43 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_AnyhowException(
+    AnyhowException self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    WalletPaymentCheckHandle self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    WalletPaymentCheckHandle self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+    FutureOr<void> Function(WalletMaybeTransactionIdResponse) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_DartOpaque(Object self, SseSerializer serializer);
+
+  @protected
+  void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    WalletPaymentCheckHandle self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
@@ -836,6 +937,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     IsValidTokenResponse self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_isize(PlatformInt64 self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
@@ -1193,4 +1297,38 @@ class RustLibWire implements BaseWire {
   /// The symbols are looked up in [dynamicLibrary].
   RustLibWire(ffi.DynamicLibrary dynamicLibrary)
     : _lookup = dynamicLibrary.lookup;
+
+  void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandlePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+        'frbgen_wallet_ffi_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle',
+      );
+  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle =
+      _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandlePtr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandlePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+        'frbgen_wallet_ffi_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle',
+      );
+  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle =
+      _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandlePtr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 }

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -20,6 +20,40 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     required super.portManager,
   });
 
+  CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_WalletPaymentCheckHandlePtr => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle;
+
+  @protected
+  AnyhowException dco_decode_AnyhowException(dynamic raw);
+
+  @protected
+  WalletPaymentCheckHandle
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    dynamic raw,
+  );
+
+  @protected
+  WalletPaymentCheckHandle
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    dynamic raw,
+  );
+
+  @protected
+  FutureOr<void> Function(WalletMaybeTransactionIdResponse)
+  dco_decode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+    dynamic raw,
+  );
+
+  @protected
+  Object dco_decode_DartOpaque(dynamic raw);
+
+  @protected
+  WalletPaymentCheckHandle
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    dynamic raw,
+  );
+
   @protected
   String dco_decode_String(dynamic raw);
 
@@ -104,6 +138,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   IsValidTokenResponse dco_decode_is_valid_token_response(dynamic raw);
+
+  @protected
+  PlatformInt64 dco_decode_isize(dynamic raw);
 
   @protected
   List<String> dco_decode_list_String(dynamic raw);
@@ -333,6 +370,30 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletsIdsResponse dco_decode_wallets_ids_response(dynamic raw);
 
   @protected
+  AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
+
+  @protected
+  WalletPaymentCheckHandle
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPaymentCheckHandle
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  Object sse_decode_DartOpaque(SseDeserializer deserializer);
+
+  @protected
+  WalletPaymentCheckHandle
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
@@ -448,6 +509,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   IsValidTokenResponse sse_decode_is_valid_token_response(
     SseDeserializer deserializer,
   );
+
+  @protected
+  PlatformInt64 sse_decode_isize(SseDeserializer deserializer);
 
   @protected
   List<String> sse_decode_list_String(SseDeserializer deserializer);
@@ -711,6 +775,43 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_AnyhowException(
+    AnyhowException self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    WalletPaymentCheckHandle self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    WalletPaymentCheckHandle self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+    FutureOr<void> Function(WalletMaybeTransactionIdResponse) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_DartOpaque(Object self, SseSerializer serializer);
+
+  @protected
+  void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    WalletPaymentCheckHandle self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
@@ -838,6 +939,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     IsValidTokenResponse self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_isize(PlatformInt64 self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
@@ -1186,6 +1290,22 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
 class RustLibWire implements BaseWire {
   RustLibWire.fromExternalLibrary(ExternalLibrary lib);
+
+  void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    int ptr,
+  ) => wasmModule
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+        ptr,
+      );
+
+  void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    int ptr,
+  ) => wasmModule
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+        ptr,
+      );
 }
 
 @JS('wasm_bindgen')
@@ -1193,4 +1313,14 @@ external RustLibWasmModule get wasmModule;
 
 @JS()
 @anonymous
-extension type RustLibWasmModule._(JSObject _) implements JSObject {}
+extension type RustLibWasmModule._(JSObject _) implements JSObject {
+  external void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    int ptr,
+  );
+
+  external void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
+    int ptr,
+  );
+}


### PR DESCRIPTION
* Improve Payment Request Reliability & Performance
    * Remove `initial_delay` and `check_interval` parameters
    * We now use a long-running subscription and listen to it when receiving payments only, which is much more efficient
    * `check_received_payment` returns a `cancel_token` and takes a `result_callback`
        * This way, the caller can control, when to cancel a payment request asynchronously
