### PR TITLE
Implement Recovery of Stale Proofs after Failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     * Remove credit pocket
     * Remove unit from API
     * Remove the concept of redemption
+* Add job and endpoint for `wallet_recover_pending_stale_proofs`, which recovers proofs which are stale after a failed operation
 
 # 0.8.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bcr-common"
 version = "0.7.0"
-source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=39fe6fb9062624c21f87d21bfa0eef36b8ff745d#39fe6fb9062624c21f87d21bfa0eef36b8ff745d"
+source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=4b7146965201d44da325e7a653bbccbb26947f86#4b7146965201d44da325e7a653bbccbb26947f86"
 dependencies = [
  "async-trait",
  "bdk_wallet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ strip = "symbols"
 
 [workspace.dependencies]
 async-trait = {version = "0.1"}
-bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "39fe6fb9062624c21f87d21bfa0eef36b8ff745d"}
+bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "4b7146965201d44da325e7a653bbccbb26947f86"}
 bcr-wallet-core = {path = "./crates/bcr-wallet-core"}
 bcr-wallet-api = {path = "./crates/bcr-wallet-api"}
 bcr-wallet-persistence = {path = "./crates/bcr-wallet-persistence"}

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ In `pubspec.yaml`:
 ```yaml
    wallet_ffi:
      git:
-       url: git@github.com:BitcreditProtocol/wallet-ffi.git
-       ref: master
+       url: git@github.com:BitcreditProtocol/Wallet-Core.git
+       ref: vx.x.x
 ```
 
 The `ref` can either be a commit hash, a branch or a tag.

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -573,6 +573,26 @@ impl AppState {
         Ok(amount)
     }
 
+    // Recover pending stale proofs
+    pub async fn wallet_recover_pending_stale_proofs(&self, idx: usize) -> Result<cashu::Amount> {
+        tracing::debug!("wallet_recover_pending_stale_proofs({idx})");
+        let wallet = self.get_wallet(idx).await?;
+        let wlt = wallet.read().await;
+        // collect ys for pending transactions, so we don't recover proofs from open transactions
+
+        let pending_txs_ys: Vec<cashu::PublicKey> = wlt
+            .list_txs()
+            .await?
+            .into_iter()
+            .filter(wallet::util::tx_can_be_refreshed)
+            .flat_map(|tx| tx.ys)
+            .collect();
+
+        let recovered = wlt.recover_pending_stale_proofs(&pending_txs_ys).await?;
+
+        Ok(recovered)
+    }
+
     // Refreshes the state of all pending transactions of the given wallet
     pub async fn wallet_refresh_txs(&self, idx: usize) -> Result<usize> {
         tracing::debug!("wallet_refresh_txs({idx})");
@@ -673,6 +693,22 @@ impl AppState {
                     job_failed = true;
                     tracing::error!(
                         "Error running wallet_check_pending_commitments job for wallet {wallet_id}: {e}"
+                    );
+                }
+            }
+            match self
+                .wallet_recover_pending_stale_proofs(*wallet_id as usize)
+                .await
+            {
+                Ok(recovered) => {
+                    tracing::info!(
+                        "Recovered pending stale proofs for wallet {wallet_id}, recovered: {recovered}"
+                    );
+                }
+                Err(e) => {
+                    job_failed = true;
+                    tracing::error!(
+                        "Error running wallet_recover_pending_stale_proofs job for wallet {wallet_id}: {e}"
                     );
                 }
             }

--- a/crates/bcr-wallet-api/src/pocket/debit.rs
+++ b/crates/bcr-wallet-api/src/pocket/debit.rs
@@ -36,6 +36,15 @@ pub trait DebitPocketApi: super::PocketApi {
         client: Arc<dyn ClowderMintConnector>,
         swap_config: SwapConfig,
     ) -> Result<Amount>;
