### PR TITLE
Endpoint to show full balance, Dev Mode Endpoint to see funds bound by keysets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
     * Remove the concept of redemption
 * Add job and endpoint for `wallet_recover_pending_stale_proofs`, which recovers proofs which are stale after a failed operation
 * Remove cdk MintConnector
+* Add `dev_mode` field in config
+* Add Endpoint `wallet_dev_mode_get_detailed_balance` that returns a listing of funds for each keyset with the expiry of the keyset
+* Return `debit`, `credit` and `total` from balance
 
 # 0.8.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bcr-common"
 version = "0.7.0"
-source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=4430a779c606603f558673a05134e8188de4676f#4430a779c606603f558673a05134e8188de4676f"
+source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=0597f3b4b0c1f6c6a5c2f5d3caa434c571742379#0597f3b4b0c1f6c6a5c2f5d3caa434c571742379"
 dependencies = [
  "async-trait",
  "bdk_wallet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ strip = "symbols"
 
 [workspace.dependencies]
 async-trait = {version = "0.1"}
-bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "4430a779c606603f558673a05134e8188de4676f"}
+bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "0597f3b4b0c1f6c6a5c2f5d3caa434c571742379"}
 bcr-wallet-core = {path = "./crates/bcr-wallet-core"}
 bcr-wallet-api = {path = "./crates/bcr-wallet-api"}
 bcr-wallet-persistence = {path = "./crates/bcr-wallet-persistence"}

