### PR TITLE
Precompiled binaries fix: add checks for existing release assets and handle uploads

### DIFF
--- a/cargokit/build_tool/lib/src/precompile_binaries.dart
+++ b/cargokit/build_tool/lib/src/precompile_binaries.dart
@@ -120,15 +120,18 @@ class PrecompileBinaries {
               ])
           .toList(growable: false);
 
-      final existingRequiredAssetNames = requiredAssetNames
-          .where((name) => releaseAssets.containsKey(name))
+      final uploadedRequiredAssetNames = requiredAssetNames
+          .where((name) => _assetIsUploaded(releaseAssets[name]))
           .toList(growable: false);
 
-      if (existingRequiredAssetNames.length == requiredAssetNames.length) {
+      if (uploadedRequiredAssetNames.length == requiredAssetNames.length) {
         _log.info("All artifacts for $target already exist - skipping");
         continue;
       }
 
+      final existingRequiredAssetNames = requiredAssetNames
+          .where((name) => releaseAssets.containsKey(name))
+          .toList(growable: false);
       if (existingRequiredAssetNames.isNotEmpty) {
         _log.warning(
             'Found partial artifacts for $target - deleting and rebuilding: '
@@ -199,7 +202,7 @@ class PrecompileBinaries {
       }
 
       final missingAssetNames = requiredAssetNames
-          .where((name) => !releaseAssets.containsKey(name))
+          .where((name) => !_assetIsUploaded(releaseAssets[name]))
           .toList(growable: false);
       if (missingAssetNames.isNotEmpty) {
         throw Exception('Missing uploaded assets for $target: '
@@ -224,6 +227,10 @@ class PrecompileBinaries {
       for (final asset in assets)
         if (asset.name != null) asset.name!: asset,
     };
+  }
+
+  bool _assetIsUploaded(ReleaseAsset? asset) {
+    return asset?.state == 'uploaded';
   }
 
   Future<Release> _getOrCreateRelease({

--- a/cargokit/build_tool/lib/src/precompile_binaries.dart
+++ b/cargokit/build_tool/lib/src/precompile_binaries.dart
@@ -125,7 +125,7 @@ class PrecompileBinaries {
           .toList(growable: false);
 
       if (uploadedRequiredAssetNames.length == requiredAssetNames.length) {
-        _log.info("All artifacts for $target already exist - skipping");
+        _log.info('All artifacts for $target already exist - skipping');
         continue;
       }
 

--- a/cargokit/build_tool/lib/src/precompile_binaries.dart
+++ b/cargokit/build_tool/lib/src/precompile_binaries.dart
@@ -105,6 +105,7 @@ class PrecompileBinaries {
     );
 
     final rustup = Rustup();
+    final releaseAssets = await _releaseAssetsByName(repo, release);
 
     for (final target in targets) {
       final artifactNames = getArtifactNames(
@@ -112,13 +113,30 @@ class PrecompileBinaries {
         libraryName: crateInfo.packageName,
         remote: true,
       );
+      final requiredAssetNames = artifactNames
+          .expand((name) => [
+                PrecompileBinaries.fileName(target, name),
+                signatureFileName(target, name),
+              ])
+          .toList(growable: false);
 
-      if (artifactNames.every((name) {
-        final fileName = PrecompileBinaries.fileName(target, name);
-        return (release.assets ?? []).any((e) => e.name == fileName);
-      })) {
+      final existingRequiredAssetNames = requiredAssetNames
+          .where((name) => releaseAssets.containsKey(name))
+          .toList(growable: false);
+
+      if (existingRequiredAssetNames.length == requiredAssetNames.length) {
         _log.info("All artifacts for $target already exist - skipping");
         continue;
+      }
+
+      if (existingRequiredAssetNames.isNotEmpty) {
+        _log.warning(
+            'Found partial artifacts for $target - deleting and rebuilding: '
+            '$existingRequiredAssetNames');
+        for (final name in existingRequiredAssetNames) {
+          final asset = releaseAssets.remove(name)!;
+          await repo.deleteReleaseAsset(repositorySlug, asset);
+        }
       }
 
       _log.info('Building for $target');
@@ -160,7 +178,13 @@ class PrecompileBinaries {
         int retryCount = 0;
         while (true) {
           try {
-            await repo.uploadReleaseAssets(release, [asset]);
+            final uploaded = await repo.uploadReleaseAssets(release, [asset]);
+            for (final uploadedAsset in uploaded) {
+              final name = uploadedAsset.name;
+              if (name != null) {
+                releaseAssets[name] = uploadedAsset;
+              }
+            }
             break;
           } on Exception catch (e) {
             if (retryCount == 10) {
@@ -173,10 +197,33 @@ class PrecompileBinaries {
           }
         }
       }
+
+      final missingAssetNames = requiredAssetNames
+          .where((name) => !releaseAssets.containsKey(name))
+          .toList(growable: false);
+      if (missingAssetNames.isNotEmpty) {
+        throw Exception('Missing uploaded assets for $target: '
+            '${missingAssetNames.join(', ')}');
+      }
     }
 
     _log.info('Cleaning up');
     tempDir.deleteSync(recursive: true);
+  }
+
+  Future<Map<String, ReleaseAsset>> _releaseAssetsByName(
+    RepositoriesService repo,
+    Release release,
+  ) async {
+    if (release.id == null) {
+      return {};
+    }
+    final assets =
+        await repo.listReleaseAssets(repositorySlug, release).toList();
+    return {
+      for (final asset in assets)
+        if (asset.name != null) asset.name!: asset,
+    };
   }
 
   Future<Release> _getOrCreateRelease({


### PR DESCRIPTION
Running the fix added the missing files to the same hash:
https://github.com/BitcreditProtocol/Wallet-Core/actions/runs/25335089049

```
WARNING: Found partial artifacts for armv7-linux-androideabi - deleting and rebuilding: [armv7-linux-androideabi_libwallet_ffi.so, armv7-linux-androideabi_libwallet_ffi.so.sig]
INFO: Building for armv7-linux-androideabi
INFO: Installing Rust target: armv7-linux-androideabi
FINER: Running command rustup target add --toolchain stable armv7-linux-androideabi
FINER: Running command rustup run stable cargo build --manifest-path ../../crates/bcr-wallet-ffi/Cargo.toml -p wallet_ffi --release --target armv7-linux-androideabi --target-dir /tmp/precompiled_JSHNNE
INFO: Uploading assets: (armv7-linux-androideabi_libwallet_ffi.so, armv7-linux-androideabi_libwallet_ffi.so.sig)
INFO: All artifacts for aarch64-linux-android already exist - skipping
INFO: All artifacts for i686-linux-android already exist - skipping
INFO: All artifacts for x86_64-linux-android already exist - skipping
```


https://github.com/BitcreditProtocol/Wallet-Core/releases/tag/precompiled_a586d16dac8989e40eb36e67937eede4
<img width="740" height="118" alt="image" src="https://github.com/user-attachments/assets/1cb7d4b5-4b0c-4048-a589-95eee80cd07b" />
