### PR TITLE
Adapt to new bcr-common and clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bcr-common"
 version = "0.7.0"
-source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=746902f6637c3cc3030e593c04bd33515d386966#746902f6637c3cc3030e593c04bd33515d386966"
+source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=39fe6fb9062624c21f87d21bfa0eef36b8ff745d#39fe6fb9062624c21f87d21bfa0eef36b8ff745d"
 dependencies = [
  "async-trait",
  "bdk_wallet",
@@ -313,6 +313,7 @@ dependencies = [
  "cdk-common",
  "chrono",
  "ciborium",
+ "infer",
  "mockall",
  "nostr",
  "rand 0.8.5",
@@ -793,6 +794,17 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
 ]
 
 [[package]]
@@ -1322,6 +1334,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1871,6 +1889,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+dependencies = [
+ "cfb",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ strip = "symbols"
 
 [workspace.dependencies]
 async-trait = {version = "0.1"}
-bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "746902f6637c3cc3030e593c04bd33515d386966"}
+bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "39fe6fb9062624c21f87d21bfa0eef36b8ff745d"}
 bcr-wallet-core = {path = "./crates/bcr-wallet-core"}
 bcr-wallet-api = {path = "./crates/bcr-wallet-api"}
 bcr-wallet-persistence = {path = "./crates/bcr-wallet-persistence"}

--- a/crates/bcr-wallet-api/src/external/mint.rs
+++ b/crates/bcr-wallet-api/src/external/mint.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use bcr_common::{
     cashu::{self, Proof},
     cdk::{self, Error as CdkError},
-    client::clowder::Client as ClowderClient,
+    client::mint::Client as MintClient,
     wire::{
         clowder::{self as wire_clowder, ConnectedMintsResponse},
         exchange as wire_exchange, keys as wire_keys, melt as wire_melt, mint as wire_mint,
@@ -89,13 +89,18 @@ async fn do_post_swap_commitment(
     })
 }
 