--- a/crates/bcr-wallet-api/src/config.rs
+++ b/crates/bcr-wallet-api/src/config.rs
@@ -15,6 +15,7 @@ pub struct AppStateConfig {
     pub mnemonic: bip39::Mnemonic,
     pub swap_expiry: chrono::TimeDelta,
     pub default_mint_url: MintUrl,
+    pub dev_mode: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/bcr-wallet-api/src/error.rs
+++ b/crates/bcr-wallet-api/src/error.rs
@@ -128,4 +128,6 @@ pub enum Error {
     Database(#[from] bcr_wallet_persistence::error::Error),
     #[error("External Error: {0}")]
     External(#[from] crate::external::Error),
+    #[error("Dev Mode is disabled")]
+    NoDevMode,
 }

--- a/crates/bcr-wallet-api/src/external/mint.rs
+++ b/crates/bcr-wallet-api/src/external/mint.rs
@@ -295,14 +295,14 @@ impl ClowderMintConnector for HttpClientExt {
         &self,
         alpha_id: secp256k1::PublicKey,
     ) -> MintResult<Vec<cashu::KeySet>> {
-        debug!("Clowder client call to get_alpha_keysets");
+        debug!("Clowder client call to get_alpha_keysets for {alpha_id}");
         let response = self.main.get_active_keysets(alpha_id).await?;
         Ok(response.keysets)
     }
 
     /// Is Alpha Offline
     async fn get_alpha_offline(&self, alpha_id: secp256k1::PublicKey) -> MintResult<bool> {
-        debug!("Clowder client call to get_alpha_offline");
+        debug!("Clowder client call to get_alpha_offline for {alpha_id}");
         let response = self.main.get_offline(alpha_id).await?;
         Ok(response.offline)
     }
@@ -384,7 +384,7 @@ impl ClowderMintConnector for HttpClientExt {
         &self,
         origin_mint_url: cashu::MintUrl,
     ) -> MintResult<ConnectedMintsResponse> {
-        debug!("Clowder client call to post_clowder_path");
+        debug!("Clowder client call to post_clowder_path for mint url {origin_mint_url}");
         self.main
             .post_path(convert_mint_url(origin_mint_url)?)
             .await
@@ -399,7 +399,7 @@ impl ClowderMintConnector for HttpClientExt {
     ) -> Result<SwapCommitmentResult> {
         let url = self
             .url
-            .join("v1/core/swap/commit")
+            .join(MintClient::SWAPCOMMIT_EP_V1)
             .expect("post_swap_commitment url error");
         debug!("HTTP call to post_swap_commitment on {url}");
         post_swap_commitment_inner(
@@ -419,7 +419,7 @@ impl ClowderMintConnector for HttpClientExt {
     ) -> Result<wire_swap::SwapResponse> {
         let url = self
             .url
-            .join("v1/core/swap")
+            .join(MintClient::SWAP_EP_V1)
             .expect("post_swap_committed url error");
         debug!("HTTP call to post_swap_committed on {url}");
         let res = self
@@ -644,14 +644,14 @@ impl ClowderMintConnector for SentinelClient {
         &self,
         alpha_id: secp256k1::PublicKey,
     ) -> MintResult<Vec<cashu::KeySet>> {
-        debug!("Clowder client call to get_alpha_keysets on sentinel");
+        debug!("Clowder client call to get_alpha_keysets on sentinel for {alpha_id}");
         let response = self.main.get_active_keysets(alpha_id).await?;
         Ok(response.keysets)
     }
 
     /// Is Alpha Offline
     async fn get_alpha_offline(&self, alpha_id: secp256k1::PublicKey) -> MintResult<bool> {
-        debug!("Clowder client call to get_alpha_offline on sentinel");
+        debug!("Clowder client call to get_alpha_offline on sentinel for {alpha_id}");
         let response = self.main.get_offline(alpha_id).await?;
         Ok(response.offline)
     }
@@ -727,7 +727,9 @@ impl ClowderMintConnector for SentinelClient {
         &self,
         origin_mint_url: cashu::MintUrl,
     ) -> MintResult<ConnectedMintsResponse> {
-        debug!("Clowder client call to post_clowder_path on sentinel");
+        debug!(
+            "Clowder client call to post_clowder_path on sentinel for mint url {origin_mint_url}"
+        );
         self.main
             .post_path(convert_mint_url(origin_mint_url)?)
             .await
@@ -742,7 +744,7 @@ impl ClowderMintConnector for SentinelClient {
     ) -> Result<SwapCommitmentResult> {
         let url = self
             .url
-            .join("v1/core/swap/commit")
+            .join(MintClient::SWAPCOMMIT_EP_V1)
             .expect("post_swap_commitment url error");
         debug!("HTTP call to post_swap_commitment on sentinel {url}");
         post_swap_commitment_inner(
@@ -762,7 +764,7 @@ impl ClowderMintConnector for SentinelClient {
     ) -> Result<wire_swap::SwapResponse> {
         let url = self
             .url
-            .join("v1/core/swap")
+            .join(MintClient::SWAP_EP_V1)
             .expect("post_swap_committed url error");
         debug!("HTTP call to post_swap_committed on sentinel {url}");
         let response = self
@@ -817,7 +819,7 @@ impl ClowderMintConnector for SentinelClient {
     ) -> Result<MeltQuoteResult> {
         let url = self
             .url
-            .join("v1/melt/quote/onchain")
+            .join(MintClient::MELTQUOTE_ONCHAIN_EP_V1)
             .expect("melt_quote_onchain url error");
         debug!("HTTP call on sentinel to melt_quote_onchain on {url}");
         post_melt_quote_onchain_inner(&self.secondary, url, inputs, address, amount, alpha_pk).await
@@ -829,7 +831,7 @@ impl ClowderMintConnector for SentinelClient {
     ) -> Result<wire_melt::MeltOnchainResponse> {
         let url = self
             .url
-            .join("v1/melt/onchain")
+            .join(MintClient::MELT_ONCHAIN_EP_V1)
             .expect("melt_onchain url error");
         debug!("HTTP call on sentinel to melt_onchain on {url}");
 

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::config::AppStateConfig;
 use crate::external::mint::{ClowderMintConnector, HttpClientExt};
-use crate::wallet::types::{WalletBalance, WalletProtestResult};
+use crate::wallet::types::{WalletBalance, WalletDetailedBalanceEntry, WalletProtestResult};
 use crate::{config::NostrConfig, wallet::api::WalletApi};
 use bcr_common::cdk_common::wallet::Transaction;
 use bcr_common::{
@@ -652,6 +652,20 @@ impl AppState {
         let wallet = self.get_wallet(idx).await?;
         let updated = wallet.read().await.refresh_tx(tx_id).await?;
         Ok(updated)
+    }
+
+    //////////////////////////////////////////////////// Wallet Dev Mode Calls
+    pub async fn wallet_dev_mode_detailed_balance(
+        &self,
+        idx: usize,
+    ) -> Result<Vec<WalletDetailedBalanceEntry>> {
+        tracing::debug!("dev_mode_detailed_wallet_balance({idx})");
+        if !self.cfg.dev_mode {
+            return Err(Error::NoDevMode);
+        }
+
+        let wallet = self.get_wallet(idx).await?;
+        wallet.read().await.dev_mode_detailed_balance().await
     }
 
     //////////////////////////////////////////////////// General App-Level calls

--- a/crates/bcr-wallet-api/src/pocket/debit.rs
+++ b/crates/bcr-wallet-api/src/pocket/debit.rs
@@ -325,10 +325,40 @@ impl super::PocketApi for Pocket {
         self.unit.clone()
     }
 
-    async fn balance(&self) -> Result<cashu::Amount> {
+    async fn balance(&self, keysets_info: &[KeySetInfo]) -> Result<PocketBalance> {
         let proofs: Vec<Proof> = self.pdb.list_unspent().await?.into_values().collect();
-        let total = proofs.total_amount()?;
-        Ok(total)
+        let mut debit = Amount::ZERO;
+        let mut credit = Amount::ZERO;
+
+        let infos = collect_keyset_infos_from_proofs(proofs.iter(), keysets_info)?;
+        let start_of_today = chrono::Utc::now()
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .expect("valid date")
+            .and_utc()
+            .timestamp() as u64;
+
+        for proof in proofs {
+            let info = infos
+                .get(&proof.keyset_id)
+                .ok_or(Error::UnknownKeysetId(proof.keyset_id))?;
+
+            // no final expiry -> debit
+            // final expiry before today -> debit
+            // final expiry today, or after -> credit
+            let is_credit = match info.final_expiry {
+                Some(expiry) => expiry >= start_of_today,
+                None => false,
+            };
+
+            if is_credit {
+                credit += proof.amount;
+            } else {
+                debit += proof.amount;
+            }
+        }
+
+        Ok(PocketBalance { debit, credit })
     }
 
     async fn receive_proofs(
@@ -537,6 +567,29 @@ impl super::PocketApi for Pocket {
         }
 
         Ok(swapped_proofs)
+    }
+
+    async fn dev_mode_detailed_balance(
+        &self,
+        keysets_info: &[KeySetInfo],
+    ) -> Result<HashMap<cashu::Id, (Option<u64>, Amount)>> {
+        let proofs: Vec<Proof> = self.pdb.list_unspent().await?.into_values().collect();
+        let infos = collect_keyset_infos_from_proofs(proofs.iter(), keysets_info)?;
+
+        let mut balances: HashMap<cashu::Id, (Option<u64>, Amount)> = HashMap::new();
+
+        for proof in proofs {
+            let kid = proof.keyset_id;
+            let info = infos.get(&kid).ok_or(Error::UnknownKeysetId(kid))?;
+
+            let entry = balances
+                .entry(kid)
+                .or_insert((info.final_expiry, Amount::ZERO));
+
+            entry.1 += proof.amount;
+        }
+
+        Ok(balances)
     }
 }
 
@@ -1092,6 +1145,136 @@ mod tests {
         let mnemonic = bip39::Mnemonic::generate(12).unwrap();
         let seed = mnemonic.to_seed("");
         super::Pocket::new(unit, pdb, mdb, seed)
+    }
+
+    #[tokio::test]
+    async fn debit_balance() {
+        let (info, keyset) = core_tests::generate_random_ecash_keyset();
+        let k_infos = vec![KeySetInfo::from(info)];
+        let amounts = [Amount::from(8u64), Amount::from(16u64)];
+        let proofs = core_tests::generate_random_ecash_proofs(&keyset, &amounts);
+        let mut pdb = MockPocketRepository::new();
+        let mdb = MockMintMeltRepository::new();
+
+        let proofs_clone = proofs.clone();
+        pdb.expect_list_unspent().times(1).returning(move || {
+            let mut map = HashMap::new();
+            map.insert(proofs_clone[0].y().unwrap(), proofs_clone[0].clone());
+            map.insert(proofs_clone[1].y().unwrap(), proofs_clone[1].clone());
+            Ok(map)
+        });
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+        let balance = pocket.balance(&k_infos).await.expect("balance works");
+        assert_eq!(balance.credit, Amount::ZERO);
+        assert_eq!(balance.debit, Amount::from(24u64))
+    }
+
+    #[tokio::test]
+    async fn credit_balance_keyset_expiring_in_future() {
+        let (info, keyset) = core_tests::generate_random_ecash_keyset();
+        let mut k_info = KeySetInfo::from(info);
+        k_info.final_expiry =
+            Some((chrono::Utc::now() + chrono::TimeDelta::days(1)).timestamp() as u64);
+
+        let k_infos = vec![k_info];
+        let amounts = [Amount::from(8u64), Amount::from(16u64)];
+        let proofs = core_tests::generate_random_ecash_proofs(&keyset, &amounts);
+        let mut pdb = MockPocketRepository::new();
+        let mdb = MockMintMeltRepository::new();
+
+        let proofs_clone = proofs.clone();
+        pdb.expect_list_unspent().times(1).returning(move || {
+            let mut map = HashMap::new();
+            map.insert(proofs_clone[0].y().unwrap(), proofs_clone[0].clone());
+            map.insert(proofs_clone[1].y().unwrap(), proofs_clone[1].clone());
+            Ok(map)
+        });
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+        let balance = pocket.balance(&k_infos).await.expect("balance works");
+
+        assert_eq!(balance.debit, Amount::ZERO);
+        assert_eq!(balance.credit, Amount::from(24u64));
+    }
+
+    #[tokio::test]
+    async fn credit_balance_keyset_expiring_earlier_today() {
+        let (info, keyset) = core_tests::generate_random_ecash_keyset();
+        let mut k_info = KeySetInfo::from(info);
+
+        let earlier_today = chrono::Utc::now()
+            .date_naive()
+            .and_hms_opt(0, 0, 1)
+            .unwrap()
+            .and_utc()
+            .timestamp() as u64;
+
+        k_info.final_expiry = Some(earlier_today);
+
+        let k_infos = vec![k_info];
+        let amounts = [Amount::from(8u64), Amount::from(16u64)];
+        let proofs = core_tests::generate_random_ecash_proofs(&keyset, &amounts);
+        let mut pdb = MockPocketRepository::new();
+        let mdb = MockMintMeltRepository::new();
+
+        let proofs_clone = proofs.clone();
+        pdb.expect_list_unspent().times(1).returning(move || {
+            let mut map = HashMap::new();
+            map.insert(proofs_clone[0].y().unwrap(), proofs_clone[0].clone());
+            map.insert(proofs_clone[1].y().unwrap(), proofs_clone[1].clone());
+            Ok(map)
+        });
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+        let balance = pocket.balance(&k_infos).await.expect("balance works");
+
+        assert_eq!(balance.debit, Amount::ZERO);
+        assert_eq!(balance.credit, Amount::from(24u64));
+    }
+
+    #[tokio::test]
+    async fn mixed_credit_and_debit_balance() {
+        let (info_debit, keyset_debit) = core_tests::generate_random_ecash_keyset();
+        let (info_credit, keyset_credit) = core_tests::generate_random_ecash_keyset();
+
+        let mut ks_debit = KeySetInfo::from(info_debit);
+        // yesterday → debit
+        ks_debit.final_expiry =
+            Some((chrono::Utc::now() - chrono::TimeDelta::days(1)).timestamp() as u64);
+
+        let mut ks_credit = KeySetInfo::from(info_credit);
+        // tomorrow → credit
+        ks_credit.final_expiry =
+            Some((chrono::Utc::now() + chrono::TimeDelta::days(1)).timestamp() as u64);
+
+        let k_infos = vec![ks_debit, ks_credit];
+
+        let debit_amount = Amount::from(8u64);
+        let credit_amount = Amount::from(16u64);
+
+        let proofs_debit = core_tests::generate_random_ecash_proofs(&keyset_debit, &[debit_amount]);
+        let proofs_credit =
+            core_tests::generate_random_ecash_proofs(&keyset_credit, &[credit_amount]);
+
+        let mut pdb = MockPocketRepository::new();
+        let mdb = MockMintMeltRepository::new();
+
+        let p_debit = proofs_debit[0].clone();
+        let p_credit = proofs_credit[0].clone();
+
+        pdb.expect_list_unspent().times(1).returning(move || {
+            let mut map = HashMap::new();
+            map.insert(p_debit.y().unwrap(), p_debit.clone());
+            map.insert(p_credit.y().unwrap(), p_credit.clone());
+            Ok(map)
+        });
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+        let balance = pocket.balance(&k_infos).await.expect("balance works");
+
+        assert_eq!(balance.debit, debit_amount);
+        assert_eq!(balance.credit, credit_amount);
     }
 
     #[tokio::test]

--- a/crates/bcr-wallet-api/src/pocket/mod.rs
+++ b/crates/bcr-wallet-api/src/pocket/mod.rs
@@ -28,7 +28,7 @@ pub mod test_utils;
 #[async_trait]
 pub trait PocketApi: SendSync {
     fn unit(&self) -> CurrencyUnit;
-    async fn balance(&self) -> Result<Amount>;
+    async fn balance(&self, keysets_info: &[KeySetInfo]) -> Result<PocketBalance>;
     async fn receive_proofs(
         &self,
         client: Arc<dyn ClowderMintConnector>,
@@ -67,6 +67,16 @@ pub trait PocketApi: SendSync {
         send_amount: Amount,
         swap_config: SwapConfig,
     ) -> Result<Vec<cashu::Proof>>;
+    async fn dev_mode_detailed_balance(
+        &self,
+        keysets_info: &[KeySetInfo],
+    ) -> Result<HashMap<cashu::Id, (Option<u64>, Amount)>>;
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct PocketBalance {
+    pub debit: Amount,
+    pub credit: Amount,
 }
 
 ///////////////////////////////////////////// SendReference

--- a/crates/bcr-wallet-api/src/pocket/test_utils.rs
+++ b/crates/bcr-wallet-api/src/pocket/test_utils.rs
@@ -56,7 +56,7 @@ pub mod tests {
         #[async_trait]
         impl PocketApi for DebitPocket {
             fn unit(&self) -> CurrencyUnit;
-            async fn balance(&self) -> Result<Amount>;
+            async fn balance(&self, keysets_info: &[KeySetInfo]) -> Result<crate::pocket::PocketBalance>;
             async fn receive_proofs(
                 &self,
                 client: Arc<dyn ClowderMintConnector>,
@@ -94,6 +94,10 @@ pub mod tests {
                 send_amount: Amount,
                 swap_config: SwapConfig,
             ) -> Result<Vec<cashu::Proof>>;
+            async fn dev_mode_detailed_balance(
+                &self,
+                keysets_info: &[KeySetInfo],
+            ) -> Result<HashMap<cashu::Id, (Option<u64>, Amount)>>;
         }
 
         #[async_trait]

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -873,9 +873,9 @@ impl WalletApi for super::Wallet {
                 self.swap_config(),
             )
             .await?;
-        let debit_balance = self.debit.balance().await?;
+        let balance = self.debit.balance(&keysets_info).await?;
 
-        tracing::info!("Migration successful balance debit {debit_balance}");
+        tracing::info!("Migration successful balance: {:?}", balance);
 
         Ok(self.client.mint_url())
     }

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{Error, Result},
     pocket::debit::DebitPocketApi,
     types::{PAYMENT_TYPE_METADATA_KEY, TRANSACTION_STATUS_METADATA_KEY},
-    wallet::types::{PayReference, SwapConfig, WalletBalance},
+    wallet::types::{PayReference, SwapConfig, WalletBalance, WalletDetailedBalanceEntry},
 };
 use bcr_common::{
     cashu::{
@@ -180,8 +180,13 @@ impl Wallet {
     }
 
     pub async fn balance(&self) -> Result<WalletBalance> {
-        let debit = self.debit.balance().await?;
-        Ok(WalletBalance { debit })
+        let keysets_info = self.get_wallet_mint_keyset_infos().await?;
+        let balance = self.debit.balance(&keysets_info).await?;
+        Ok(WalletBalance {
+            debit: balance.debit,
+            credit: balance.credit,
+            total: balance.debit + balance.credit,
+        })
     }
 
     async fn check_nut18_request(
@@ -745,6 +750,30 @@ impl Wallet {
             Err(e) => Err(e),
         }
     }
+
+    pub async fn dev_mode_detailed_balance(&self) -> Result<Vec<WalletDetailedBalanceEntry>> {
+        let keysets_info = self.get_wallet_mint_keyset_infos().await?;
+
+        let detailed_balance = self.debit.dev_mode_detailed_balance(&keysets_info).await?;
+        let mut res = Vec::with_capacity(detailed_balance.len());
+        for (kid, (final_expiry, amount)) in detailed_balance.into_iter() {
+            res.push(WalletDetailedBalanceEntry {
+                kid,
+                final_expiry,
+                amount,
+            })
+        }
+
+        // sort by final expiry descending, with no final expiry at the end
+        res.sort_by_key(|e| {
+            (
+                e.final_expiry.is_none(),
+                std::cmp::Reverse(e.final_expiry.unwrap_or(0)),
+            )
+        });
+
+        Ok(res)
+    }
 }
 
 #[cfg(test)]
@@ -761,7 +790,7 @@ mod tests {
     use super::*;
     use crate::{
         external::{mint::HttpClientExt, test_utils::tests::MockMintConnector},
-        pocket::test_utils::tests::MockDebitPocket,
+        pocket::{PocketBalance, test_utils::tests::MockDebitPocket},
         wallet::{api::WalletApi, types::WalletPaymentType},
     };
 
@@ -1006,14 +1035,20 @@ mod tests {
     #[tokio::test]
     async fn test_balance() {
         let mut ctx = wallet_ctx();
+        ctx.client
+            .expect_get_mint_keysets()
+            .times(1)
+            .returning(|| Ok(vec![]));
         ctx.debit
             .expect_balance()
             .times(1)
-            .returning(|| Ok(Amount::ZERO));
+            .returning(|_| Ok(PocketBalance::default()));
         let wlt = wallet(ctx);
 
         let res = wlt.balance().await.expect("balance works");
         assert_eq!(res.debit, Amount::ZERO);
+        assert_eq!(res.credit, Amount::ZERO);
+        assert_eq!(res.total, Amount::ZERO);
     }
 
     #[tokio::test]

--- a/crates/bcr-wallet-api/src/wallet/types.rs
+++ b/crates/bcr-wallet-api/src/wallet/types.rs
@@ -31,6 +31,15 @@ pub struct PayReference {
 #[derive(Debug, Clone, Default)]
 pub struct WalletBalance {
     pub debit: cashu::Amount,
+    pub credit: cashu::Amount,
+    pub total: cashu::Amount,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletDetailedBalanceEntry {
+    pub kid: cashu::Id,
+    pub final_expiry: Option<u64>,
+    pub amount: cashu::Amount,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/bcr-wallet-cli/alice.toml
+++ b/crates/bcr-wallet-cli/alice.toml
@@ -1,6 +1,6 @@
-mint_url = "http://localhost:4343"
+# mint_url = "http://localhost:4343"
 # mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
-# mint_url = "https://mint.wildcat0.clowder-dev.minibill.tech"
+mint_url = "https://mint.wildcat0.clowder-dev.minibill.tech"
 mnemonic = "royal scheme canoe flame sell jewel valve citizen deal patch stereo walk"
 log_level = "DEBUG"
 db_path = "./alice.db"

--- a/crates/bcr-wallet-cli/bob.toml
+++ b/crates/bcr-wallet-cli/bob.toml
@@ -1,5 +1,6 @@
-#mint_url = "https://mint.wildcat1.clowder-dev.minibill.tech"
-mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
+# mint_url = "https://mint.wildcat1.clowder-dev.minibill.tech"
+mint_url = "https://mint.wildcat0.clowder-dev.minibill.tech"
+# mint_url = "https://mint.wildcat0.clowder1.minibill.tech"
 mnemonic = "spoil frost juice sketch spirit fine trophy puzzle crater roast holiday payment"
 log_level = "DEBUG"
 db_path = "./bob.db"

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -24,15 +24,36 @@ pub async fn cmd_info(app_state: &AppState) -> Result<String> {
     for id in wallet_ids.iter() {
         let name = app_state.wallet_name(*id).await?;
         let mint_url = app_state.wallet_mint_url(*id).await?;
-        let unit = app_state.wallet_currency_unit(*id).await?;
+        let unit = app_state.wallet_currency_unit(*id).await?.unit;
         let balance = app_state.wallet_balance(*id).await?;
+        let dev_mode_detailed_balance = app_state.wallet_dev_mode_detailed_balance(*id).await?;
 
         let transactions = app_state.wallet_list_txs(*id).await?;
 
         res.push_str(&format!("Name: {name}\n"));
         res.push_str(&format!("Wallet ID: {id}\n"));
         res.push_str(&format!("Mint URL: {mint_url}\n"));
-        res.push_str(&format!("Debit Balance: {} {}\n", balance.debit, unit.unit));
+        res.push_str(&format!("Debit Balance: {} {}\n", balance.debit, unit));
+        res.push_str(&format!("Credit Balance: {} {}\n", balance.credit, unit));
+        res.push_str(&format!("Total Balance: {} {}\n", balance.total, unit));
+
+        if !dev_mode_detailed_balance.is_empty() {
+            res.push_str("Dev Mode Detailed Balance:");
+            for entry in dev_mode_detailed_balance.iter() {
+                res.push_str(&format!(
+                    "\t\tId: {} \t Expiry: {} \t Amount: {}",
+                    entry.kid,
+                    if let Some(exp) = entry.final_expiry {
+                        format_timestamp(exp)
+                    } else {
+                        "None".to_owned()
+                    },
+                    entry.amount
+                ));
+                push_break(&mut res);
+            }
+        }
+
         if !transactions.is_empty() {
             res.push_str("Transactions:");
             push_break(&mut res);

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -126,6 +126,7 @@ async fn main() -> Result<()> {
         mnemonic: settings.mnemonic.clone(),
         default_mint_url: settings.mint_url.clone(),
         swap_expiry: chrono::TimeDelta::minutes(15),
+        dev_mode: true,
     };
     let app_state = AppState::initialize(app_state_cfg).await?;
 

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -6,7 +6,6 @@ use bitcoin::{address::NetworkUnchecked, secp256k1};
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 use uuid::Uuid;
 
-pub type TStamp = chrono::DateTime<chrono::Utc>;
 pub type Seed = [u8; 64];
 
 pub type PaymentResultCallback = Arc<dyn Fn(Option<TransactionId>) + Send + Sync + 'static>;

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -85,6 +85,8 @@ pub struct WalletFfiConfig {
     pub nostr_relays: Vec<String>,
     // Swap commitment expiry in minutes
     pub swap_expiry_minutes: u32,
+    // Dev Mode Enabled
+    pub dev_mode: bool,
 }
 
 #[frb]
@@ -132,6 +134,7 @@ pub async fn init_wallet_ffi(conf: WalletFfiConfig) {
         mnemonic: parsed_mnemonic,
         swap_expiry,
         default_mint_url: parsed_url,
+        dev_mode: conf.dev_mode,
     };
 
     let app_state = AppState::initialize(app_state_cfg)
@@ -280,6 +283,8 @@ pub async fn wallet_get_balance(req: WalletRequest) -> Result<WalletBalanceRespo
     let balance = app_state.wallet_balance(req.wallet_id).await?;
     Ok(WalletBalanceResponse {
         debit: u64::from(balance.debit),
+        credit: u64::from(balance.credit),
+        total: u64::from(balance.total),
     })
 }
 
@@ -610,6 +615,26 @@ pub async fn wallet_get_ids() -> Result<WalletsIdsResponse, WalletError> {
 }
 
 #[frb]
+pub async fn wallet_dev_mode_get_detailed_balance(
+    req: WalletRequest,
+) -> Result<WalletDevModeDetailedBalanceResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let detailed_balance = app_state
+        .wallet_dev_mode_detailed_balance(req.wallet_id)
+        .await?;
+    Ok(WalletDevModeDetailedBalanceResponse {
+        entries: detailed_balance
+            .into_iter()
+            .map(|entry| WalletDevModeDetailedBalanceEntry {
+                kid: entry.kid.to_string(),
+                final_expiry: entry.final_expiry,
+                amount: u64::from(entry.amount),
+            })
+            .collect(),
+    })
+}
+
+#[frb]
 pub async fn generate_random_mnemonic(
     req: MnemonicRequest,
 ) -> Result<MnemonicResponse, WalletError> {
@@ -705,6 +730,20 @@ pub struct WalletCurrencyUnitResponse {
 #[derive(Debug, Clone)]
 pub struct WalletBalanceResponse {
     pub debit: u64,
+    pub credit: u64,
+    pub total: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletDevModeDetailedBalanceResponse {
+    pub entries: Vec<WalletDevModeDetailedBalanceEntry>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletDevModeDetailedBalanceEntry {
+    pub kid: String,
+    pub final_expiry: Option<u64>,
+    pub amount: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -1217,6 +1256,7 @@ impl From<BcrWalletError> for WalletError {
             BcrWalletError::SchnorrSignature(_) => WalletError::internal(),
             BcrWalletError::Database(_) => WalletError::internal(),
             BcrWalletError::NoBetas => WalletError::internal(),
+            BcrWalletError::NoDevMode => WalletError::bad_request(value.to_string()),
         }
     }
 }

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 446898311;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -930769447;
 
 // Section: executor
 
@@ -485,6 +485,43 @@ fn wire__crate__api__wallet_delete_impl(
                 transform_result_sse::<_, crate::api::WalletError>(
                     (move || async move {
                         let output_ok = crate::api::wallet_delete(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet_dev_mode_get_detailed_balance_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_dev_mode_get_detailed_balance",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::WalletRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::wallet_dev_mode_get_detailed_balance(api_req).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -1865,6 +1902,20 @@ impl SseDecode for Vec<crate::api::Transaction> {
     }
 }
 
+impl SseDecode for Vec<crate::api::WalletDevModeDetailedBalanceEntry> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::WalletDevModeDetailedBalanceEntry>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for crate::api::MeltTx {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2119,7 +2170,13 @@ impl SseDecode for crate::api::WalletBalanceResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_debit = <u64>::sse_decode(deserializer);
-        return crate::api::WalletBalanceResponse { debit: var_debit };
+        let mut var_credit = <u64>::sse_decode(deserializer);
+        let mut var_total = <u64>::sse_decode(deserializer);
+        return crate::api::WalletBalanceResponse {
+            debit: var_debit,
+            credit: var_credit,
+            total: var_total,
+        };
     }
 }
 
@@ -2150,6 +2207,31 @@ impl SseDecode for crate::api::WalletCurrencyUnitResponse {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_unit = <String>::sse_decode(deserializer);
         return crate::api::WalletCurrencyUnitResponse { unit: var_unit };
+    }
+}
+
+impl SseDecode for crate::api::WalletDevModeDetailedBalanceEntry {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_kid = <String>::sse_decode(deserializer);
+        let mut var_finalExpiry = <Option<u64>>::sse_decode(deserializer);
+        let mut var_amount = <u64>::sse_decode(deserializer);
+        return crate::api::WalletDevModeDetailedBalanceEntry {
+            kid: var_kid,
+            final_expiry: var_finalExpiry,
+            amount: var_amount,
+        };
+    }
+}
+
+impl SseDecode for crate::api::WalletDevModeDetailedBalanceResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_entries =
+            <Vec<crate::api::WalletDevModeDetailedBalanceEntry>>::sse_decode(deserializer);
+        return crate::api::WalletDevModeDetailedBalanceResponse {
+            entries: var_entries,
+        };
     }
 }
 
@@ -2193,6 +2275,7 @@ impl SseDecode for crate::api::WalletFfiConfig {
         let mut var_mnemonic = <String>::sse_decode(deserializer);
         let mut var_nostrRelays = <Vec<String>>::sse_decode(deserializer);
         let mut var_swapExpiryMinutes = <u32>::sse_decode(deserializer);
+        let mut var_devMode = <bool>::sse_decode(deserializer);
         return crate::api::WalletFfiConfig {
             db_folder_path: var_dbFolderPath,
             log_level: var_logLevel,
@@ -2203,6 +2286,7 @@ impl SseDecode for crate::api::WalletFfiConfig {
             mnemonic: var_mnemonic,
             nostr_relays: var_nostrRelays,
             swap_expiry_minutes: var_swapExpiryMinutes,
+            dev_mode: var_devMode,
         };
     }
 }
@@ -2614,46 +2698,52 @@ fn pde_ffi_dispatcher_primary_impl(
             wire__crate__api__wallet_check_received_payment_impl(port, ptr, rust_vec_len, data_len)
         }
         13 => wire__crate__api__wallet_delete_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__wallet_error_bad_request_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__wallet_error_internal_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__wallet_error_network_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__wallet_error_not_found_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__wallet_get_balance_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__wallet_get_currency_unit_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__wallet_get_ids_impl(port, ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__wallet_get_mint_url_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__wallet_get_name_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__wallet_get_status_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__wallet_get_transaction_ids_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__wallet_get_transactions_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__wallet_load_transaction_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__wallet_melt_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__wallet_migrate_rabid_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__wallet_mint_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__wallet_mint_is_offline_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__wallet_mint_is_rabid_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__wallet_pay_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__wallet_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__wallet_prepare_melt_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__wallet_prepare_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__wallet_prepare_payment_impl(port, ptr, rust_vec_len, data_len),
-        37 => {
-            wire__crate__api__wallet_prepare_payment_request_impl(port, ptr, rust_vec_len, data_len)
-        }
-        38 => wire__crate__api__wallet_protest_melt_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__wallet_protest_mint_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__wallet_protest_swap_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__wallet_receive_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__wallet_reclaim_transaction_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__wallet_recover_pending_stale_proofs_impl(
+        14 => wire__crate__api__wallet_dev_mode_get_detailed_balance_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__wallet_error_bad_request_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__wallet_error_internal_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__wallet_error_network_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__wallet_error_not_found_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__wallet_get_balance_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__wallet_get_currency_unit_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__wallet_get_ids_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__wallet_get_mint_url_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__wallet_get_name_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__wallet_get_status_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__wallet_get_transaction_ids_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__wallet_get_transactions_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__wallet_load_transaction_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__wallet_melt_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__wallet_migrate_rabid_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__wallet_mint_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__wallet_mint_is_offline_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__wallet_mint_is_rabid_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__wallet_pay_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__wallet_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__wallet_prepare_melt_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__wallet_prepare_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__wallet_prepare_payment_impl(port, ptr, rust_vec_len, data_len),
+        38 => {
+            wire__crate__api__wallet_prepare_payment_request_impl(port, ptr, rust_vec_len, data_len)
+        }
+        39 => wire__crate__api__wallet_protest_melt_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__wallet_protest_mint_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__wallet_protest_swap_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__wallet_receive_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__wallet_reclaim_transaction_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__wallet_recover_pending_stale_proofs_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        45 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3011,7 +3101,12 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::TransactionStatus>
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::WalletBalanceResponse {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [self.debit.into_into_dart().into_dart()].into_dart()
+        [
+            self.debit.into_into_dart().into_dart(),
+            self.credit.into_into_dart().into_dart(),
+            self.total.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
@@ -3082,6 +3177,45 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletCurrencyUnitResponse>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletDevModeDetailedBalanceEntry {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.kid.into_into_dart().into_dart(),
+            self.final_expiry.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletDevModeDetailedBalanceEntry
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletDevModeDetailedBalanceEntry>
+    for crate::api::WalletDevModeDetailedBalanceEntry
+{
+    fn into_into_dart(self) -> crate::api::WalletDevModeDetailedBalanceEntry {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletDevModeDetailedBalanceResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.entries.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletDevModeDetailedBalanceResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletDevModeDetailedBalanceResponse>
+    for crate::api::WalletDevModeDetailedBalanceResponse
+{
+    fn into_into_dart(self) -> crate::api::WalletDevModeDetailedBalanceResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::WalletError {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -3132,6 +3266,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::WalletFfiConfig {
             self.mnemonic.into_into_dart().into_dart(),
             self.nostr_relays.into_into_dart().into_dart(),
             self.swap_expiry_minutes.into_into_dart().into_dart(),
+            self.dev_mode.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -3929,6 +4064,16 @@ impl SseEncode for Vec<crate::api::Transaction> {
     }
 }
 
+impl SseEncode for Vec<crate::api::WalletDevModeDetailedBalanceEntry> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::WalletDevModeDetailedBalanceEntry>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for crate::api::MeltTx {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4153,6 +4298,8 @@ impl SseEncode for crate::api::WalletBalanceResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.debit, serializer);
+        <u64>::sse_encode(self.credit, serializer);
+        <u64>::sse_encode(self.total, serializer);
     }
 }
 
@@ -4176,6 +4323,22 @@ impl SseEncode for crate::api::WalletCurrencyUnitResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.unit, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletDevModeDetailedBalanceEntry {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.kid, serializer);
+        <Option<u64>>::sse_encode(self.final_expiry, serializer);
+        <u64>::sse_encode(self.amount, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletDevModeDetailedBalanceResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<crate::api::WalletDevModeDetailedBalanceEntry>>::sse_encode(self.entries, serializer);
     }
 }
 
@@ -4219,6 +4382,7 @@ impl SseEncode for crate::api::WalletFfiConfig {
         <String>::sse_encode(self.mnemonic, serializer);
         <Vec<String>>::sse_encode(self.nostr_relays, serializer);
         <u32>::sse_encode(self.swap_expiry_minutes, serializer);
+        <bool>::sse_encode(self.dev_mode, serializer);
     }
 }
 

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `get_app_state`, `init_logging`, `init_panic_hook`, `new`, `reset_runtime`, `start_jobs`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `WalletCleanLocalDbResponse`, `WalletRuntime`, `WalletsNamesResponse`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
 
 Future<void> initWalletFfi({required WalletFfiConfig conf}) =>
     RustLib.instance.api.crateApiInitWalletFfi(conf: conf);
@@ -126,6 +126,10 @@ Future<WalletTransactionsResponse> walletGetTransactions({
 
 Future<WalletsIdsResponse> walletGetIds() =>
     RustLib.instance.api.crateApiWalletGetIds();
+
+Future<WalletDevModeDetailedBalanceResponse> walletDevModeGetDetailedBalance({
+  required WalletRequest req,
+}) => RustLib.instance.api.crateApiWalletDevModeGetDetailedBalance(req: req);
 
 Future<MnemonicResponse> generateRandomMnemonic({
   required MnemonicRequest req,
@@ -501,18 +505,26 @@ enum TransactionStatus {
 
 class WalletBalanceResponse {
   final BigInt debit;
+  final BigInt credit;
+  final BigInt total;
 
-  const WalletBalanceResponse({required this.debit});
+  const WalletBalanceResponse({
+    required this.debit,
+    required this.credit,
+    required this.total,
+  });
 
   @override
-  int get hashCode => debit.hashCode;
+  int get hashCode => debit.hashCode ^ credit.hashCode ^ total.hashCode;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is WalletBalanceResponse &&
           runtimeType == other.runtimeType &&
-          debit == other.debit;
+          debit == other.debit &&
+          credit == other.credit &&
+          total == other.total;
 }
 
 class WalletCheckPendingMintsResponse {
@@ -571,6 +583,46 @@ class WalletCurrencyUnitResponse {
           unit == other.unit;
 }
 
+class WalletDevModeDetailedBalanceEntry {
+  final String kid;
+  final BigInt? finalExpiry;
+  final BigInt amount;
+
+  const WalletDevModeDetailedBalanceEntry({
+    required this.kid,
+    this.finalExpiry,
+    required this.amount,
+  });
+
+  @override
+  int get hashCode => kid.hashCode ^ finalExpiry.hashCode ^ amount.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletDevModeDetailedBalanceEntry &&
+          runtimeType == other.runtimeType &&
+          kid == other.kid &&
+          finalExpiry == other.finalExpiry &&
+          amount == other.amount;
+}
+
+class WalletDevModeDetailedBalanceResponse {
+  final List<WalletDevModeDetailedBalanceEntry> entries;
+
+  const WalletDevModeDetailedBalanceResponse({required this.entries});
+
+  @override
+  int get hashCode => entries.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletDevModeDetailedBalanceResponse &&
+          runtimeType == other.runtimeType &&
+          entries == other.entries;
+}
+
 class WalletError implements FrbException {
   final WalletErrorKind kind;
   final String msg;
@@ -620,6 +672,7 @@ class WalletFfiConfig {
   final String mnemonic;
   final List<String> nostrRelays;
   final int swapExpiryMinutes;
+  final bool devMode;
 
   const WalletFfiConfig({
     required this.dbFolderPath,
@@ -631,6 +684,7 @@ class WalletFfiConfig {
     required this.mnemonic,
     required this.nostrRelays,
     required this.swapExpiryMinutes,
+    required this.devMode,
   });
 
   @override
@@ -643,7 +697,8 @@ class WalletFfiConfig {
       bitcoinNetwork.hashCode ^
       mnemonic.hashCode ^
       nostrRelays.hashCode ^
-      swapExpiryMinutes.hashCode;
+      swapExpiryMinutes.hashCode ^
+      devMode.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -658,7 +713,8 @@ class WalletFfiConfig {
           bitcoinNetwork == other.bitcoinNetwork &&
           mnemonic == other.mnemonic &&
           nostrRelays == other.nostrRelays &&
-          swapExpiryMinutes == other.swapExpiryMinutes;
+          swapExpiryMinutes == other.swapExpiryMinutes &&
+          devMode == other.devMode;
 }
 
 class WalletMaybeTransactionIdResponse {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -66,7 +66,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 446898311;
+  int get rustContentHash => -930769447;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -114,6 +114,9 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<void> crateApiWalletDelete({required WalletRequest req});
+
+  Future<WalletDevModeDetailedBalanceResponse>
+  crateApiWalletDevModeGetDetailedBalance({required WalletRequest req});
 
   Future<WalletError> crateApiWalletErrorBadRequest({required String msg});
 
@@ -648,6 +651,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "wallet_delete", argNames: ["req"]);
 
   @override
+  Future<WalletDevModeDetailedBalanceResponse>
+  crateApiWalletDevModeGetDetailedBalance({required WalletRequest req}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_request(req, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 14,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_wallet_dev_mode_detailed_balance_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletDevModeGetDetailedBalanceConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletDevModeGetDetailedBalanceConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_dev_mode_get_detailed_balance",
+        argNames: ["req"],
+      );
+
+  @override
   Future<WalletError> crateApiWalletErrorBadRequest({required String msg}) {
     return handler.executeNormal(
       NormalTask(
@@ -657,7 +693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -687,7 +723,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -715,7 +751,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -743,7 +779,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -776,7 +812,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -806,7 +842,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 20,
             port: port_,
           );
         },
@@ -836,7 +872,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 21,
             port: port_,
           );
         },
@@ -866,7 +902,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 22,
             port: port_,
           );
         },
@@ -896,7 +932,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 23,
             port: port_,
           );
         },
@@ -923,7 +959,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 24,
             port: port_,
           );
         },
@@ -953,7 +989,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -986,7 +1022,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1019,7 +1055,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1052,7 +1088,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1079,7 +1115,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1109,7 +1145,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1139,7 +1175,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1172,7 +1208,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1202,7 +1238,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1235,7 +1271,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1265,7 +1301,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1298,7 +1334,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1334,7 +1370,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1370,7 +1406,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -1403,7 +1439,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1433,7 +1469,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1463,7 +1499,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1493,7 +1529,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1526,7 +1562,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1558,7 +1594,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1595,7 +1631,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -1628,7 +1664,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -1658,7 +1694,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -1995,6 +2031,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<WalletDevModeDetailedBalanceEntry>
+  dco_decode_list_wallet_dev_mode_detailed_balance_entry(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_wallet_dev_mode_detailed_balance_entry)
+        .toList();
+  }
+
+  @protected
   MeltTx dco_decode_melt_tx(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -2189,9 +2234,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   WalletBalanceResponse dco_decode_wallet_balance_response(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 1)
-      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return WalletBalanceResponse(debit: dco_decode_u_64(arr[0]));
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return WalletBalanceResponse(
+      debit: dco_decode_u_64(arr[0]),
+      credit: dco_decode_u_64(arr[1]),
+      total: dco_decode_u_64(arr[2]),
+    );
   }
 
   @protected
@@ -2232,6 +2281,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletDevModeDetailedBalanceEntry
+  dco_decode_wallet_dev_mode_detailed_balance_entry(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return WalletDevModeDetailedBalanceEntry(
+      kid: dco_decode_String(arr[0]),
+      finalExpiry: dco_decode_opt_box_autoadd_u_64(arr[1]),
+      amount: dco_decode_u_64(arr[2]),
+    );
+  }
+
+  @protected
+  WalletDevModeDetailedBalanceResponse
+  dco_decode_wallet_dev_mode_detailed_balance_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return WalletDevModeDetailedBalanceResponse(
+      entries: dco_decode_list_wallet_dev_mode_detailed_balance_entry(arr[0]),
+    );
+  }
+
+  @protected
   WalletError dco_decode_wallet_error(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -2253,8 +2328,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   WalletFfiConfig dco_decode_wallet_ffi_config(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 9)
-      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    if (arr.length != 10)
+      throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
     return WalletFfiConfig(
       dbFolderPath: dco_decode_String(arr[0]),
       logLevel: dco_decode_String(arr[1]),
@@ -2265,6 +2340,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       mnemonic: dco_decode_String(arr[6]),
       nostrRelays: dco_decode_list_String(arr[7]),
       swapExpiryMinutes: dco_decode_u_32(arr[8]),
+      devMode: dco_decode_bool(arr[9]),
     );
   }
 
@@ -2999,6 +3075,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<WalletDevModeDetailedBalanceEntry>
+  sse_decode_list_wallet_dev_mode_detailed_balance_entry(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <WalletDevModeDetailedBalanceEntry>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_wallet_dev_mode_detailed_balance_entry(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   MeltTx sse_decode_melt_tx(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_alphaTxId = sse_decode_opt_String(deserializer);
@@ -3210,7 +3301,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_debit = sse_decode_u_64(deserializer);
-    return WalletBalanceResponse(debit: var_debit);
+    var var_credit = sse_decode_u_64(deserializer);
+    var var_total = sse_decode_u_64(deserializer);
+    return WalletBalanceResponse(
+      debit: var_debit,
+      credit: var_credit,
+      total: var_total,
+    );
   }
 
   @protected
@@ -3247,6 +3344,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletDevModeDetailedBalanceEntry
+  sse_decode_wallet_dev_mode_detailed_balance_entry(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_kid = sse_decode_String(deserializer);
+    var var_finalExpiry = sse_decode_opt_box_autoadd_u_64(deserializer);
+    var var_amount = sse_decode_u_64(deserializer);
+    return WalletDevModeDetailedBalanceEntry(
+      kid: var_kid,
+      finalExpiry: var_finalExpiry,
+      amount: var_amount,
+    );
+  }
+
+  @protected
+  WalletDevModeDetailedBalanceResponse
+  sse_decode_wallet_dev_mode_detailed_balance_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_entries = sse_decode_list_wallet_dev_mode_detailed_balance_entry(
+      deserializer,
+    );
+    return WalletDevModeDetailedBalanceResponse(entries: var_entries);
+  }
+
+  @protected
   WalletError sse_decode_wallet_error(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_kind = sse_decode_wallet_error_kind(deserializer);
@@ -3273,6 +3398,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_mnemonic = sse_decode_String(deserializer);
     var var_nostrRelays = sse_decode_list_String(deserializer);
     var var_swapExpiryMinutes = sse_decode_u_32(deserializer);
+    var var_devMode = sse_decode_bool(deserializer);
     return WalletFfiConfig(
       dbFolderPath: var_dbFolderPath,
       logLevel: var_logLevel,
@@ -3283,6 +3409,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       mnemonic: var_mnemonic,
       nostrRelays: var_nostrRelays,
       swapExpiryMinutes: var_swapExpiryMinutes,
+      devMode: var_devMode,
     );
   }
 
@@ -4003,6 +4130,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_wallet_dev_mode_detailed_balance_entry(
+    List<WalletDevModeDetailedBalanceEntry> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_wallet_dev_mode_detailed_balance_entry(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_melt_tx(MeltTx self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_opt_String(self.alphaTxId, serializer);
@@ -4199,6 +4338,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.debit, serializer);
+    sse_encode_u_64(self.credit, serializer);
+    sse_encode_u_64(self.total, serializer);
   }
 
   @protected
@@ -4228,6 +4369,29 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.unit, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_dev_mode_detailed_balance_entry(
+    WalletDevModeDetailedBalanceEntry self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.kid, serializer);
+    sse_encode_opt_box_autoadd_u_64(self.finalExpiry, serializer);
+    sse_encode_u_64(self.amount, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_dev_mode_detailed_balance_response(
+    WalletDevModeDetailedBalanceResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_wallet_dev_mode_detailed_balance_entry(
+      self.entries,
+      serializer,
+    );
   }
 
   @protected
@@ -4261,6 +4425,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.mnemonic, serializer);
     sse_encode_list_String(self.nostrRelays, serializer);
     sse_encode_u_32(self.swapExpiryMinutes, serializer);
+    sse_encode_bool(self.devMode, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -167,6 +167,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<Transaction> dco_decode_list_transaction(dynamic raw);
 
   @protected
+  List<WalletDevModeDetailedBalanceEntry>
+  dco_decode_list_wallet_dev_mode_detailed_balance_entry(dynamic raw);
+
+  @protected
   MeltTx dco_decode_melt_tx(dynamic raw);
 
   @protected
@@ -247,6 +251,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletCurrencyUnitResponse dco_decode_wallet_currency_unit_response(
     dynamic raw,
   );
+
+  @protected
+  WalletDevModeDetailedBalanceEntry
+  dco_decode_wallet_dev_mode_detailed_balance_entry(dynamic raw);
+
+  @protected
+  WalletDevModeDetailedBalanceResponse
+  dco_decode_wallet_dev_mode_detailed_balance_response(dynamic raw);
 
   @protected
   WalletError dco_decode_wallet_error(dynamic raw);
@@ -563,6 +575,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<Transaction> sse_decode_list_transaction(SseDeserializer deserializer);
 
   @protected
+  List<WalletDevModeDetailedBalanceEntry>
+  sse_decode_list_wallet_dev_mode_detailed_balance_entry(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   MeltTx sse_decode_melt_tx(SseDeserializer deserializer);
 
   @protected
@@ -655,6 +673,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletCurrencyUnitResponse sse_decode_wallet_currency_unit_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletDevModeDetailedBalanceEntry
+  sse_decode_wallet_dev_mode_detailed_balance_entry(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletDevModeDetailedBalanceResponse
+  sse_decode_wallet_dev_mode_detailed_balance_response(
     SseDeserializer deserializer,
   );
 
@@ -1036,6 +1066,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_wallet_dev_mode_detailed_balance_entry(
+    List<WalletDevModeDetailedBalanceEntry> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_melt_tx(MeltTx self, SseSerializer serializer);
 
   @protected
@@ -1155,6 +1191,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_currency_unit_response(
     WalletCurrencyUnitResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_dev_mode_detailed_balance_entry(
+    WalletDevModeDetailedBalanceEntry self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_dev_mode_detailed_balance_response(
+    WalletDevModeDetailedBalanceResponse self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -169,6 +169,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<Transaction> dco_decode_list_transaction(dynamic raw);
 
   @protected
+  List<WalletDevModeDetailedBalanceEntry>
+  dco_decode_list_wallet_dev_mode_detailed_balance_entry(dynamic raw);
+
+  @protected
   MeltTx dco_decode_melt_tx(dynamic raw);
 
   @protected
@@ -249,6 +253,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletCurrencyUnitResponse dco_decode_wallet_currency_unit_response(
     dynamic raw,
   );
+
+  @protected
+  WalletDevModeDetailedBalanceEntry
+  dco_decode_wallet_dev_mode_detailed_balance_entry(dynamic raw);
+
+  @protected
+  WalletDevModeDetailedBalanceResponse
+  dco_decode_wallet_dev_mode_detailed_balance_response(dynamic raw);
 
   @protected
   WalletError dco_decode_wallet_error(dynamic raw);
@@ -565,6 +577,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<Transaction> sse_decode_list_transaction(SseDeserializer deserializer);
 
   @protected
+  List<WalletDevModeDetailedBalanceEntry>
+  sse_decode_list_wallet_dev_mode_detailed_balance_entry(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   MeltTx sse_decode_melt_tx(SseDeserializer deserializer);
 
   @protected
@@ -657,6 +675,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletCurrencyUnitResponse sse_decode_wallet_currency_unit_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletDevModeDetailedBalanceEntry
+  sse_decode_wallet_dev_mode_detailed_balance_entry(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletDevModeDetailedBalanceResponse
+  sse_decode_wallet_dev_mode_detailed_balance_response(
     SseDeserializer deserializer,
   );
 
@@ -1038,6 +1068,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_wallet_dev_mode_detailed_balance_entry(
+    List<WalletDevModeDetailedBalanceEntry> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_melt_tx(MeltTx self, SseSerializer serializer);
 
   @protected
@@ -1157,6 +1193,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_currency_unit_response(
     WalletCurrencyUnitResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_dev_mode_detailed_balance_entry(
+    WalletDevModeDetailedBalanceEntry self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_dev_mode_detailed_balance_response(
+    WalletDevModeDetailedBalanceResponse self,
     SseSerializer serializer,
   );
 


### PR DESCRIPTION
* Add `dev_mode` field in config
* Add Endpoint `wallet_dev_mode_get_detailed_balance` that returns a listing of funds for each keyset with the expiry of the keyset
* Return `debit`, `credit` and `total` from balance
* Fix Melt URLs