+    /// Attempt to recover proofs, which are pending, but not part of
+    /// a pending transaction
+    async fn recover_pending_stale_proofs(
+        &self,
+        pending_txs_ys: &[cashu::PublicKey],
+        keysets_info: &[KeySetInfo],
+        client: Arc<dyn ClowderMintConnector>,
+        swap_config: SwapConfig,
+    ) -> Result<Amount>;
     async fn prepare_onchain_melt(
         &self,
         invoice: wire_melt::OnchainInvoice,
@@ -555,6 +564,81 @@ impl DebitPocketApi for Pocket {
         Ok(reclaimed)
     }
 
+    async fn recover_pending_stale_proofs(
+        &self,
+        pending_txs_ys: &[cashu::PublicKey],
+        keysets_info: &[KeySetInfo],
+        client: Arc<dyn ClowderMintConnector>,
+        swap_config: SwapConfig,
+    ) -> Result<Amount> {
+        // remove pending transaction ys from pending proofs
+        let mut pendings = self.pdb.list_pending().await?;
+        let remove_set: HashSet<&cashu::PublicKey> = pending_txs_ys.iter().collect();
+        pendings.retain(|k, _| !remove_set.contains(k));
+
+        let req = cdk07::CheckStateRequest {
+            ys: pendings.keys().cloned().collect(),
+        };
+        let cdk07::CheckStateResponse { states } = client.post_check_state(req).await?;
+        let mut to_digest = HashMap::new();
+        for state in states.iter() {
+            match state.state {
+                cdk07::State::Spent => {
+                    tracing::warn!(
+                        "Pending Stale Proof returned as SPENT from Mint - not recovering and setting to SPENT"
+                    );
+                    if let Err(e) = self.pdb.mark_pending_as_spent(state.y).await {
+                        tracing::error!(
+                            "Error setting stale proof {} from Pending/PendingSpent to Spent: {e}",
+                            state.y
+                        )
+                    }
+                }
+                cdk07::State::Unspent => {
+                    // collect for digesting later
+                    if let Some(proof) = pendings.get(&state.y) {
+                        to_digest.insert(state.y, proof.to_owned());
+                    }
+                }
+                cdk07::State::Pending => {
+                    tracing::warn!(
+                        "Pending Stale Proof returned as PENDING from Mint - not recovering"
+                    );
+                }
+                cdk07::State::Reserved => {
+                    tracing::warn!(
+                        "Pending Stale Proof returned as RESERVED from Mint - not recovering"
+                    );
+                }
+                cdk07::State::PendingSpent => {
+                    tracing::warn!(
+                        "Pending Stale Proof returned as PENDINGSPENT from Mint - not recovering"
+                    );
+                }
+            }
+        }
+        if to_digest.is_empty() {
+            return Ok(Amount::ZERO);
+        }
+        let active_keys = self.find_active_keyset(keysets_info, &client).await?;
+        // attempt to recover the proofs collected for digesting
+        let to_digest_ys: Vec<cashu::PublicKey> = to_digest.keys().cloned().collect();
+        let (recovered, _) = self
+            .digest_proofs(client, active_keys, to_digest, swap_config)
+            .await?;
+        // if recovery successful, set previous proofs to spent
+        for y in to_digest_ys.into_iter() {
+            if let Err(e) = self.pdb.mark_pending_as_spent(y).await {
+                tracing::error!(
+                    "Error setting recovered stale proof {} from Pending/PendingSpent to Spent: {e}",
+                    y
+                )
+            }
+        }
+
+        Ok(recovered)
+    }
+
     async fn prepare_onchain_melt(
         &self,
         invoice: wire_melt::OnchainInvoice,
@@ -1056,6 +1140,89 @@ mod tests {
             .await
             .expect("reclaim works");
         assert_eq!(reclaimed, Amount::from(24u64));
+    }
+
+    #[tokio::test]
+    async fn debit_recover_pending_stale_proofs() {
+        let (info, keyset) = core_tests::generate_random_ecash_keyset();
+        let kid = info.id;
+        let k_infos = vec![KeySetInfo::from(info)];
+        let amounts = [Amount::from(8u64), Amount::from(16u64)];
+        let proofs = core_tests::generate_random_ecash_proofs(&keyset, &amounts);
+
+        // we pretend that the second proof belongs to a pending transaction we don't want to recover
+        let pending_tx_y = proofs[1].clone().y().unwrap();
+
+        let mdb = MockMintMeltRepository::new();
+        let mut pdb = MockPocketRepository::new();
+        let mut connector = MockMintConnector::new();
+        let cloned_keyset = keyset.clone();
+
+        connector
+            .expect_get_mint_keyset()
+            .times(1)
+            .with(eq(kid))
+            .returning(move |_| Ok(KeySet::from(cloned_keyset.clone())));
+        connector
+            .expect_post_check_state()
+            .times(1)
+            .returning(move |request| {
+                let states = request
+                    .ys
+                    .iter()
+                    .map(|y| cdk07::ProofState {
+                        y: *y,
+                        state: cdk07::State::Unspent,
+                        witness: None,
+                    })
+                    .collect();
+                let response = cdk07::CheckStateResponse { states };
+                Ok(response)
+            });
+        let proofs_clone = proofs.clone();
+        pdb.expect_list_pending().times(1).returning(move || {
+            let mut map = HashMap::new();
+            map.insert(proofs_clone[0].y().unwrap(), proofs_clone[0].clone());
+            map.insert(proofs_clone[1].y().unwrap(), proofs_clone[1].clone());
+            Ok(map)
+        });
+        pdb.expect_counter()
+            .times(1)
+            .with(eq(kid))
+            .returning(|_| Ok(0));
+        pdb.expect_increment_counter()
+            .times(1)
+            .with(eq(kid), eq(0), eq(1))
+            .returning(|_, _, _| Ok(()));
+        let proofs_clone_mark = proofs.clone();
+        pdb.expect_mark_pending_as_spent()
+            .times(1)
+            .returning(move |_| Ok(proofs_clone_mark[0].clone()));
+        setup_commitment_mocks(&mut connector, &mut pdb);
+        connector
+            .expect_post_swap_committed()
+            .times(1)
+            .returning(move |request| {
+                let amounts = request.outputs.iter().map(|b| b.amount).collect::<Vec<_>>();
+                let signatures = core_tests::generate_ecash_signatures(&keyset, &amounts);
+                Ok(bcr_common::wire::swap::SwapResponse { signatures })
+            });
+        pdb.expect_store_new().times(1).returning(|p| {
+            let y = p.y().expect("Hash to curve should not fail");
+            Ok(y)
+        });
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+        let recovered = pocket
+            .recover_pending_stale_proofs(
+                &[pending_tx_y],
+                &k_infos,
+                Arc::new(connector),
+                test_swap_config(),
+            )
+            .await
+            .expect("recover pending stale proofs works");
+        assert_eq!(recovered, Amount::from(8u64));
     }
 
     #[tokio::test]

--- a/crates/bcr-wallet-api/src/pocket/test_utils.rs
+++ b/crates/bcr-wallet-api/src/pocket/test_utils.rs
@@ -105,6 +105,13 @@ pub mod tests {
                 client: Arc<dyn ClowderMintConnector>,
                 swap_config: SwapConfig,
             ) -> Result<Amount>;
+            async fn recover_pending_stale_proofs(
+                &self,
+                pending_txs_ys: &[cashu::PublicKey],
+                keysets_info: &[KeySetInfo],
+                client: Arc<dyn ClowderMintConnector>,
+                swap_config: SwapConfig,
+            ) -> Result<Amount>;
             async fn prepare_onchain_melt(
                 &self,
                 invoice: wire_melt::OnchainInvoice,

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -261,6 +261,23 @@ impl Wallet {
         Ok(updated)
     }
 
+    pub async fn recover_pending_stale_proofs(
+        &self,
+        pending_txs_ys: &[cashu::PublicKey],
+    ) -> Result<Amount> {
+        let infos = self.get_wallet_mint_keyset_infos().await?;
+        let recovered = self
+            .debit
+            .recover_pending_stale_proofs(
+                pending_txs_ys,
+                &infos,
+                self.client.clone(),
+                self.swap_config(),
+            )
+            .await?;
+        Ok(recovered)
+    }
+
     pub async fn reclaim_tx(&self, tx_id: TransactionId) -> Result<Amount> {
         let infos = self.get_wallet_mint_keyset_infos().await?;
         self.refresh_tx(tx_id).await?;
@@ -1257,5 +1274,24 @@ mod tests {
 
         let wlt = wallet(ctx);
         let _ = wlt.mint(bitcoin::Amount::from_sat(1000)).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_recover_pending_stale_proofs() {
+        let mut ctx = wallet_ctx();
+
+        ctx.client
+            .expect_get_mint_keysets()
+            .times(1)
+            .returning(|| Ok(cashu::KeysetResponse { keysets: vec![] }));
+
+        ctx.debit
+            .expect_recover_pending_stale_proofs()
+            .times(1)
+            .returning(|_, _, _, _| Ok(Amount::from(10u64)));
+
+        let wlt = wallet(ctx);
+        let recovered = wlt.recover_pending_stale_proofs(&[]).await.unwrap();
+        assert_eq!(recovered, Amount::from(10u64));
     }
 }

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -262,6 +262,18 @@ pub async fn cmd_reclaim(
     Ok(res)
 }
 
+pub async fn cmd_recover_stale(app_state: &AppState, name: &str, id: usize) -> Result<String> {
+    let mut res = String::new();
+    let recovered = app_state.wallet_recover_pending_stale_proofs(id).await?;
+
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!(
+        "Recover Stale Proofs Funds for {name} - Wallet ID: {id} - Recovered: {recovered}.\n"
+    ));
+    Ok(res)
+}
+
 pub async fn cmd_melt(
     app_state: &AppState,
     name: &str,

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -61,6 +61,8 @@ enum Commands {
     },
     #[command(name = "reclaim")]
     Reclaim { id: usize, tx_id: String },
+    #[command(name = "recover_stale")]
+    RecoverStale { id: usize },
     #[command(name = "melt")]
     Melt {
         id: usize,
@@ -206,6 +208,13 @@ async fn main() -> Result<()> {
                 "Reclaim for {}: {}",
                 cli.wallet,
                 command::cmd_reclaim(&app_state, &cli.wallet, id, &tx_id).await?
+            );
+        }
+        Commands::RecoverStale { id } => {
+            info!(
+                "Recover Stale proofs for {}: {}",
+                cli.wallet,
+                command::cmd_recover_stale(&app_state, &cli.wallet, id).await?
             );
         }
         Commands::Melt {

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -341,6 +341,19 @@ pub async fn wallet_reclaim_transaction(
 }
 
 #[frb]
+pub async fn wallet_recover_pending_stale_proofs(
+    req: WalletRequest,
+) -> Result<WalletRecoverStaleTransactionResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let recovered = app_state
+        .wallet_recover_pending_stale_proofs(req.wallet_id)
+        .await?;
+    Ok(WalletRecoverStaleTransactionResponse {
+        amount: u64::from(recovered),
+    })
+}
+
+#[frb]
 pub async fn wallet_prepare_melt(
     req: WalletPrepareMeltRequest,
 ) -> Result<WalletPreparePaymentResponse, WalletError> {
@@ -865,6 +878,11 @@ pub struct WalletReclaimTransactionRequest {
 
 #[derive(Debug, Clone)]
 pub struct WalletReclaimTransactionResponse {
+    pub amount: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletRecoverStaleTransactionResponse {
     pub amount: u64,
 }
 

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1407724778;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 526008345;
 
 // Section: executor
 
@@ -1490,6 +1490,43 @@ fn wire__crate__api__wallet_reclaim_transaction_impl(
         },
     )
 }
+fn wire__crate__api__wallet_recover_pending_stale_proofs_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_recover_pending_stale_proofs",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::WalletRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::wallet_recover_pending_stale_proofs(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet_refresh_transaction_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2382,6 +2419,14 @@ impl SseDecode for crate::api::WalletReclaimTransactionResponse {
     }
 }
 
+impl SseDecode for crate::api::WalletRecoverStaleTransactionResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_amount = <u64>::sse_decode(deserializer);
+        return crate::api::WalletRecoverStaleTransactionResponse { amount: var_amount };
+    }
+}
+
 impl SseDecode for crate::api::WalletRefreshTransactionRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2539,9 +2584,15 @@ fn pde_ffi_dispatcher_primary_impl(
         39 => wire__crate__api__wallet_protest_swap_impl(port, ptr, rust_vec_len, data_len),
         40 => wire__crate__api__wallet_receive_impl(port, ptr, rust_vec_len, data_len),
         41 => wire__crate__api__wallet_reclaim_transaction_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__wallet_recover_pending_stale_proofs_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        43 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3451,6 +3502,23 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletReclaimTransactionRespo
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletRecoverStaleTransactionResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.amount.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletRecoverStaleTransactionResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletRecoverStaleTransactionResponse>
+    for crate::api::WalletRecoverStaleTransactionResponse
+{
+    fn into_into_dart(self) -> crate::api::WalletRecoverStaleTransactionResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::WalletRefreshTransactionRequest {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -4214,6 +4282,13 @@ impl SseEncode for crate::api::WalletReclaimTransactionRequest {
 }
 
 impl SseEncode for crate::api::WalletReclaimTransactionResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u64>::sse_encode(self.amount, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletRecoverStaleTransactionResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.amount, serializer);

--- a/crates/bcr-wallet-persistence/src/lib.rs
+++ b/crates/bcr-wallet-persistence/src/lib.rs
@@ -41,21 +41,20 @@ pub trait PocketRepository: SendSync {
     async fn list_unspent(&self) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>>;
     async fn list_pending(&self) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>>;
     async fn list_reserved(&self) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>>;
+    async fn list_spent(&self) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>>;
     async fn list_all(&self) -> Result<Vec<cdk01::PublicKey>>;
     async fn mark_as_pendingspent(&self, y: cdk01::PublicKey) -> Result<cdk00::Proof>;
+    async fn mark_pending_as_spent(&self, y: cdk01::PublicKey) -> Result<cdk00::Proof>;
 
     async fn counter(&self, kid: cashu::Id) -> Result<u32>;
     async fn increment_counter(&self, kid: cashu::Id, old: u32, increment: u32) -> Result<()>;
 
     async fn store_commitment(&self, record: SwapCommitmentRecord) -> Result<()>;
-
     async fn load_commitment(
         &self,
         commitment: secp256k1::schnorr::Signature,
     ) -> Result<SwapCommitmentRecord>;
-
     async fn delete_commitment(&self, commitment: secp256k1::schnorr::Signature) -> Result<()>;
-
     async fn list_commitments(&self) -> Result<Vec<SwapCommitmentRecord>>;
 }
 

--- a/crates/bcr-wallet-persistence/src/redb/pocket.rs
+++ b/crates/bcr-wallet-persistence/src/redb/pocket.rs
@@ -611,6 +611,18 @@ impl PocketRepository for PocketDB {
             .collect())
     }
 
+    async fn list_spent(&self) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>> {
+        let db_clone = self.db.clone();
+        let table = self.proof_table;
+        let list =
+            spawn_blocking(move || Self::list_sync(db_clone, table, Some(cdk07::State::Spent)))
+                .await??;
+        Ok(list
+            .into_iter()
+            .map(|entry| (entry.y, cdk00::Proof::from(entry)))
+            .collect())
+    }
+
     async fn list_pending(&self) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>> {
         let db_clone = self.db.clone();
         let db_clone_two = self.db.clone();
@@ -662,6 +674,22 @@ impl PocketRepository for PocketDB {
                 y,
                 &[cdk07::State::Unspent],
                 cdk07::State::PendingSpent,
+            )
+        })
+        .await??;
+        Ok(proof.into())
+    }
+
+    async fn mark_pending_as_spent(&self, y: cdk01::PublicKey) -> Result<cdk00::Proof> {
+        let db_clone = self.db.clone();
+        let table = self.proof_table;
+        let proof = spawn_blocking(move || {
+            Self::update_entry_state_sync(
+                db_clone,
+                table,
+                y,
+                &[cdk07::State::Pending, cdk07::State::PendingSpent],
+                cdk07::State::Spent,
             )
         })
         .await??;
@@ -828,6 +856,30 @@ mod tests {
 
         let unspent = repo.list_unspent().await.unwrap();
         assert!(!unspent.contains_key(&y));
+    }
+
+    #[tokio::test]
+    async fn test_mark_as_spent() {
+        let repo = get_db(&wallet_id(), CurrencyUnit::Sat);
+
+        let y = repo.store_new(test_proof()).await.unwrap();
+        let _proof = repo
+            .mark_as_pendingspent(y)
+            .await
+            .expect("mark_as_pendingspent works");
+        let _proof = repo
+            .mark_pending_as_spent(y)
+            .await
+            .expect("mark_pending_as_spent works");
+
+        let (_loaded, state) = repo.load_proof(y).await.unwrap();
+        assert_eq!(state, cdk07::State::Spent);
+
+        let pending = repo.list_pending().await.unwrap();
+        assert!(!pending.contains_key(&y));
+
+        let spent = repo.list_spent().await.unwrap();
+        assert!(spent.contains_key(&y));
     }
 
     #[tokio::test]

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `get_app_state`, `init_logging`, `init_panic_hook`, `new`, `reset_runtime`, `start_jobs`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `WalletCleanLocalDbResponse`, `WalletRuntime`, `WalletsNamesResponse`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
 
 Future<void> initWalletFfi({required WalletFfiConfig conf}) =>
     RustLib.instance.api.crateApiInitWalletFfi(conf: conf);
@@ -54,6 +54,10 @@ Future<WalletRefreshTransactionsResponse> walletRefreshTransactions({
 Future<WalletReclaimTransactionResponse> walletReclaimTransaction({
   required WalletReclaimTransactionRequest req,
 }) => RustLib.instance.api.crateApiWalletReclaimTransaction(req: req);
+
+Future<WalletRecoverStaleTransactionResponse> walletRecoverPendingStaleProofs({
+  required WalletRequest req,
+}) => RustLib.instance.api.crateApiWalletRecoverPendingStaleProofs(req: req);
 
 Future<WalletPreparePaymentResponse> walletPrepareMelt({
   required WalletPrepareMeltRequest req,
@@ -1073,6 +1077,22 @@ class WalletReclaimTransactionResponse {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is WalletReclaimTransactionResponse &&
+          runtimeType == other.runtimeType &&
+          amount == other.amount;
+}
+
+class WalletRecoverStaleTransactionResponse {
+  final BigInt amount;
+
+  const WalletRecoverStaleTransactionResponse({required this.amount});
+
+  @override
+  int get hashCode => amount.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletRecoverStaleTransactionResponse &&
           runtimeType == other.runtimeType &&
           amount == other.amount;
 }

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -66,7 +66,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1407724778;
+  int get rustContentHash => 526008345;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -212,6 +212,9 @@ abstract class RustLibApi extends BaseApi {
   Future<WalletReclaimTransactionResponse> crateApiWalletReclaimTransaction({
     required WalletReclaimTransactionRequest req,
   });
+
+  Future<WalletRecoverStaleTransactionResponse>
+  crateApiWalletRecoverPendingStaleProofs({required WalletRequest req});
 
   Future<WalletRefreshTransactionResponse> crateApiWalletRefreshTransaction({
     required WalletRefreshTransactionRequest req,
@@ -1511,6 +1514,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<WalletRecoverStaleTransactionResponse>
+  crateApiWalletRecoverPendingStaleProofs({required WalletRequest req}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_request(req, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 42,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_wallet_recover_stale_transaction_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletRecoverPendingStaleProofsConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletRecoverPendingStaleProofsConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_recover_pending_stale_proofs",
+        argNames: ["req"],
+      );
+
+  @override
   Future<WalletRefreshTransactionResponse> crateApiWalletRefreshTransaction({
     required WalletRefreshTransactionRequest req,
   }) {
@@ -1525,7 +1561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1558,7 +1594,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1588,7 +1624,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -2457,6 +2493,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return WalletReclaimTransactionResponse(amount: dco_decode_u_64(arr[0]));
+  }
+
+  @protected
+  WalletRecoverStaleTransactionResponse
+  dco_decode_wallet_recover_stale_transaction_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return WalletRecoverStaleTransactionResponse(
+      amount: dco_decode_u_64(arr[0]),
+    );
   }
 
   @protected
@@ -3403,6 +3451,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletRecoverStaleTransactionResponse
+  sse_decode_wallet_recover_stale_transaction_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_amount = sse_decode_u_64(deserializer);
+    return WalletRecoverStaleTransactionResponse(amount: var_amount);
+  }
+
+  @protected
   WalletRefreshTransactionRequest sse_decode_wallet_refresh_transaction_request(
     SseDeserializer deserializer,
   ) {
@@ -4302,6 +4360,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_wallet_reclaim_transaction_response(
     WalletReclaimTransactionResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_64(self.amount, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_recover_stale_transaction_response(
+    WalletRecoverStaleTransactionResponse self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -338,6 +338,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_wallet_reclaim_transaction_response(dynamic raw);
 
   @protected
+  WalletRecoverStaleTransactionResponse
+  dco_decode_wallet_recover_stale_transaction_response(dynamic raw);
+
+  @protected
   WalletRefreshTransactionRequest dco_decode_wallet_refresh_transaction_request(
     dynamic raw,
   );
@@ -745,6 +749,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletReclaimTransactionResponse
   sse_decode_wallet_reclaim_transaction_response(SseDeserializer deserializer);
+
+  @protected
+  WalletRecoverStaleTransactionResponse
+  sse_decode_wallet_recover_stale_transaction_response(
+    SseDeserializer deserializer,
+  );
 
   @protected
   WalletRefreshTransactionRequest sse_decode_wallet_refresh_transaction_request(
@@ -1252,6 +1262,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_reclaim_transaction_response(
     WalletReclaimTransactionResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_recover_stale_transaction_response(
+    WalletRecoverStaleTransactionResponse self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -340,6 +340,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_wallet_reclaim_transaction_response(dynamic raw);
 
   @protected
+  WalletRecoverStaleTransactionResponse
+  dco_decode_wallet_recover_stale_transaction_response(dynamic raw);
+
+  @protected
   WalletRefreshTransactionRequest dco_decode_wallet_refresh_transaction_request(
     dynamic raw,
   );
@@ -747,6 +751,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletReclaimTransactionResponse
   sse_decode_wallet_reclaim_transaction_response(SseDeserializer deserializer);
+
+  @protected
+  WalletRecoverStaleTransactionResponse
+  sse_decode_wallet_recover_stale_transaction_response(
+    SseDeserializer deserializer,
+  );
 
   @protected
   WalletRefreshTransactionRequest sse_decode_wallet_refresh_transaction_request(
@@ -1254,6 +1264,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_reclaim_transaction_response(
     WalletReclaimTransactionResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_recover_stale_transaction_response(
+    WalletRecoverStaleTransactionResponse self,
     SseSerializer serializer,
   );
 


### PR DESCRIPTION
Add job and endpoint for `wallet_recover_pending_stale_proofs`, which recovers proofs which are stale after a failed operation