### PR TITLE
Add support for publishing precompiled `wallet_ffi` binaries for iOS and Android

### DIFF
--- a/.github/workflows/cd_precompiled.yml
+++ b/.github/workflows/cd_precompiled.yml
@@ -2,7 +2,8 @@ name: Release precompiled binaries
 
 on:
   push:
-    branches: ["**"]
+    branches: ["**"] # replace with master
+    tags: ["v*"]
     paths:
       - "Cargo.lock"
       - "Cargo.toml"
@@ -10,6 +11,12 @@ on:
       - "cargokit/**"
       - ".github/workflows/cd_precompiled.yml"
   workflow_dispatch:
+    inputs:
+      prerelease:
+        description: "Create GitHub release as a prerelease"
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -70,6 +77,7 @@ jobs:
             --manifest-dir=../../crates/bcr-wallet-ffi \
             --repository=$GITHUB_REPOSITORY \
             --target-commitish=$GITHUB_SHA \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) && '--prerelease' || '' }} \
             --target=aarch64-apple-ios \
             --target=aarch64-apple-ios-sim \
             --target=x86_64-apple-ios
@@ -93,6 +101,7 @@ jobs:
             --manifest-dir=../../crates/bcr-wallet-ffi \
             --repository=$GITHUB_REPOSITORY \
             --target-commitish=$GITHUB_SHA \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) && '--prerelease' || '' }} \
             --android-sdk-location="$android_sdk" \
             --android-ndk-version="$ndk_version" \
             --android-min-sdk-version=27 \

--- a/.github/workflows/cd_precompiled.yml
+++ b/.github/workflows/cd_precompiled.yml
@@ -1,0 +1,105 @@
+name: Release precompiled binaries
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "cargokit/**"
+      - ".github/workflows/cd_precompiled.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: precompiled-binaries-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
+jobs:
+  precompile:
+    name: Precompile ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - platform: ios
+            os: macos-latest
+          - platform: android
+            os: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.PRIVATE_REPO_ACCESS_APP_ID }}
+          private-key: ${{ secrets.PRIVATE_REPO_ACCESS_APP_PRIVATE_KEY }}
+          owner: BitcreditProtocol
+
+      - name: Git auth with app token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+      - name: Activate cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          prefix-key: wallet-ffi-precompiled-${{ matrix.platform }}
+
+      - name: Precompile iOS
+        if: matrix.platform == 'ios'
+        working-directory: cargokit/build_tool
+        run: |
+          dart run build_tool precompile-binaries -v \
+            --manifest-dir=../../crates/bcr-wallet-ffi \
+            --repository=$GITHUB_REPOSITORY \
+            --target-commitish=$GITHUB_SHA \
+            --target=aarch64-apple-ios \
+            --target=aarch64-apple-ios-sim \
+            --target=x86_64-apple-ios
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PRIVATE_KEY: ${{ secrets.PRECOMPILED_BINARIES_SIG_PRIVATE_KEY }}
+
+      - name: Precompile Android
+        if: matrix.platform == 'android'
+        working-directory: cargokit/build_tool
+        run: |
+          android_sdk="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}}"
+          ndk_path="${ANDROID_NDK_HOME:-}"
+          if [ -z "$ndk_path" ]; then
+            ndk_path="$(find "$android_sdk/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)"
+          fi
+          ndk_version="$(basename "$ndk_path")"
+          echo "NDK Version: $ndk_version"
+
+          dart run build_tool precompile-binaries -v \
+            --manifest-dir=../../crates/bcr-wallet-ffi \
+            --repository=$GITHUB_REPOSITORY \
+            --target-commitish=$GITHUB_SHA \
+            --android-sdk-location="$android_sdk" \
+            --android-ndk-version="$ndk_version" \
+            --android-min-sdk-version=27 \
+            --target=armv7-linux-androideabi \
+            --target=aarch64-linux-android \
+            --target=i686-linux-android \
+            --target=x86_64-linux-android
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PRIVATE_KEY: ${{ secrets.PRECOMPILED_BINARIES_SIG_PRIVATE_KEY }}