-fn clowder_err_to_cdk(e: bcr_common::client::clowder::Error) -> CdkError {
+fn clowder_err_to_cdk(e: bcr_common::client::mint::Error) -> CdkError {
     match e {
-        bcr_common::client::clowder::Error::NotFound => {
-            CdkError::HttpError(None, "Wildcat Clowder resource not found".to_string())
+        bcr_common::client::mint::Error::ResourceNotFound(err) => {
+            CdkError::HttpError(None, format!("Wildcat Clowder resource not found: {err}"))
         }
-        bcr_common::client::clowder::Error::Reqwest(e) => CdkError::HttpError(None, e.to_string()),
+        bcr_common::client::mint::Error::Reqwest(e) => CdkError::HttpError(None, e.to_string()),
+        e => CdkError::HttpError(None, e.to_string()),
     }
+}
+
+fn convert_mint_url(mint_url: cashu::MintUrl) -> CdkResult<reqwest::Url> {
+    reqwest::Url::from_str(&mint_url.to_string()).map_err(CdkError::UrlParseError)
 }
 
 #[async_trait]
@@ -177,7 +182,7 @@ pub struct HttpClientExt {
     main: cdk::wallet::HttpClient,
     url: reqwest::Url,
     secondary: reqwest::Client,
-    clowder: ClowderClient,
+    clowder: MintClient,
 }
 
 impl HttpClientExt {
@@ -186,7 +191,7 @@ impl HttpClientExt {
             .expect("cashu::MintUrl is as good as reqwest::Url");
         Self {
             main: cdk::wallet::HttpClient::new(cdk_url),
-            clowder: ClowderClient::new(mint_url.clone()),
+            clowder: MintClient::new(mint_url.clone()),
             url: mint_url,
             secondary: reqwest::Client::new(),
         }
@@ -435,7 +440,7 @@ impl ClowderMintConnector for HttpClientExt {
     ) -> CdkResult<ConnectedMintsResponse> {
         debug!("Clowder client call to post_clowder_path");
         self.clowder
-            .post_path(origin_mint_url)
+            .post_path(convert_mint_url(origin_mint_url)?)
             .await
             .map_err(clowder_err_to_cdk)
     }
@@ -609,7 +614,7 @@ pub struct SentinelClient {
     main: cdk::wallet::HttpClient,
     url: reqwest::Url,
     secondary: reqwest::Client,
-    clowder: ClowderClient,
+    clowder: MintClient,
     sentinels: Vec<reqwest::Url>,
 }
 
@@ -927,7 +932,7 @@ impl ClowderMintConnector for SentinelClient {
     ) -> CdkResult<ConnectedMintsResponse> {
         debug!("Clowder client call to post_clowder_path on sentinel");
         self.clowder
-            .post_path(origin_mint_url)
+            .post_path(convert_mint_url(origin_mint_url)?)
             .await
             .map_err(clowder_err_to_cdk)
     }

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::config::AppStateConfig;
 use crate::external::mint::{ClowderMintConnector, HttpClientExt};
-use crate::wallet::types::WalletBalance;
+use crate::wallet::types::{WalletBalance, WalletProtestResult};
 use crate::{config::NostrConfig, pocket::credit::CreditPocketApi, wallet::api::WalletApi};
 use bcr_common::cdk_common::wallet::Transaction;
 use bcr_common::{
@@ -466,11 +466,14 @@ impl AppState {
         &self,
         idx: usize,
         quote_id: String,
-    ) -> Result<(bcr_common::wire::mint::ProtestStatus, Option<cashu::Amount>)> {
+    ) -> Result<(
+        bcr_common::wire::common::ProtestStatus,
+        Option<cashu::Amount>,
+    )> {
         tracing::debug!("wallet_protest_mint({idx}, {quote_id})");
         let qid = Uuid::from_str(&quote_id)?;
         let wallet = self.get_wallet(idx).await?;
-        let (status, result) = wallet.read().await.protest_mint(qid).await?;
+        let WalletProtestResult { status, result } = wallet.read().await.protest_mint(qid).await?;
         Ok((status, result.map(|(amount, _)| amount)))
     }
 
@@ -486,7 +489,7 @@ impl AppState {
         let sig = bitcoin::secp256k1::schnorr::Signature::from_str(&commitment_sig)
             .map_err(|e| Error::SchnorrSignature(e.to_string()))?;
         let wallet = self.get_wallet(idx).await?;
-        let (status, result) = wallet.read().await.protest_swap(sig).await?;
+        let WalletProtestResult { status, result } = wallet.read().await.protest_swap(sig).await?;
         Ok((status, result.map(|(amount, _)| amount)))
     }
 

--- a/crates/bcr-wallet-api/src/pocket/debit.rs
+++ b/crates/bcr-wallet-api/src/pocket/debit.rs
@@ -71,10 +71,7 @@ pub trait DebitPocketApi: super::PocketApi {
         client: Arc<dyn ClowderMintConnector>,
         swap_config: SwapConfig,
         clowder_id: bitcoin::secp256k1::PublicKey,
-    ) -> Result<(
-        wire_mint::ProtestStatus,
-        Option<(cashu::Amount, Vec<cashu::PublicKey>)>,
-    )>;
+    ) -> Result<ProtestResult>;
     async fn check_pending_commitments(&self, tstamp: u64) -> Result<()>;
     async fn protest_swap(
         &self,
@@ -84,10 +81,13 @@ pub trait DebitPocketApi: super::PocketApi {
         beta_client: Arc<dyn ClowderMintConnector>,
         alpha_id: bitcoin::secp256k1::PublicKey,
         swap_config: SwapConfig,
-    ) -> Result<(
-        wire_common::ProtestStatus,
-        Option<(cashu::Amount, Vec<cashu::PublicKey>)>,
-    )>;
+    ) -> Result<ProtestResult>;
+}
+
+#[derive(Debug, Clone)]
+pub struct ProtestResult {
+    pub status: wire_common::ProtestStatus,
+    pub result: Option<(cashu::Amount, Vec<cashu::PublicKey>)>,
 }
 
 struct MeltReference {
@@ -787,10 +787,7 @@ impl DebitPocketApi for Pocket {
         client: Arc<dyn ClowderMintConnector>,
         swap_config: SwapConfig,
         clowder_id: bitcoin::secp256k1::PublicKey,
-    ) -> Result<(
-        wire_mint::ProtestStatus,
-        Option<(cashu::Amount, Vec<cashu::PublicKey>)>,
-    )> {
+    ) -> Result<ProtestResult> {
         let record = self.mdb.load_mint(qid).await?;
 
         let request = wire_mint::MintProtestRequest {
@@ -803,7 +800,7 @@ impl DebitPocketApi for Pocket {
         let response = client.post_protest_mint(request).await?;
 
         match response.status {
-            wire_mint::ProtestStatus::Resolved => {
+            wire_common::ProtestStatus::Resolved => {
                 let signatures = response.signatures.ok_or(Error::MintingError(
                     "protest resolved but no signatures returned".to_string(),
                 ))?;
@@ -821,11 +818,17 @@ impl DebitPocketApi for Pocket {
                 self.mdb.delete_mint(qid).await?;
 
                 tracing::info!("Protest resolved for {qid}, minted {amount}");
-                Ok((wire_mint::ProtestStatus::Resolved, Some((amount, ys))))
+                Ok(ProtestResult {
+                    status: wire_common::ProtestStatus::Resolved,
+                    result: Some((amount, ys)),
+                })
             }
-            wire_mint::ProtestStatus::Rabid => {
+            wire_common::ProtestStatus::Rabid => {
                 tracing::warn!("Protest for {qid} returned rabid");
-                Ok((wire_mint::ProtestStatus::Rabid, None))
+                Ok(ProtestResult {
+                    status: wire_common::ProtestStatus::Rabid,
+                    result: None,
+                })
             }
         }
     }
@@ -838,10 +841,7 @@ impl DebitPocketApi for Pocket {
         beta_client: Arc<dyn ClowderMintConnector>,
         alpha_id: bitcoin::secp256k1::PublicKey,
         swap_config: SwapConfig,
-    ) -> Result<(
-        wire_common::ProtestStatus,
-        Option<(cashu::Amount, Vec<cashu::PublicKey>)>,
-    )> {
+    ) -> Result<ProtestResult> {
         let record = self.pdb.load_commitment(commitment_sig).await?;
         let loaded_proofs = self.pdb.load_proofs(&record.inputs).await?;
         let ephemeral_keypair =
@@ -913,11 +913,17 @@ impl DebitPocketApi for Pocket {
                 self.pdb.delete_commitment(commitment_sig).await?;
 
                 tracing::info!("Swap protest resolved for {commitment_sig}, received {amount}");
-                Ok((wire_common::ProtestStatus::Resolved, Some((amount, ys))))
+                Ok(ProtestResult {
+                    status: wire_common::ProtestStatus::Resolved,
+                    result: Some((amount, ys)),
+                })
             }
             wire_common::ProtestStatus::Rabid => {
                 tracing::warn!("Swap protest for {commitment_sig} returned rabid");
-                Ok((wire_common::ProtestStatus::Rabid, None))
+                Ok(ProtestResult {
+                    status: wire_common::ProtestStatus::Rabid,
+                    result: None,
+                })
             }
         }
     }
@@ -1365,7 +1371,7 @@ mod tests {
             .times(1)
             .returning(move |_| {
                 Ok(wire_mint::MintProtestResponse {
-                    status: wire_mint::ProtestStatus::Resolved,
+                    status: wire_common::ProtestStatus::Resolved,
                     signatures: Some(blind_sigs.clone()),
                 })
             });
@@ -1414,7 +1420,7 @@ mod tests {
         let clowder_id = bitcoin::secp256k1::PublicKey::from_keypair(&clowder_keypair);
 
         let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
-        let (status, result) = pocket
+        let ProtestResult { status, result } = pocket
             .protest_mint(
                 uuid,
                 &k_infos,
@@ -1425,7 +1431,7 @@ mod tests {
             .await
             .expect("protest_mint resolved works");
 
-        assert!(matches!(status, wire_mint::ProtestStatus::Resolved));
+        assert!(matches!(status, wire_common::ProtestStatus::Resolved));
         let (minted_amount, ys) = result.expect("resolved should return proofs");
         assert_eq!(minted_amount, Amount::from(amount.to_sat()));
         assert!(!ys.is_empty());
@@ -1471,7 +1477,7 @@ mod tests {
             .times(1)
             .returning(move |_| {
                 Ok(wire_mint::MintProtestResponse {
-                    status: wire_mint::ProtestStatus::Rabid,
+                    status: wire_common::ProtestStatus::Rabid,
                     signatures: None,
                 })
             });
@@ -1487,7 +1493,7 @@ mod tests {
         let clowder_id = bitcoin::secp256k1::PublicKey::from_keypair(&clowder_keypair);
 
         let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
-        let (status, result) = pocket
+        let ProtestResult { status, result } = pocket
             .protest_mint(
                 uuid,
                 &k_infos,
@@ -1498,7 +1504,7 @@ mod tests {
             .await
             .expect("protest_mint rabid works");
 
-        assert!(matches!(status, wire_mint::ProtestStatus::Rabid));
+        assert!(matches!(status, wire_common::ProtestStatus::Rabid));
         assert!(result.is_none());
     }
 
@@ -1617,7 +1623,7 @@ mod tests {
         let clowder_id = secp256k1::PublicKey::from_keypair(&clowder_keypair);
 
         let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
-        let (status, result) = pocket
+        let ProtestResult { status, result } = pocket
             .protest_swap(
                 commitment_sig,
                 &k_infos,
@@ -1703,7 +1709,7 @@ mod tests {
         let clowder_id = secp256k1::PublicKey::from_keypair(&clowder_keypair);
 
         let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
-        let (status, result) = pocket
+        let ProtestResult { status, result } = pocket
             .protest_swap(
                 commitment_sig,
                 &k_infos,

--- a/crates/bcr-wallet-api/src/pocket/test_utils.rs
+++ b/crates/bcr-wallet-api/src/pocket/test_utils.rs
@@ -2,11 +2,15 @@ pub mod tests {
     use crate::RedemptionSummary;
     use crate::Result;
     use crate::external::mint::ClowderMintConnector;
-    use crate::pocket::{PocketApi, credit::CreditPocketApi, debit::DebitPocketApi};
+    use crate::pocket::{
+        PocketApi,
+        credit::CreditPocketApi,
+        debit::{DebitPocketApi, ProtestResult},
+    };
     use crate::types::{MeltSummary, MintSummary, SendSummary};
     use crate::wallet::types::SwapConfig;
     use async_trait::async_trait;
-    use bcr_common::wire::{melt as wire_melt, mint as wire_mint};
+    use bcr_common::wire::melt as wire_melt;
     use std::collections::HashMap;
     use std::sync::Arc;
     use uuid::Uuid;
@@ -139,7 +143,7 @@ pub mod tests {
                 client: Arc<dyn ClowderMintConnector>,
                 swap_config: SwapConfig,
                 clowder_id: bitcoin::secp256k1::PublicKey,
-            ) -> Result<(wire_mint::ProtestStatus, Option<(cashu::Amount, Vec<cashu::PublicKey>)>)>;
+            ) -> Result<ProtestResult>;
             async fn protest_swap(
                 &self,
                 commitment_sig: bitcoin::secp256k1::schnorr::Signature,
@@ -148,7 +152,7 @@ pub mod tests {
                 beta_client: Arc<dyn ClowderMintConnector>,
                 alpha_id: bitcoin::secp256k1::PublicKey,
                 swap_config: SwapConfig,
-            ) -> Result<(bcr_common::wire::common::ProtestStatus, Option<(cashu::Amount, Vec<cashu::PublicKey>)>)>;
+            ) -> Result<ProtestResult>;
         }
     }
 

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -1,11 +1,12 @@
 use crate::{
     ClowderMintConnector,
     error::{Error, Result},
+    pocket::debit::ProtestResult,
     types::{
         MintSummary, PAYMENT_TYPE_METADATA_KEY, PaymentSummary, TRANSACTION_STATUS_METADATA_KEY,
         WalletConfig,
     },
-    wallet::types::{PayReference, WalletPaymentType},
+    wallet::types::{PayReference, WalletPaymentType, WalletProtestResult},
 };
 use async_trait::async_trait;
 use bcr_common::{
@@ -17,7 +18,7 @@ use bcr_common::{
     wallet::Token,
     wire::{
         clowder::{self as wire_clowder},
-        common as wire_common, melt as wire_melt,
+        melt as wire_melt,
     },
 };
 use bcr_wallet_core::{
@@ -80,20 +81,11 @@ pub trait WalletApi: SendSync {
     async fn mint(&self, amount: bitcoin::Amount) -> Result<MintSummary>;
     async fn check_pending_mints(&self) -> Result<Vec<TransactionId>>;
     async fn check_pending_commitments(&self) -> Result<()>;
-    async fn protest_mint(
-        &self,
-        quote_id: Uuid,
-    ) -> Result<(
-        bcr_common::wire::mint::ProtestStatus,
-        Option<(Amount, Vec<cashu::PublicKey>)>,
-    )>;
+    async fn protest_mint(&self, quote_id: Uuid) -> Result<WalletProtestResult>;
     async fn protest_swap(
         &self,
         commitment_sig: bitcoin::secp256k1::schnorr::Signature,
-    ) -> Result<(
-        wire_common::ProtestStatus,
-        Option<(Amount, Vec<cashu::PublicKey>)>,
-    )>;
+    ) -> Result<WalletProtestResult>;
     async fn migrate_pockets_substitute(
         &mut self,
         substitute: Arc<dyn ClowderMintConnector>,
@@ -553,15 +545,9 @@ impl WalletApi for super::Wallet {
         self.debit.check_pending_commitments(now).await
     }
 
-    async fn protest_mint(
-        &self,
-        quote_id: Uuid,
-    ) -> Result<(
-        bcr_common::wire::mint::ProtestStatus,
-        Option<(Amount, Vec<cashu::PublicKey>)>,
-    )> {
+    async fn protest_mint(&self, quote_id: Uuid) -> Result<WalletProtestResult> {
         let keysets_info = self.get_wallet_mint_keyset_infos().await?;
-        let (status, result) = self
+        let ProtestResult { status, result } = self
             .debit
             .protest_mint(
                 quote_id,
@@ -599,16 +585,13 @@ impl WalletApi for super::Wallet {
             self.tx_repo.store_tx(tx).await?;
         }
 
-        Ok((status, result))
+        Ok(WalletProtestResult { status, result })
     }
 
     async fn protest_swap(
         &self,
         commitment_sig: bitcoin::secp256k1::schnorr::Signature,
-    ) -> Result<(
-        wire_common::ProtestStatus,
-        Option<(Amount, Vec<cashu::PublicKey>)>,
-    )> {
+    ) -> Result<WalletProtestResult> {
         let keysets_info = self.get_wallet_mint_keyset_infos().await?;
         let swap_config = self.swap_config();
 
@@ -620,7 +603,7 @@ impl WalletApi for super::Wallet {
             .ok_or(Error::BetaNotFound(beta_url))?
             .clone();
 
-        let (status, result) = self
+        let ProtestResult { status, result } = self
             .debit
             .protest_swap(
                 commitment_sig,
@@ -659,7 +642,7 @@ impl WalletApi for super::Wallet {
             self.tx_repo.store_tx(tx).await?;
         }
 
-        Ok((status, result))
+        Ok(WalletProtestResult { status, result })
     }
 
     async fn receive_proofs(

--- a/crates/bcr-wallet-api/src/wallet/types.rs
+++ b/crates/bcr-wallet-api/src/wallet/types.rs
@@ -1,4 +1,7 @@
-use bcr_common::cashu::{self, Amount, CurrencyUnit};
+use bcr_common::{
+    cashu::{self, Amount, CurrencyUnit},
+    wire::common as wire_common,
+};
 use bitcoin::secp256k1;
 use uuid::Uuid;
 
@@ -29,4 +32,10 @@ pub struct PayReference {
 pub struct WalletBalance {
     pub debit: cashu::Amount,
     pub credit: cashu::Amount,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletProtestResult {
+    pub status: wire_common::ProtestStatus,
+    pub result: Option<(cashu::Amount, Vec<cashu::PublicKey>)>,
 }

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -370,7 +370,7 @@ pub async fn cmd_protest_mint(
     ));
     push_break(&mut res);
     match status {
-        bcr_common::wire::mint::ProtestStatus::Resolved => match amount {
+        bcr_common::wire::common::ProtestStatus::Resolved => match amount {
             Some(amount) => {
                 res.push_str(&format!("Protest Resolved - Received {amount}"));
             }
@@ -378,7 +378,7 @@ pub async fn cmd_protest_mint(
                 res.push_str("Protest Resolved - Warning: no amount returned despite resolution");
             }
         },
-        bcr_common::wire::mint::ProtestStatus::Rabid => {
+        bcr_common::wire::common::ProtestStatus::Rabid => {
             res.push_str("Protest returned Rabid - mint declared rabid by betas");
         }
     }

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -850,11 +850,11 @@ pub enum ProtestStatus {
     Rabid,
 }
 
-impl From<bcr_common::wire::mint::ProtestStatus> for ProtestStatus {
-    fn from(s: bcr_common::wire::mint::ProtestStatus) -> Self {
+impl From<bcr_common::wire::common::ProtestStatus> for ProtestStatus {
+    fn from(s: bcr_common::wire::common::ProtestStatus) -> Self {
         match s {
-            bcr_common::wire::mint::ProtestStatus::Resolved => ProtestStatus::Resolved,
-            bcr_common::wire::mint::ProtestStatus::Rabid => ProtestStatus::Rabid,
+            bcr_common::wire::common::ProtestStatus::Resolved => ProtestStatus::Resolved,
+            bcr_common::wire::common::ProtestStatus::Rabid => ProtestStatus::Rabid,
         }
     }
 }

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -27,7 +27,7 @@
 
 use crate::api::*;
 use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
-use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
 use flutter_rust_bridge::{Handler, IntoIntoDart};
 
 // Section: boilerplate
@@ -4567,7 +4567,7 @@ mod io {
     use flutter_rust_bridge::for_generated::byteorder::{
         NativeEndian, ReadBytesExt, WriteBytesExt,
     };
-    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate
@@ -4606,7 +4606,7 @@ mod web {
     };
     use flutter_rust_bridge::for_generated::wasm_bindgen;
     use flutter_rust_bridge::for_generated::wasm_bindgen::prelude::*;
-    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate


### PR DESCRIPTION
In preparation for removing the `credit` part:

* Latest bcr-common
* Adapt to new clients structure
* A bit of cleanup