--- a/.github/workflows/cd_precompiled.yml
+++ b/.github/workflows/cd_precompiled.yml
@@ -2,21 +2,8 @@ name: Release precompiled binaries
 
 on:
   push:
-    branches: ["**"] # replace with master
     tags: ["v*"]
-    paths:
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/**"
-      - "cargokit/**"
-      - ".github/workflows/cd_precompiled.yml"
   workflow_dispatch:
-    inputs:
-      prerelease:
-        description: "Create GitHub release as a prerelease"
-        required: true
-        default: true
-        type: boolean
 
 permissions:
   contents: write
@@ -77,7 +64,7 @@ jobs:
             --manifest-dir=../../crates/bcr-wallet-ffi \
             --repository=$GITHUB_REPOSITORY \
             --target-commitish=$GITHUB_SHA \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) && '--prerelease' || '' }} \
+            --prerelease \
             --target=aarch64-apple-ios \
             --target=aarch64-apple-ios-sim \
             --target=x86_64-apple-ios
@@ -101,7 +88,7 @@ jobs:
             --manifest-dir=../../crates/bcr-wallet-ffi \
             --repository=$GITHUB_REPOSITORY \
             --target-commitish=$GITHUB_SHA \
-            ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) && '--prerelease' || '' }} \
+            --prerelease \
             --android-sdk-location="$android_sdk" \
             --android-ndk-version="$ndk_version" \
             --android-min-sdk-version=27 \

--- a/.github/workflows/cd_precompiled.yml
+++ b/.github/workflows/cd_precompiled.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Dart
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
 
       - name: Create GitHub App token
         id: app-token

--- a/.github/workflows/cd_precompiled.yml
+++ b/.github/workflows/cd_precompiled.yml
@@ -62,8 +62,8 @@ jobs:
         run: |
           dart run build_tool precompile-binaries -v \
             --manifest-dir=../../crates/bcr-wallet-ffi \
-            --repository=$GITHUB_REPOSITORY \
-            --target-commitish=$GITHUB_SHA \
+            --repository="$GITHUB_REPOSITORY" \
+            --target-commitish="$GITHUB_SHA" \
             --prerelease \
             --target=aarch64-apple-ios \
             --target=aarch64-apple-ios-sim \
@@ -86,8 +86,8 @@ jobs:
 
           dart run build_tool precompile-binaries -v \
             --manifest-dir=../../crates/bcr-wallet-ffi \
-            --repository=$GITHUB_REPOSITORY \
-            --target-commitish=$GITHUB_SHA \
+            --repository="$GITHUB_REPOSITORY" \
+            --target-commitish="$GITHUB_SHA" \
             --prerelease \
             --android-sdk-location="$android_sdk" \
             --android-ndk-version="$ndk_version" \

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ In `pubspec.yaml`:
 
 The `ref` can either be a commit hash, a branch or a tag.
 
+### Precompiled binaries
+
+This package publishes signed precompiled iOS and Android Rust binaries from
+`.github/workflows/cd_precompiled.yml`. App CI can opt in by adding
+`cargokit_options.yaml` at the Flutter app root:
+
+```yaml
+use_precompiled_binaries: true
+```
+
+Alternatively set `CARGOKIT_USE_PRECOMPILED_BINARIES=true` in the app build
+environment. Cargokit falls back to a local Rust build if a signed binary for
+the current crate hash and target is not available.
+
 Then, in `main.dart`:
 
 ```dart
@@ -77,4 +91,3 @@ void main() async {
   runApp(const MyApp());
 }
 ```
-

--- a/cargokit/build_tool/lib/src/build_tool.dart
+++ b/cargokit/build_tool/lib/src/build_tool.dart
@@ -135,6 +135,11 @@ class PrecompileBinariesCommand extends Command {
         help: 'Commit-ish used when creating a GitHub release tag',
       )
       ..addFlag(
+        'prerelease',
+        defaultsTo: false,
+        help: 'Create the GitHub release as a prerelease',
+      )
+      ..addFlag(
         "verbose",
         abbr: "v",
         defaultsTo: false,
@@ -199,6 +204,7 @@ class PrecompileBinariesCommand extends Command {
       repositorySlug: RepositorySlug.full(argResults!['repository'] as String),
       targets: targets,
       targetCommitish: argResults!['target-commitish'] as String?,
+      prerelease: argResults!['prerelease'] as bool,
       androidSdkLocation: argResults!['android-sdk-location'] as String?,
       androidNdkVersion: argResults!['android-ndk-version'] as String?,
       androidMinSdkVersion: androidMinSdkVersion,

--- a/cargokit/build_tool/lib/src/build_tool.dart
+++ b/cargokit/build_tool/lib/src/build_tool.dart
@@ -130,6 +130,10 @@ class PrecompileBinariesCommand extends Command {
         'temp-dir',
         help: 'Directory to store temporary build artifacts',
       )
+      ..addOption(
+        'target-commitish',
+        help: 'Commit-ish used when creating a GitHub release tag',
+      )
       ..addFlag(
         "verbose",
         abbr: "v",
@@ -194,6 +198,7 @@ class PrecompileBinariesCommand extends Command {
       manifestDir: manifestDir,
       repositorySlug: RepositorySlug.full(argResults!['repository'] as String),
       targets: targets,
+      targetCommitish: argResults!['target-commitish'] as String?,
       androidSdkLocation: argResults!['android-sdk-location'] as String?,
       androidNdkVersion: argResults!['android-ndk-version'] as String?,
       androidMinSdkVersion: androidMinSdkVersion,

--- a/cargokit/build_tool/lib/src/crate_hash.dart
+++ b/cargokit/build_tool/lib/src/crate_hash.dart
@@ -9,11 +9,14 @@ import 'package:collection/collection.dart';
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as path;
+import 'package:toml/toml.dart';
 
 class CrateHash {
-  /// Computes a hash uniquely identifying crate content. This takes into account
-  /// content all all .rs files inside the src directory, as well as Cargo.toml,
-  /// Cargo.lock, build.rs and cargokit.yaml.
+  /// Computes a hash uniquely identifying crate content.
+  ///
+  /// For workspace crates this also includes workspace package sources and the
+  /// root Cargo manifest/lockfile. The FFI crate depends on sibling crates, so
+  /// hashing only the FFI crate directory can otherwise reuse stale binaries.
   ///
   /// If [tempStorage] is provided, computed hash is stored in a file in that directory
   /// and reused on subsequent calls if the crate content hasn't changed.
@@ -24,10 +27,7 @@ class CrateHash {
     )._compute();
   }
 
-  CrateHash._({
-    required this.manifestDir,
-    required this.tempStorage,
-  });
+  CrateHash._({required this.manifestDir, required this.tempStorage});
 
   String _compute() {
     final files = getFiles();
@@ -99,24 +99,115 @@ class CrateHash {
   }
 
   List<File> getFiles() {
-    final src = Directory(path.join(manifestDir, 'src'));
-    final files = src
-        .listSync(recursive: true, followLinks: false)
-        .whereType<File>()
-        .toList();
-    files.sortBy((element) => element.path);
-    void addFile(String relative) {
-      final file = File(path.join(manifestDir, relative));
-      if (file.existsSync()) {
-        files.add(file);
-      }
+    final files = <File>[];
+    final packageDirs = <String>{path.normalize(path.absolute(manifestDir))};
+
+    final workspaceRoot = _findWorkspaceRoot();
+    if (workspaceRoot != null) {
+      packageDirs.addAll(_workspaceMemberDirs(workspaceRoot));
+      _addFile(files, path.join(workspaceRoot, 'Cargo.toml'));
+      _addFile(files, path.join(workspaceRoot, 'Cargo.lock'));
     }
 
-    addFile('Cargo.toml');
-    addFile('Cargo.lock');
-    addFile('build.rs');
-    addFile('cargokit.yaml');
-    return files;
+    for (final packageDir in packageDirs) {
+      _addSourceFiles(files, packageDir);
+      _addFile(files, path.join(packageDir, 'Cargo.toml'));
+      _addFile(files, path.join(packageDir, 'Cargo.lock'));
+      _addFile(files, path.join(packageDir, 'build.rs'));
+      _addFile(files, path.join(packageDir, 'cargokit.yaml'));
+    }
+
+    final uniqueFiles = files
+        .groupListsBy((file) => path.normalize(path.absolute(file.path)))
+        .values
+        .map((files) => files.first)
+        .toList();
+    uniqueFiles.sortBy((element) => element.path);
+    return uniqueFiles;
+  }
+
+  void _addSourceFiles(List<File> files, String packageDir) {
+    final src = Directory(path.join(packageDir, 'src'));
+    if (src.existsSync()) {
+      files.addAll(
+        src.listSync(recursive: true, followLinks: false).whereType<File>(),
+      );
+    }
+  }
+
+  void _addFile(List<File> files, String filePath) {
+    final file = File(filePath);
+    if (file.existsSync()) {
+      files.add(file);
+    }
+  }
+
+  String? _findWorkspaceRoot() {
+    var current = Directory(path.normalize(path.absolute(manifestDir)));
+
+    while (true) {
+      final manifestFile = File(path.join(current.path, 'Cargo.toml'));
+      if (manifestFile.existsSync()) {
+        final manifest = TomlDocument.parse(manifestFile.readAsStringSync());
+        if (manifest.toMap()['workspace'] is Map) {
+          return current.path;
+        }
+      }
+
+      final parent = current.parent;
+      if (parent.path == current.path) {
+        return null;
+      }
+      current = parent;
+    }
+  }
+
+  List<String> _workspaceMemberDirs(String workspaceRoot) {
+    final manifestFile = File(path.join(workspaceRoot, 'Cargo.toml'));
+    final manifest = TomlDocument.parse(manifestFile.readAsStringSync());
+    final workspace = manifest.toMap()['workspace'];
+    if (workspace is! Map) {
+      return [];
+    }
+
+    final members = workspace['members'];
+    if (members is! List) {
+      return [];
+    }
+
+    return members
+        .whereType<String>()
+        .expand((member) => _expandWorkspaceMember(workspaceRoot, member))
+        .toList(growable: false);
+  }
+
+  Iterable<String> _expandWorkspaceMember(String workspaceRoot, String member) {
+    if (!member.contains('*')) {
+      final memberDir = path.normalize(path.join(workspaceRoot, member));
+      if (File(path.join(memberDir, 'Cargo.toml')).existsSync()) {
+        return [memberDir];
+      }
+      return const [];
+    }
+
+    if (!member.endsWith('/*')) {
+      return const [];
+    }
+
+    final baseDir = Directory(
+      path.normalize(
+        path.join(workspaceRoot, member.substring(0, member.length - 2)),
+      ),
+    );
+    if (!baseDir.existsSync()) {
+      return const [];
+    }
+
+    return baseDir
+        .listSync(followLinks: false)
+        .whereType<Directory>()
+        .where((dir) => File(path.join(dir.path, 'Cargo.toml')).existsSync())
+        .map((dir) => path.normalize(dir.path));
   }
 
   final String manifestDir;

--- a/cargokit/build_tool/lib/src/options.dart
+++ b/cargokit/build_tool/lib/src/options.dart
@@ -236,7 +236,8 @@ class CargokitUserOptions {
     if (value == null) {
       return null;
     }
-    switch (value.toLowerCase()) {
+    final normalizedValue = value.trim().toLowerCase();
+    switch (normalizedValue) {
       case '1':
       case 'true':
       case 'yes':

--- a/cargokit/build_tool/lib/src/options.dart
+++ b/cargokit/build_tool/lib/src/options.dart
@@ -231,9 +231,35 @@ class CargokitCrateOptions {
 }
 
 class CargokitUserOptions {
+  static bool? _environmentUsePrecompiledBinaries() {
+    final value = Platform.environment['CARGOKIT_USE_PRECOMPILED_BINARIES'];
+    if (value == null) {
+      return null;
+    }
+    switch (value.toLowerCase()) {
+      case '1':
+      case 'true':
+      case 'yes':
+      case 'on':
+        return true;
+      case '0':
+      case 'false':
+      case 'no':
+      case 'off':
+        return false;
+      default:
+        throw ArgumentError(
+            'Invalid CARGOKIT_USE_PRECOMPILED_BINARIES value: $value');
+    }
+  }
+
   // When Rustup is installed always build locally unless user opts into
   // using precompiled binaries.
   static bool defaultUsePrecompiledBinaries() {
+    final fromEnvironment = _environmentUsePrecompiledBinaries();
+    if (fromEnvironment != null) {
+      return fromEnvironment;
+    }
     return Rustup.executablePath() == null;
   }
 
@@ -276,6 +302,8 @@ class CargokitUserOptions {
             entry.key.span);
       }
     }
+    usePrecompiledBinaries =
+        _environmentUsePrecompiledBinaries() ?? usePrecompiledBinaries;
     return CargokitUserOptions(
       usePrecompiledBinaries: usePrecompiledBinaries,
       verboseLogging: verboseLogging,

--- a/cargokit/build_tool/lib/src/precompile_binaries.dart
+++ b/cargokit/build_tool/lib/src/precompile_binaries.dart
@@ -199,7 +199,7 @@ class PrecompileBinaries {
         body: jsonEncode({
           'tag_name': tagName,
           'name': 'Precompiled binaries ${hash.substring(0, 8)}',
-          'target_commitish': targetCommitish,
+          if (targetCommitish != null) 'target_commitish': targetCommitish,
           'draft': false,
           'prerelease': prerelease,
           'make_latest': 'false',

--- a/cargokit/build_tool/lib/src/precompile_binaries.dart
+++ b/cargokit/build_tool/lib/src/precompile_binaries.dart
@@ -74,7 +74,7 @@ class PrecompileBinaries {
 
     final github = GitHub(auth: Authentication.withToken(githubToken));
     final repo = github.repositories;
-    final release = await _getOrCreateRelease(
+    var release = await _getOrCreateRelease(
       repo: repo,
       tagName: tagName,
       packageName: crateInfo.packageName,
@@ -174,6 +174,8 @@ class PrecompileBinaries {
         }
       }
     }
+
+    release = await _updateReleaseMetadata(github, release);
 
     _log.info('Cleaning up');
     tempDir.deleteSync(recursive: true);

--- a/cargokit/build_tool/lib/src/precompile_binaries.dart
+++ b/cargokit/build_tool/lib/src/precompile_binaries.dart
@@ -1,6 +1,7 @@
 /// This is copied from Cargokit (which is the official way to use it currently)
 /// Details: https://fzyzcjy.github.io/flutter_rust_bridge/manual/integrate/builtin
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:ed25519_edwards/ed25519_edwards.dart';
@@ -26,6 +27,7 @@ class PrecompileBinaries {
     required this.manifestDir,
     required this.targets,
     this.targetCommitish,
+    required this.prerelease,
     this.androidSdkLocation,
     this.androidNdkVersion,
     this.androidMinSdkVersion,
@@ -38,6 +40,7 @@ class PrecompileBinaries {
   final String manifestDir;
   final List<Target> targets;
   final String? targetCommitish;
+  final bool prerelease;
   final String? androidSdkLocation;
   final String? androidNdkVersion;
   final int? androidMinSdkVersion;
@@ -76,6 +79,7 @@ class PrecompileBinaries {
       tagName: tagName,
       packageName: crateInfo.packageName,
       hash: hash,
+      github: github,
     );
 
     final tempDir = this.tempDir != null
@@ -180,6 +184,7 @@ class PrecompileBinaries {
     required String tagName,
     required String packageName,
     required String hash,
+    required GitHub github,
   }) async {
     Release release;
     try {
@@ -187,17 +192,21 @@ class PrecompileBinaries {
       release = await repo.getReleaseByTagName(repositorySlug, tagName);
     } on ReleaseNotFound {
       _log.info('Release not found - creating release $tagName');
-      release = await repo.createRelease(
-          repositorySlug,
-          CreateRelease.from(
-            tagName: tagName,
-            name: 'Precompiled binaries ${hash.substring(0, 8)}',
-            targetCommitish: targetCommitish,
-            isDraft: false,
-            isPrerelease: false,
-            body: 'Precompiled binaries for crate $packageName, '
-                'crate hash $hash.',
-          ));
+      release = await github.postJSON<Map<String, dynamic>, Release>(
+        '/repos/${repositorySlug.fullName}/releases',
+        statusCode: 201,
+        convert: Release.fromJson,
+        body: jsonEncode({
+          'tag_name': tagName,
+          'name': 'Precompiled binaries ${hash.substring(0, 8)}',
+          'target_commitish': targetCommitish,
+          'draft': false,
+          'prerelease': prerelease,
+          'make_latest': 'false',
+          'body': 'Precompiled binaries for crate $packageName, '
+              'crate hash $hash.',
+        }),
+      );
     }
     return release;
   }

--- a/cargokit/build_tool/lib/src/precompile_binaries.dart
+++ b/cargokit/build_tool/lib/src/precompile_binaries.dart
@@ -25,6 +25,7 @@ class PrecompileBinaries {
     required this.repositorySlug,
     required this.manifestDir,
     required this.targets,
+    this.targetCommitish,
     this.androidSdkLocation,
     this.androidNdkVersion,
     this.androidMinSdkVersion,
@@ -36,6 +37,7 @@ class PrecompileBinaries {
   final RepositorySlug repositorySlug;
   final String manifestDir;
   final List<Target> targets;
+  final String? targetCommitish;
   final String? androidSdkLocation;
   final String? androidNdkVersion;
   final int? androidMinSdkVersion;
@@ -190,7 +192,7 @@ class PrecompileBinaries {
           CreateRelease.from(
             tagName: tagName,
             name: 'Precompiled binaries ${hash.substring(0, 8)}',
-            targetCommitish: null,
+            targetCommitish: targetCommitish,
             isDraft: false,
             isPrerelease: false,
             body: 'Precompiled binaries for crate $packageName, '

--- a/cargokit/build_tool/lib/src/precompile_binaries.dart
+++ b/cargokit/build_tool/lib/src/precompile_binaries.dart
@@ -175,8 +175,6 @@ class PrecompileBinaries {
       }
     }
 
-    release = await _updateReleaseMetadata(github, release);
-
     _log.info('Cleaning up');
     tempDir.deleteSync(recursive: true);
   }

--- a/cargokit/build_tool/lib/src/precompile_binaries.dart
+++ b/cargokit/build_tool/lib/src/precompile_binaries.dart
@@ -208,6 +208,26 @@ class PrecompileBinaries {
         }),
       );
     }
-    return release;
+    return _updateReleaseMetadata(github, release);
+  }
+
+  Future<Release> _updateReleaseMetadata(
+    GitHub github,
+    Release release,
+  ) async {
+    final releaseId = release.id;
+    if (releaseId == null) {
+      return release;
+    }
+    return github.patchJSON<Map<String, dynamic>, Release>(
+      '/repos/${repositorySlug.fullName}/releases/$releaseId',
+      statusCode: 200,
+      convert: Release.fromJson,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'prerelease': prerelease,
+        'make_latest': 'false',
+      }),
+    );
   }
 }

--- a/crates/bcr-wallet-ffi/cargokit.yaml
+++ b/crates/bcr-wallet-ffi/cargokit.yaml
@@ -1,0 +1,6 @@
+precompiled_binaries:
+  # Uri prefix used when downloading precompiled binaries.
+  url_prefix: https://github.com/BitcreditProtocol/Wallet-Core/releases/download/precompiled_
+
+  # Public key for verifying downloaded precompiled binaries.
+  public_key: 65d7c5859d185e114b41b1da4fc71e7d2b7cb8f6e299c465dd641ab2f795716f


### PR DESCRIPTION
This PR:
- adds a `Release precompiled binaries` workflow
- publishes signed precompiled artifacts to `precompiled_<crate_hash>` GitHub prereleases
- adds `cargokit.yaml` for `crates/bcr-wallet-ffi`
- lets app builds opt into precompiled binaries via `cargokit_options.yaml` or `CARGOKIT_USE_PRECOMPILED_BINARIES`

## Testing

- Ran `dart analyze` in `cargokit/build_tool`
- Parsed workflow YAML successfully
- Verified Flutter app builds reach Dart compilation with the new precompiled path configured; current app/core API mismatches block full app build before Android native packaging

-> testing with https://github.com/BitcreditProtocol/wallet/pull/386
-> test dev build https://github.com/BitcreditProtocol/wallet/actions/runs/25132077997


