### PR TITLE
Latest bcr-common and Melt Fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
     * Nostr clients are now running per-wallet, instead of one per application
 * Add proper error logging to external mint calls
 * Upgrade dependencies
+* Upgrade to latest bcr-common
+* Implement Melt Fees
 
 # 0.9.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,21 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,15 +142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,18 +152,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "async-compression"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
-dependencies = [
- "compression-codecs",
- "compression-core",
- "pin-project-lite",
- "tokio",
-]
 
 [[package]]
 name = "async-trait"
@@ -301,7 +265,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bcr-common"
 version = "0.7.0"
-source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=6fa6decd59da74e9a325a49d56adf8fe88e03bfc#6fa6decd59da74e9a325a49d56adf8fe88e03bfc"
+source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=288a0dc243688ad785dce33dae3e120d4ce6b498#288a0dc243688ad785dce33dae3e120d4ce6b498"
 dependencies = [
  "async-trait",
  "bdk_wallet",
@@ -309,7 +273,6 @@ dependencies = [
  "bitcoin",
  "borsh",
  "cashu",
- "cdk",
  "cdk-common",
  "chrono",
  "ciborium",
@@ -378,6 +341,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -392,6 +356,7 @@ dependencies = [
  "serde",
  "strum",
  "thiserror 2.0.18",
+ "url",
  "uuid",
 ]
 
@@ -412,6 +377,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "url",
  "uuid",
 ]
 
@@ -454,12 +420,6 @@ dependencies = [
 
 [[package]]
 name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
-
-[[package]]
-name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
@@ -485,7 +445,7 @@ checksum = "9cf93e61f2dbc3e3c41234ca26a65e2c0b0975c52e0f069ab9893ebbede584d3"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
- "bech32 0.11.1",
+ "bech32",
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
@@ -581,27 +541,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "brotli"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -705,50 +644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
-]
-
-[[package]]
-name = "cdk"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91e06069935fd4b63a9ee36be8e4cb70e8e43485fd65169926fbdaa38f8bc76"
-dependencies = [
- "anyhow",
- "arc-swap",
- "async-trait",
- "bech32 0.9.1",
- "bitcoin",
- "cbor-diag",
- "cdk-common",
- "cdk-signatory",
- "ciborium",
- "futures",
- "getrandom 0.2.17",
- "gloo-timers",
- "lightning",
- "lightning-invoice",
- "regex",
- "reqwest",
- "ring",
- "rustls",
- "serde",
- "serde_json",
- "serde_with",
- "sync_wrapper 0.1.2",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite",
- "tokio-util",
- "tracing",
- "url",
- "uuid",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-time",
- "zeroize",
 ]
 
 [[package]]
@@ -774,28 +670,6 @@ dependencies = [
  "url",
  "uuid",
  "web-time",
-]
-
-[[package]]
-name = "cdk-signatory"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff58811ad1426a11920d47b7ec62a20ebd2393fe0486d967f9d50f3c507c4e7"
-dependencies = [
- "anyhow",
- "async-trait",
- "bip39",
- "bitcoin",
- "cdk-common",
- "clap",
- "getrandom 0.2.17",
- "home",
- "rustls",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -944,26 +818,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "compression-codecs"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
-dependencies = [
- "brotli",
- "compression-core",
- "flate2",
- "memchr",
- "zstd",
- "zstd-safe",
-]
-
-[[package]]
-name = "compression-core"
-version = "0.4.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
-
-[[package]]
 name = "config"
 version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,16 +877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,15 +889,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1271,30 +1106,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "flutter_rust_bridge"
@@ -1623,15 +1438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,7 +1506,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1966,16 +1771,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,7 +1823,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ffe63f56b10d214be1ade8698ee80af82d981237cae3e581e7a631f5f4959f3"
 dependencies = [
- "bech32 0.11.1",
+ "bech32",
  "bitcoin",
  "dnssec-prover",
  "hashbrown 0.13.2",
@@ -2044,7 +1839,7 @@ version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
 dependencies = [
- "bech32 0.11.1",
+ "bech32",
  "bitcoin",
  "lightning-types",
  "serde",
@@ -2093,15 +1888,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,7 +1915,7 @@ version = "12.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c14116d8342edd3626b0f8e84df16f4e6a76dc04799ba747493403236a1b8ac5"
 dependencies = [
- "bech32 0.11.1",
+ "bech32",
  "bitcoin",
  "serde",
 ]
@@ -2141,7 +1927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -2204,7 +1989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
 dependencies = [
  "base64 0.22.1",
- "bech32 0.11.1",
+ "bech32",
  "bip39",
  "bitcoin_hashes",
  "cbc",
@@ -2353,12 +2138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,16 +2156,6 @@ dependencies = [
  "cc",
  "dashmap",
  "log",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -2483,12 +2252,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
@@ -2826,12 +2589,11 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tower",
@@ -2909,18 +2671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,15 +2710,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
  "cipher",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3032,29 +2773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -3225,22 +2943,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3311,12 +3013,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -3476,9 +3172,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -3518,17 +3212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3537,7 +3220,6 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3618,7 +3300,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -3630,17 +3312,12 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
- "async-compression",
  "bitflags",
  "bytes",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
- "http-body-util",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3709,14 +3386,10 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
- "matchers",
  "nu-ansi-term",
- "once_cell",
- "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -3905,6 +3578,7 @@ dependencies = [
  "once_cell",
  "tokio",
  "tokio-util",
+ "url",
  "uuid",
 ]
 
@@ -4511,31 +4185,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ strip = "symbols"
 
 [workspace.dependencies]
 async-trait = {version = "0.1"}
-bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "6fa6decd59da74e9a325a49d56adf8fe88e03bfc"}
+bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "288a0dc243688ad785dce33dae3e120d4ce6b498"}
 bcr-wallet-core = {path = "./crates/bcr-wallet-core"}
 bcr-wallet-api = {path = "./crates/bcr-wallet-api"}
 bcr-wallet-persistence = {path = "./crates/bcr-wallet-persistence"}

--- a/crates/bcr-wallet-api/src/config.rs
+++ b/crates/bcr-wallet-api/src/config.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use crate::error::Result;
-use bcr_common::cashu::MintUrl;
 use nostr_sdk::{Keys, RelayUrl, nips::nip06::FromMnemonic, nips::nip19::Nip19Profile};
 
 pub const LOCK_REDUCTION_SECONDS_PER_HOP: u64 = 600;
@@ -21,7 +20,7 @@ pub struct CreateWalletConfig {
     pub network: bitcoin::Network,
     pub nostr_relays: Vec<RelayUrl>,
     pub mnemonic: bip39::Mnemonic,
-    pub default_mint_url: MintUrl,
+    pub default_mint_url: url::Url,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/bcr-wallet-api/src/error.rs
+++ b/crates/bcr-wallet-api/src/error.rs
@@ -1,5 +1,5 @@
 use bcr_common::{
-    cashu::{self, MintUrl},
+    cashu::{self},
     cdk_common,
 };
 use thiserror::Error;
@@ -91,8 +91,6 @@ pub enum Error {
     InvalidNetwork(bitcoin::Network, bitcoin::Network),
     #[error("mnemonic mismatch")]
     InvalidMnemonic,
-    #[error("mint url mismatch, ours: {0}, theirs: {1}")]
-    InvalidMintUrl(MintUrl, MintUrl),
     #[error("payment request, missing amount")]
     MissingAmount,
     #[error("payment request unknown {0}")]
@@ -114,7 +112,7 @@ pub enum Error {
     #[error("Invalid Clowder Path for foreign eCash")]
     InvalidClowderPath,
     #[error("Beta not found")]
-    BetaNotFound(cashu::MintUrl),
+    BetaNotFound(url::Url),
     #[error("No Substitute could be determined")]
     NoSubstitute,
     #[error("No beta mints available")]

--- a/crates/bcr-wallet-api/src/external/mint.rs
+++ b/crates/bcr-wallet-api/src/external/mint.rs
@@ -18,7 +18,6 @@ use bcr_wallet_core::SendSync;
 use bitcoin::base64::prelude::*;
 use bitcoin::secp256k1;
 use rand::seq::IndexedRandom;
-use std::str::FromStr;
 use tracing::debug;
 
 pub struct SwapCommitmentResult {
@@ -34,6 +33,7 @@ pub struct SwapCommitmentResult {
 pub struct MeltQuoteResult {
     pub quote_id: uuid::Uuid,
     pub expiry: u64,
+    pub amount: bitcoin::Amount,
     pub commitment: secp256k1::schnorr::Signature,
     pub ephemeral_secret: secp256k1::SecretKey,
     pub body_content: String,
@@ -111,7 +111,6 @@ async fn post_melt_quote_onchain_inner(
     url: reqwest::Url,
     inputs: Vec<cashu::Proof>,
     address: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
-    amount: bitcoin::Amount,
     alpha_pk: secp256k1::PublicKey,
 ) -> Result<MeltQuoteResult> {
     let ephemeral_keypair =
@@ -127,7 +126,6 @@ async fn post_melt_quote_onchain_inner(
     let request = wire_melt::MeltQuoteOnchainRequest {
         inputs: fingerprints,
         address,
-        amount,
         wallet_key,
     };
 
@@ -151,6 +149,7 @@ async fn post_melt_quote_onchain_inner(
             Ok(MeltQuoteResult {
                 quote_id: response_body.quote,
                 expiry: response_body.expiry,
+                amount: response_body.amount,
                 commitment,
                 ephemeral_secret,
                 body_content: response_content,
@@ -171,13 +170,9 @@ async fn post_melt_quote_onchain_inner(
     }
 }
 
-fn convert_mint_url(mint_url: cashu::MintUrl) -> MintResult<reqwest::Url> {
-    reqwest::Url::from_str(&mint_url.to_string()).map_err(|e| MintError::Internal(e.to_string()))
-}
-
 #[async_trait]
 pub trait ClowderMintConnector: SendSync {
-    fn mint_url(&self) -> cashu::MintUrl;
+    fn mint_url(&self) -> url::Url;
     async fn post_restore(
         &self,
         request: cashu::RestoreRequest,
@@ -188,7 +183,7 @@ pub trait ClowderMintConnector: SendSync {
     ) -> MintResult<Vec<cashu::ProofState>>;
     async fn get_mint_keyset(&self, keyset_id: cashu::Id) -> MintResult<cashu::KeySet>;
     async fn get_mint_keysets(&self) -> MintResult<Vec<cashu::KeySetInfo>>;
-    async fn get_clowder_betas(&self) -> MintResult<Vec<cashu::MintUrl>>;
+    async fn get_clowder_betas(&self) -> MintResult<Vec<url::Url>>;
     async fn post_online_exchange(
         &self,
         alpha_proofs: Vec<Proof>,
@@ -197,7 +192,7 @@ pub trait ClowderMintConnector: SendSync {
     async fn get_clowder_id(&self) -> MintResult<secp256k1::PublicKey>;
     async fn post_clowder_path(
         &self,
-        origin_mint_url: cashu::MintUrl,
+        origin_mint_url: url::Url,
     ) -> MintResult<ConnectedMintsResponse>;
     async fn get_alpha_keysets(
         &self,
@@ -237,7 +232,6 @@ pub trait ClowderMintConnector: SendSync {
         &self,
         inputs: Vec<cashu::Proof>,
         address: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
-        amount: bitcoin::Amount,
         alpha_pk: secp256k1::PublicKey,
     ) -> Result<MeltQuoteResult>;
     async fn post_melt_onchain(
@@ -270,12 +264,10 @@ pub struct HttpClientExt {
 }
 
 impl HttpClientExt {
-    pub fn new(cdk_url: cashu::MintUrl) -> Self {
-        let mint_url = reqwest::Url::parse(&cdk_url.to_string())
-            .expect("cashu::MintUrl is as good as reqwest::Url");
+    pub fn new(cdk_url: url::Url) -> Self {
         Self {
-            main: MintClient::new(mint_url.clone()),
-            url: mint_url,
+            main: MintClient::new(cdk_url.clone()),
+            url: cdk_url,
             secondary: reqwest::Client::new(),
         }
     }
@@ -283,9 +275,8 @@ impl HttpClientExt {
 
 #[async_trait]
 impl ClowderMintConnector for HttpClientExt {
-    fn mint_url(&self) -> cashu::MintUrl {
-        cashu::MintUrl::from_str(self.url.as_str())
-            .expect("cashu::MintUrl is as good as reqwest::Url")
+    fn mint_url(&self) -> url::Url {
+        self.url.clone()
     }
 
     async fn post_restore(
@@ -357,7 +348,7 @@ impl ClowderMintConnector for HttpClientExt {
         self.main.get_substitute(&alpha_id).await
     }
 
-    async fn get_clowder_betas(&self) -> MintResult<Vec<cashu::MintUrl>> {
+    async fn get_clowder_betas(&self) -> MintResult<Vec<url::Url>> {
         debug!("Clowder client call to get_clowder_betas");
         let response = self.main.get_betas().await?;
         Ok(response.mints.into_iter().map(|m| m.mint).collect())
@@ -408,12 +399,10 @@ impl ClowderMintConnector for HttpClientExt {
 
     async fn post_clowder_path(
         &self,
-        origin_mint_url: cashu::MintUrl,
+        origin_mint_url: url::Url,
     ) -> MintResult<ConnectedMintsResponse> {
         debug!("Clowder client call to post_clowder_path for mint url {origin_mint_url}");
-        self.main
-            .post_path(convert_mint_url(origin_mint_url)?)
-            .await
+        self.main.post_path(origin_mint_url).await
     }
 
     async fn post_swap_commitment(
@@ -503,7 +492,6 @@ impl ClowderMintConnector for HttpClientExt {
         &self,
         inputs: Vec<cashu::Proof>,
         address: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
-        amount: bitcoin::Amount,
         alpha_pk: secp256k1::PublicKey,
     ) -> Result<MeltQuoteResult> {
         let url = self
@@ -511,7 +499,7 @@ impl ClowderMintConnector for HttpClientExt {
             .join("v1/melt/quote/onchain")
             .expect("melt_quote_onchain url error");
         debug!("HTTP call to melt_quote_onchain on {url}");
-        post_melt_quote_onchain_inner(&self.secondary, url, inputs, address, amount, alpha_pk).await
+        post_melt_quote_onchain_inner(&self.secondary, url, inputs, address, alpha_pk).await
     }
 
     async fn post_melt_onchain(
@@ -683,15 +671,7 @@ pub struct SentinelClient {
 }
 
 impl SentinelClient {
-    pub fn new(client: HttpClientExt, sentinels: Vec<cashu::MintUrl>) -> Self {
-        let sentinels = sentinels
-            .iter()
-            .map(|url| {
-                reqwest::Url::parse(&url.to_string())
-                    .expect("cashu::MintUrl is as good as reqwest::Url")
-            })
-            .collect();
-
+    pub fn new(client: HttpClientExt, sentinels: Vec<url::Url>) -> Self {
         let HttpClientExt {
             main,
             url,
@@ -718,9 +698,8 @@ impl SentinelClient {
 
 #[async_trait]
 impl ClowderMintConnector for SentinelClient {
-    fn mint_url(&self) -> cashu::MintUrl {
-        cashu::MintUrl::from_str(self.url.as_str())
-            .expect("cashu::MintUrl is as good as reqwest::Url")
+    fn mint_url(&self) -> url::Url {
+        self.url.clone()
     }
 
     async fn post_restore(
@@ -783,7 +762,7 @@ impl ClowderMintConnector for SentinelClient {
         self.main.get_substitute(&alpha_id).await
     }
 
-    async fn get_clowder_betas(&self) -> MintResult<Vec<cashu::MintUrl>> {
+    async fn get_clowder_betas(&self) -> MintResult<Vec<url::Url>> {
         debug!("Clowder client call to get_clowder_betas on sentinel");
         let response = self.main.get_betas().await?;
         Ok(response.mints.into_iter().map(|m| m.mint).collect())
@@ -834,14 +813,12 @@ impl ClowderMintConnector for SentinelClient {
 
     async fn post_clowder_path(
         &self,
-        origin_mint_url: cashu::MintUrl,
+        origin_mint_url: url::Url,
     ) -> MintResult<ConnectedMintsResponse> {
         debug!(
             "Clowder client call to post_clowder_path on sentinel for mint url {origin_mint_url}"
         );
-        self.main
-            .post_path(convert_mint_url(origin_mint_url)?)
-            .await
+        self.main.post_path(origin_mint_url).await
     }
 
     async fn post_swap_commitment(
@@ -946,7 +923,6 @@ impl ClowderMintConnector for SentinelClient {
         &self,
         inputs: Vec<cashu::Proof>,
         address: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
-        amount: bitcoin::Amount,
         alpha_pk: secp256k1::PublicKey,
     ) -> Result<MeltQuoteResult> {
         let url = self
@@ -954,7 +930,7 @@ impl ClowderMintConnector for SentinelClient {
             .join(TreasuryEp::MELTQUOTE_ONCHAIN_V1_EXT)
             .expect("melt_quote_onchain url error");
         debug!("HTTP call on sentinel to melt_quote_onchain on {url}");
-        post_melt_quote_onchain_inner(&self.secondary, url, inputs, address, amount, alpha_pk).await
+        post_melt_quote_onchain_inner(&self.secondary, url, inputs, address, alpha_pk).await
     }
 
     async fn post_melt_onchain(

--- a/crates/bcr-wallet-api/src/external/test_utils.rs
+++ b/crates/bcr-wallet-api/src/external/test_utils.rs
@@ -17,7 +17,7 @@ pub mod tests {
         }
         #[async_trait]
         impl crate::ClowderMintConnector for MintConnector {
-            fn mint_url(&self) -> cashu::MintUrl;
+            fn mint_url(&self) -> url::Url;
             async fn post_restore(
                 &self,
                 request: cashu::RestoreRequest,
@@ -28,7 +28,7 @@ pub mod tests {
             ) -> MintResult<Vec<cashu::ProofState>>;
             async fn get_mint_keyset(&self, keyset_id: cashu::Id) -> MintResult<cashu::KeySet>;
             async fn get_mint_keysets(&self) -> MintResult<Vec<cashu::KeySetInfo>>;
-            async fn get_clowder_betas(&self) -> MintResult<Vec<cashu::MintUrl>>;
+            async fn get_clowder_betas(&self) -> MintResult<Vec<url::Url>>;
             async fn post_online_exchange(
                 &self,
                 alpha_proofs: Vec<cashu::Proof>,
@@ -37,7 +37,7 @@ pub mod tests {
             async fn get_clowder_id(&self) -> MintResult<secp256k1::PublicKey>;
             async fn post_clowder_path(
                 &self,
-                origin_mint_url: cashu::MintUrl,
+                origin_mint_url: url::Url,
             ) -> MintResult<bcr_common::wire::clowder::ConnectedMintsResponse>;
             async fn get_alpha_keysets(
                 &self,
@@ -71,7 +71,6 @@ pub mod tests {
                 &self,
                 inputs: Vec<cashu::Proof>,
                 address: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
-                amount: bitcoin::Amount,
                 alpha_pk: secp256k1::PublicKey,
             ) -> Result<crate::external::mint::MeltQuoteResult>;
             async fn post_melt_onchain(

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -4,7 +4,7 @@ use crate::wallet::types::{WalletBalance, WalletDetailedBalanceEntry, WalletProt
 use crate::{config::NostrConfig, wallet::api::WalletApi};
 use bcr_common::cdk_common::wallet::Transaction;
 use bcr_common::{
-    cashu::{self, CurrencyUnit, MintUrl},
+    cashu::{self, CurrencyUnit},
     cdk_common::wallet::TransactionId,
     wallet::Token,
 };
@@ -225,7 +225,7 @@ impl AppState {
         Ok(())
     }
 
-    pub async fn purse_migrate_rabid(&self) -> Result<HashMap<String, MintUrl>> {
+    pub async fn purse_migrate_rabid(&self) -> Result<HashMap<String, url::Url>> {
         tracing::debug!("purse_migrate_rabid");
 
         let purse = self.get_purse();
@@ -875,7 +875,7 @@ async fn build_wallet(
         seed,
     ));
 
-    let mut beta_clients = HashMap::<cashu::MintUrl, Arc<dyn ClowderMintConnector>>::new();
+    let mut beta_clients = HashMap::<url::Url, Arc<dyn ClowderMintConnector>>::new();
     for beta in w_cfg.betas.clone() {
         let beta_client = HttpClientExt::new(beta.clone());
         beta_clients.insert(beta, Arc::new(beta_client));

--- a/crates/bcr-wallet-api/src/pocket/debit.rs
+++ b/crates/bcr-wallet-api/src/pocket/debit.rs
@@ -759,7 +759,6 @@ impl DebitPocketApi for Pocket {
         let parsed_address: bitcoin::Address<bitcoin::address::NetworkUnchecked> = address
             .parse()
             .map_err(|e| Error::MintingError(format!("invalid address: {e}")))?;
-        let btc_amount = bitcoin::Amount::from_sat(amount);
 
         let (_, send_ref) = self
             .compute_send_costs(Amount::from(amount), keysets_info)
@@ -777,10 +776,10 @@ impl DebitPocketApi for Pocket {
         .await?;
         let sent_ys: Vec<cdk01::PublicKey> = sending_proofs.keys().cloned().collect();
 
-        let quote_and_record = async {
+        let quote_record_amount = async {
             let proofs: Vec<cashu::Proof> = sending_proofs.values().cloned().collect();
             let quote_result = client
-                .post_melt_quote_onchain(proofs, parsed_address, btc_amount, swap_config.alpha_pk)
+                .post_melt_quote_onchain(proofs, parsed_address, swap_config.alpha_pk)
                 .await?;
             let quote_id = quote_result.quote_id;
             let expiry = quote_result.expiry;
@@ -792,11 +791,11 @@ impl DebitPocketApi for Pocket {
                 body_content: quote_result.body_content,
             };
             self.mdb.store_melt_commitment(record).await?;
-            Ok::<_, Error>((quote_id, expiry))
+            Ok::<_, Error>((quote_id, expiry, quote_result.amount))
         }
         .await;
 
-        let (quote_id, expiry) = match quote_and_record {
+        let (quote_id, expiry, offered_amount) = match quote_record_amount {
             Ok(r) => r,
             Err(e) => {
                 for y in &sent_ys {
@@ -810,9 +809,16 @@ impl DebitPocketApi for Pocket {
             }
         };
 
+        let fee = if offered_amount.to_sat() > amount {
+            Amount::from(offered_amount.to_sat() - amount)
+        } else {
+            Amount::ZERO
+        };
+
         let mut summary = MeltSummary::new();
         summary.amount = Amount::from(amount);
         summary.expiry = expiry;
+        summary.fees = fee;
         let melt_ref = MeltReference {
             rid: summary.request_id,
             quote_id,
@@ -1156,7 +1162,7 @@ impl DebitPocketApi for Pocket {
                 Ok(MeltProtestResult {
                     base: ProtestResult {
                         status: wire_common::ProtestStatus::Resolved,
-                        result: Some((body.total, ys)),
+                        result: Some((cashu::Amount::from(body.amount.to_sat()), ys)),
                     },
                     txid: response.txid,
                 })
@@ -1189,7 +1195,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        external::test_utils::tests::MockMintConnector,
+        external::{mint::MeltQuoteResult, test_utils::tests::MockMintConnector},
         pocket::{PocketApi, debit::DebitPocketApi},
     };
     use bcr_common::{core_tests, wire::mint::MintResponse};
@@ -1554,7 +1560,6 @@ mod tests {
             address: bitcoin::Address::from_str("tb1qteyk7pfvvql2r2zrsu4h4xpvju0nz7ykvguyk0")
                 .expect("valid address"),
             amount: bitcoin::Amount::from_sat(100),
-            total: cashu::Amount::from(100u64),
             expiry: 999999,
             wallet_key,
         };
@@ -1609,7 +1614,6 @@ mod tests {
             address: bitcoin::Address::from_str("tb1qteyk7pfvvql2r2zrsu4h4xpvju0nz7ykvguyk0")
                 .expect("valid address"),
             amount: bitcoin::Amount::from_sat(amount),
-            total: cashu::Amount::from(amount),
             expiry: 999999,
             wallet_key,
         };
@@ -2616,6 +2620,106 @@ mod tests {
                 chrono::Utc::now().timestamp() as u64,
                 test_swap_config(),
                 clowder_id,
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::MintingError(_))));
+    }
+
+    #[tokio::test]
+    async fn prepare_onchain_melt_ready_success() {
+        let (info, keyset) = core_tests::generate_random_ecash_keyset();
+        let k_infos = vec![KeySetInfo::from(info)];
+
+        let amount = 24;
+        let quote_id = Uuid::new_v4();
+        let expiry = 999999;
+        let offered_amount = bitcoin::Amount::from_sat(25);
+
+        let proofs =
+            core_tests::generate_random_ecash_proofs(&keyset, &[Amount::from(8), Amount::from(16)]);
+
+        let proofs_by_y: HashMap<_, _> = proofs
+            .iter()
+            .cloned()
+            .map(|p| (p.y().unwrap(), p))
+            .collect();
+
+        let mut pdb = MockPocketRepository::new();
+        let mut mdb = MockMintMeltRepository::new();
+        let mut connector = MockMintConnector::new();
+
+        let unspent = proofs_by_y.clone();
+        pdb.expect_list_unspent()
+            .times(1)
+            .returning(move || Ok(unspent.clone()));
+
+        let pending = proofs_by_y.clone();
+        pdb.expect_mark_as_pendingspent()
+            .times(2)
+            .returning(move |y| Ok(pending.get(&y).unwrap().clone()));
+
+        connector
+            .expect_post_melt_quote_onchain()
+            .times(1)
+            .returning(move |_, _, _| {
+                Ok(MeltQuoteResult {
+                    quote_id,
+                    expiry,
+                    amount: offered_amount,
+                    commitment: cashu::SecretKey::generate().sign(&[0; 32]).unwrap(),
+                    ephemeral_secret: secp256k1::SecretKey::from_keypair(
+                        &secp256k1::Keypair::new_global(&mut secp256k1::rand::thread_rng()),
+                    ),
+                    body_content: mock_melt_commitment_body(quote_id, offered_amount.to_sat()),
+                })
+            });
+
+        mdb.expect_store_melt_commitment()
+            .times(1)
+            .returning(|_| Ok(()));
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+
+        let summary = pocket
+            .prepare_onchain_melt(
+                valid_payment_address_testnet().assume_checked().to_string(),
+                amount,
+                &k_infos,
+                Arc::new(connector),
+                test_swap_config(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(summary.amount, Amount::from(amount));
+        assert_eq!(summary.expiry, expiry);
+        assert_eq!(summary.fees, Amount::from(1));
+
+        let current_melt = pocket.current_melt.lock().unwrap();
+        let melt_ref = current_melt.as_ref().unwrap();
+        assert_eq!(melt_ref.rid, summary.request_id);
+        assert_eq!(melt_ref.quote_id, quote_id);
+    }
+
+    #[tokio::test]
+    async fn prepare_onchain_melt_rejects_invalid_address() {
+        let (_info, _keyset) = core_tests::generate_random_ecash_keyset();
+        let k_infos = vec![KeySetInfo::from(_info)];
+
+        let pdb = MockPocketRepository::new();
+        let mdb = MockMintMeltRepository::new();
+        let connector = MockMintConnector::new();
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+
+        let result = pocket
+            .prepare_onchain_melt(
+                "invalid-bitcoin-address".to_string(),
+                24,
+                &k_infos,
+                Arc::new(connector),
+                test_swap_config(),
             )
             .await;
 

--- a/crates/bcr-wallet-api/src/pocket/mod.rs
+++ b/crates/bcr-wallet-api/src/pocket/mod.rs
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn unblind_proofs() {
-        let amounts = [Amount::from(8u64)];
+        let amounts = [Amount::from(8)];
         let (_, mintkeyset) = core_tests::generate_random_ecash_keyset();
         let keyset = cdk02::KeySet::from(mintkeyset.clone());
         let premint =
@@ -487,12 +487,11 @@ mod tests {
         let (_, mintkeyset) = core_tests::generate_random_ecash_keyset();
         let keyset = cdk02::KeySet::from(mintkeyset.clone());
         let premint =
-            cdk00::PreMintSecrets::random(keyset.id, Amount::from(8u64), &SplitTarget::None)
-                .unwrap();
+            cdk00::PreMintSecrets::random(keyset.id, Amount::from(8), &SplitTarget::None).unwrap();
         assert_eq!(premint.blinded_messages().len(), 1);
         let signatures = core_tests::generate_ecash_signatures(
             &mintkeyset,
-            &[Amount::from(8u64), Amount::from(32u64)],
+            &[Amount::from(8), Amount::from(32)],
         );
         let proofs = super::unblind_proofs(&keyset, signatures, premint);
         assert_eq!(proofs.len(), 1);
@@ -503,12 +502,11 @@ mod tests {
         let (_, mintkeyset) = core_tests::generate_random_ecash_keyset();
         let keyset = cdk02::KeySet::from(mintkeyset.clone());
         let premint =
-            cdk00::PreMintSecrets::random(keyset.id, Amount::from(40u64), &SplitTarget::None)
-                .unwrap();
+            cdk00::PreMintSecrets::random(keyset.id, Amount::from(40), &SplitTarget::None).unwrap();
         assert_eq!(premint.blinded_messages().len(), 2);
         let signatures = core_tests::generate_ecash_signatures(
             &mintkeyset,
-            &[Amount::from(16u64), Amount::from(4u64)],
+            &[Amount::from(16), Amount::from(4)],
         );
         let proofs = super::unblind_proofs(&keyset, signatures, premint);
         assert_eq!(proofs.len(), 0);
@@ -520,9 +518,9 @@ mod tests {
         let keyset = cdk02::KeySet::from(mintkeyset.clone());
         let kid2 = core_tests::generate_random_ecash_keyset().0.id;
         let premint =
-            cdk00::PreMintSecrets::random(kid2, Amount::from(16u64), &SplitTarget::None).unwrap();
+            cdk00::PreMintSecrets::random(kid2, Amount::from(16), &SplitTarget::None).unwrap();
         assert_eq!(premint.blinded_messages().len(), 1);
-        let signatures = core_tests::generate_ecash_signatures(&mintkeyset, &[Amount::from(16u64)]);
+        let signatures = core_tests::generate_ecash_signatures(&mintkeyset, &[Amount::from(16)]);
         let proofs = super::unblind_proofs(&keyset, signatures, premint);
         assert_eq!(proofs.len(), 0);
     }
@@ -533,8 +531,8 @@ mod tests {
     async fn swap_proof_to_target() {
         let (info, keyset) = core_tests::generate_random_ecash_keyset();
         let k_infos = vec![KeySetInfo::from(info)];
-        let amount = Amount::from(16u64);
-        let target = Amount::from(13u64);
+        let amount = Amount::from(16);
+        let target = Amount::from(13);
         let proof = core_tests::generate_random_ecash_proofs(&keyset, &[amount])[0].clone();
         let seed = zero_seed();
         let mut mockdb = MockPocketRepository::new();
@@ -589,13 +587,12 @@ mod tests {
     #[tokio::test]
     async fn swap() {
         let (info, keyset) = core_tests::generate_random_ecash_keyset();
-        let amounts = [Amount::from(8u64), Amount::from(16u64)];
+        let amounts = [Amount::from(8), Amount::from(16)];
         let unit = CurrencyUnit::Sat;
         let inputs = core_tests::generate_random_ecash_proofs(&keyset, &amounts);
         let premints = HashMap::from_iter([(
             info.id,
-            cdk00::PreMintSecrets::random(info.id, Amount::from(24u64), &SplitTarget::None)
-                .unwrap(),
+            cdk00::PreMintSecrets::random(info.id, Amount::from(24), &SplitTarget::None).unwrap(),
         )]);
         let keysets = HashMap::from([(info.id, KeySet::from(keyset.clone()))]);
         let mut mockclient = MockMintConnector::new();
@@ -626,13 +623,13 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(amount, Amount::from(24u64));
+        assert_eq!(amount, Amount::from(24));
     }
 
     #[tokio::test]
     async fn send_proofs_ready() {
         let (_, keyset) = core_tests::generate_random_ecash_keyset();
-        let amounts = [Amount::from(8u64), Amount::from(16u64)];
+        let amounts = [Amount::from(8), Amount::from(16)];
         let proofs = core_tests::generate_random_ecash_proofs(&keyset, &amounts);
         let ys = proofs.iter().map(|p| p.y().unwrap()).collect::<Vec<_>>();
 
@@ -654,7 +651,7 @@ mod tests {
         let sent = super::send_proofs(
             SendPlan::Ready { proofs: ys },
             &[],
-            Amount::from(24u64),
+            Amount::from(24),
             &zero_seed(),
             &mockdb,
             &arc_client,
@@ -670,7 +667,7 @@ mod tests {
                 .collect::<Vec<_>>()
                 .total_amount()
                 .unwrap(),
-            Amount::from(24u64)
+            Amount::from(24)
         );
     }
 
@@ -680,12 +677,12 @@ mod tests {
         let k_infos = vec![KeySetInfo::from(info.clone())];
 
         let swap_proof =
-            core_tests::generate_random_ecash_proofs(&keyset, &[Amount::from(16u64)])[0].clone();
+            core_tests::generate_random_ecash_proofs(&keyset, &[Amount::from(16)])[0].clone();
         let swap_y = swap_proof.y().unwrap();
 
         let ready_proofs = core_tests::generate_random_ecash_proofs(
             &keyset,
-            &[Amount::from(8u64), Amount::from(4u64), Amount::from(1u64)],
+            &[Amount::from(8), Amount::from(4), Amount::from(1)],
         );
 
         let ready_by_y = ready_proofs
@@ -748,11 +745,11 @@ mod tests {
         let sent = super::send_proofs(
             SendPlan::NeedSplit {
                 proof: swap_y,
-                split_amount: Amount::from(13u64),
-                estimated_fee: Amount::from(0u64),
+                split_amount: Amount::from(13),
+                estimated_fee: Amount::from(0),
             },
             &k_infos,
-            Amount::from(13u64),
+            Amount::from(13),
             &zero_seed(),
             &mockdb,
             &arc_client,
@@ -768,7 +765,7 @@ mod tests {
                 .collect::<Vec<_>>()
                 .total_amount()
                 .unwrap(),
-            Amount::from(13u64)
+            Amount::from(13)
         );
     }
 
@@ -778,11 +775,11 @@ mod tests {
         let k_infos = vec![KeySetInfo::from(info.clone())];
 
         let swap_proof =
-            core_tests::generate_random_ecash_proofs(&keyset, &[Amount::from(16u64)])[0].clone();
+            core_tests::generate_random_ecash_proofs(&keyset, &[Amount::from(16)])[0].clone();
         let swap_y = swap_proof.y().unwrap();
 
         let unsplittable =
-            core_tests::generate_random_ecash_proofs(&keyset, &[Amount::from(16u64)])[0].clone();
+            core_tests::generate_random_ecash_proofs(&keyset, &[Amount::from(16)])[0].clone();
         let unspent = HashMap::from([(unsplittable.y().unwrap(), unsplittable)]);
 
         let mut mockdb = MockPocketRepository::new();
@@ -832,11 +829,11 @@ mod tests {
         let err = super::send_proofs(
             SendPlan::NeedSplit {
                 proof: swap_y,
-                split_amount: Amount::from(13u64),
-                estimated_fee: Amount::from(0u64),
+                split_amount: Amount::from(13),
+                estimated_fee: Amount::from(0),
             },
             &k_infos,
-            Amount::from(13u64),
+            Amount::from(13),
             &zero_seed(),
             &mockdb,
             &arc_client,
@@ -845,6 +842,6 @@ mod tests {
         .await
         .unwrap_err();
 
-        assert!(matches!(err, Error::ExcessiveSplitting(a) if a == Amount::from(13u64)));
+        assert!(matches!(err, Error::ExcessiveSplitting(a) if a == Amount::from(13)));
     }
 }

--- a/crates/bcr-wallet-api/src/purse/mod.rs
+++ b/crates/bcr-wallet-api/src/purse/mod.rs
@@ -2,7 +2,6 @@ use crate::{
     error::{Error, Result},
     wallet::api::WalletApi,
 };
-use bcr_common::cashu::MintUrl;
 use bcr_wallet_core::types::WalletConfig;
 use bcr_wallet_persistence::{PurseRepository, redb::purse::PurseDB};
 use std::{collections::HashMap, sync::Arc};
@@ -77,7 +76,7 @@ where
         Ok(())
     }
 
-    pub async fn migrate_rabid_wallets(&self) -> Result<HashMap<String, MintUrl>> {
+    pub async fn migrate_rabid_wallets(&self) -> Result<HashMap<String, url::Url>> {
         let mut res = HashMap::new();
         let wlts = self.wallets.read().await;
         for (wallet_id, wlt) in wlts.iter() {
@@ -135,7 +134,7 @@ mod tests {
             wallet_id: "wlt-1".to_owned(),
             name: "wallet-1".to_owned(),
             network: bitcoin::Network::Testnet,
-            mint: MintUrl::from_str("https://example.com").unwrap(),
+            mint: url::Url::from_str("https://example.com").unwrap(),
             mint_keyset_infos: vec![],
             clowder_id: test_pub_key(),
             debit: CurrencyUnit::Sat,
@@ -195,11 +194,11 @@ mod tests {
             .returning(|| Ok(true));
         wlt.expect_mint_substitute().times(1).returning(|| {
             Ok(Some(
-                MintUrl::from_str("https://substitute.example.com").unwrap(),
+                url::Url::from_str("https://substitute.example.com").unwrap(),
             ))
         });
         wlt.expect_migrate_pockets_substitute()
-            .returning(|_| Ok(MintUrl::from_str("https://substitute.example.com").unwrap()));
+            .returning(|_| Ok(url::Url::from_str("https://substitute.example.com").unwrap()));
 
         let _wlt_id = purse.add_wallet(wlt).await.expect("can create wallet");
 

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use bcr_common::{
-    cashu::{self, Amount, CurrencyUnit, MintUrl, ProofsMethods, nut00 as cdk00, nut18 as cdk18},
+    cashu::{self, Amount, CurrencyUnit, ProofsMethods, nut00 as cdk00, nut18 as cdk18},
     cdk_common::wallet::{Transaction, TransactionDirection, TransactionId},
     wallet::Token,
     wire::clowder::{self as wire_clowder},
@@ -21,6 +21,7 @@ use bcr_wallet_core::{
         BTC_ALPHA_TX_ID_TYPE_METADATA_KEY, BTC_BETA_TX_ID_TYPE_METADATA_KEY, PaymentResultCallback,
         PaymentType, TransactionStatus,
     },
+    util::to_mint_url,
 };
 use bitcoin::secp256k1;
 use futures::StreamExt;
@@ -37,11 +38,11 @@ pub trait WalletApi: SendSync {
     fn config(&self) -> Result<WalletConfig>;
     fn name(&self) -> String;
     fn id(&self) -> String;
-    fn mint_url(&self) -> Result<MintUrl>;
-    fn betas(&self) -> Vec<MintUrl>;
+    fn mint_url(&self) -> Result<url::Url>;
+    fn betas(&self) -> Vec<url::Url>;
     #[allow(dead_code)]
     fn clowder_id(&self) -> secp256k1::PublicKey;
-    fn mint_urls(&self) -> Result<Vec<MintUrl>>;
+    fn mint_urls(&self) -> Vec<url::Url>;
     async fn prepare_melt(
         &self,
         amount: bitcoin::Amount,
@@ -64,7 +65,7 @@ pub trait WalletApi: SendSync {
     ) -> Result<()>;
     async fn is_wallet_mint_rabid(&self) -> Result<bool>;
     async fn is_wallet_mint_offline(&self) -> Result<bool>;
-    async fn mint_substitute(&self) -> Result<Option<MintUrl>>;
+    async fn mint_substitute(&self) -> Result<Option<url::Url>>;
     async fn pay(
         &self,
         p_id: Uuid,
@@ -84,12 +85,12 @@ pub trait WalletApi: SendSync {
     async fn migrate_pockets_substitute(
         &mut self,
         substitute: Arc<dyn ClowderMintConnector>,
-    ) -> Result<MintUrl>;
+    ) -> Result<url::Url>;
     async fn receive_proofs(
         &self,
         proofs: Vec<cdk00::Proof>,
         unit: CurrencyUnit,
-        mint: MintUrl,
+        mint: url::Url,
         tstamp: u64,
         memo: Option<String>,
         metadata: HashMap<String, String>,
@@ -136,7 +137,7 @@ impl WalletApi for super::Wallet {
         self.id.clone()
     }
 
-    fn mint_url(&self) -> Result<cashu::MintUrl> {
+    fn mint_url(&self) -> Result<url::Url> {
         Ok(self.client.mint_url())
     }
 
@@ -209,7 +210,11 @@ impl WalletApi for super::Wallet {
             target: self.nostr_profile.to_bech32()?,
             tags: Some(vec![vec![String::from("n"), String::from("17")]]),
         };
-        let mints = self.mint_urls()?;
+        let mints = self
+            .mint_urls()
+            .into_iter()
+            .map(|url| to_mint_url(&url))
+            .collect();
         let request = cdk18::PaymentRequest {
             payment_id: Some(Uuid::new_v4().to_string()),
             amount: Some(amount),
@@ -339,7 +344,7 @@ impl WalletApi for super::Wallet {
                 );
 
                 let partial_tx = Transaction {
-                    mint_url: self.client.mint_url(),
+                    mint_url: to_mint_url(&self.client.mint_url()),
                     fee: fees,
                     direction: TransactionDirection::Outgoing,
                     memo,
@@ -381,7 +386,7 @@ impl WalletApi for super::Wallet {
                     (
                         p.clone(),
                         Token::new_cashu(
-                            self.client.mint_url(),
+                            to_mint_url(&self.client.mint_url()),
                             p.into_values().collect(),
                             memo.clone(),
                             self.debit.unit(),
@@ -402,7 +407,7 @@ impl WalletApi for super::Wallet {
                 );
 
                 let partial_tx = Transaction {
-                    mint_url: self.client.mint_url(),
+                    mint_url: to_mint_url(&self.client.mint_url()),
                     fee: fees,
                     direction: TransactionDirection::Outgoing,
                     memo,
@@ -447,7 +452,7 @@ impl WalletApi for super::Wallet {
                 }
 
                 let partial_tx = Transaction {
-                    mint_url: self.client.mint_url(),
+                    mint_url: to_mint_url(&self.client.mint_url()),
                     fee: fees,
                     direction: TransactionDirection::Outgoing,
                     memo,
@@ -500,7 +505,7 @@ impl WalletApi for super::Wallet {
             );
 
             let tx = Transaction {
-                mint_url: self.client.mint_url(),
+                mint_url: to_mint_url(&self.client.mint_url()),
                 fee: mint_result.fee,
                 direction: TransactionDirection::Incoming,
                 memo: None,
@@ -548,7 +553,7 @@ impl WalletApi for super::Wallet {
             );
 
             let tx = Transaction {
-                mint_url: self.client.mint_url(),
+                mint_url: to_mint_url(&self.client.mint_url()),
                 fee: cashu::Amount::ZERO,
                 direction: TransactionDirection::Incoming,
                 memo: Some("Mint protest resolved".to_string()),
@@ -605,7 +610,7 @@ impl WalletApi for super::Wallet {
             );
 
             let tx = Transaction {
-                mint_url: self.client.mint_url(),
+                mint_url: to_mint_url(&self.client.mint_url()),
                 fee: cashu::Amount::ZERO,
                 direction: TransactionDirection::Incoming,
                 memo: Some("Swap protest resolved".to_string()),
@@ -665,7 +670,7 @@ impl WalletApi for super::Wallet {
             }
 
             let tx = Transaction {
-                mint_url: self.client.mint_url(),
+                mint_url: to_mint_url(&self.client.mint_url()),
                 fee: cashu::Amount::ZERO,
                 direction: TransactionDirection::Outgoing,
                 memo: Some("Melt protest resolved".to_string()),
@@ -706,7 +711,7 @@ impl WalletApi for super::Wallet {
         &self,
         proofs: Vec<cashu::Proof>,
         unit: CurrencyUnit,
-        mint: MintUrl,
+        mint: url::Url,
         tstamp: u64,
         memo: Option<String>,
         metadata: HashMap<String, String>,
@@ -791,7 +796,7 @@ impl WalletApi for super::Wallet {
         Ok(offline_count > betas_count / 2)
     }
 
-    async fn mint_substitute(&self) -> Result<Option<MintUrl>> {
+    async fn mint_substitute(&self) -> Result<Option<url::Url>> {
         let mint_id = self.clowder_id;
         let betas_count = self.betas().len();
         let threshold = betas_count / 2;
@@ -805,11 +810,11 @@ impl WalletApi for super::Wallet {
 
             futures.push(async move {
                 let mint = beta_client.get_alpha_substitute(mint_id).await?.mint;
-                Ok::<MintUrl, Error>(mint)
+                Ok::<url::Url, Error>(mint)
             });
         }
 
-        let mut substitute_counts = HashMap::<MintUrl, usize>::new();
+        let mut substitute_counts = HashMap::<url::Url, usize>::new();
 
         while let Some(vote) = futures.next().await {
             let mint = vote?;
@@ -824,13 +829,13 @@ impl WalletApi for super::Wallet {
         Ok(None)
     }
 
-    fn mint_urls(&self) -> Result<Vec<cashu::MintUrl>> {
+    fn mint_urls(&self) -> Vec<url::Url> {
         let mut urls = self.betas();
         urls.push(self.client.mint_url());
-        Ok(urls)
+        urls
     }
 
-    fn betas(&self) -> Vec<cashu::MintUrl> {
+    fn betas(&self) -> Vec<url::Url> {
         self.beta_clients.keys().cloned().collect()
     }
 
@@ -841,7 +846,7 @@ impl WalletApi for super::Wallet {
     async fn migrate_pockets_substitute(
         &mut self,
         substitute: Arc<dyn ClowderMintConnector>,
-    ) -> Result<MintUrl> {
+    ) -> Result<url::Url> {
         let debit_proofs = self.debit.delete_proofs().await?;
 
         // Exchange debit
@@ -867,7 +872,7 @@ impl WalletApi for super::Wallet {
 
         self.client = substitute;
         self.clowder_id = self.client.get_clowder_id().await?;
-        let mut beta_clients = HashMap::<cashu::MintUrl, Arc<dyn ClowderMintConnector>>::new();
+        let mut beta_clients = HashMap::<url::Url, Arc<dyn ClowderMintConnector>>::new();
 
         for beta in self.client.as_ref().get_clowder_betas().await? {
             let beta_client = (self.client_factory)(beta.clone());
@@ -986,7 +991,7 @@ impl WalletApi for super::Wallet {
                 .unzip();
             tracing::debug!("Offline Pay by Token: Create Token");
             let token = Token::new_cashu(
-                substitute.clone(),
+                to_mint_url(&substitute.clone()),
                 proofs.clone(),
                 memo.clone(),
                 self.debit.unit(),
@@ -1005,7 +1010,7 @@ impl WalletApi for super::Wallet {
 
             // Create Transaction
             let partial_tx = Transaction {
-                mint_url: substitute,
+                mint_url: to_mint_url(&substitute),
                 fee: fees,
                 direction: TransactionDirection::Outgoing,
                 memo,

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -11,14 +11,17 @@ use crate::{
 };
 use bcr_common::{
     cashu::{
-        self, Amount, CurrencyUnit, KeySetInfo, MintUrl, PaymentRequest, Proof, ProofsMethods,
+        self, Amount, CurrencyUnit, KeySetInfo, PaymentRequest, Proof, ProofsMethods,
         nut18 as cdk18,
     },
     cdk_common::wallet::{Transaction, TransactionDirection, TransactionId},
     wallet::Token,
     wire::clowder::{ConnectedMintResponse, ConnectedMintsResponse},
 };
-use bcr_wallet_core::types::{PaymentType, TransactionStatus};
+use bcr_wallet_core::{
+    types::{PaymentType, TransactionStatus},
+    util::{from_mint_url, to_mint_url},
+};
 use bcr_wallet_persistence::TransactionRepository;
 use bitcoin::{
     hashes::{Hash, sha256::Hash as Sha256},
@@ -34,7 +37,7 @@ pub struct Wallet {
     network: bitcoin::Network,
     client: Arc<dyn ClowderMintConnector>,
     mint_keyset_infos: Vec<cashu::KeySetInfo>,
-    beta_clients: HashMap<cashu::MintUrl, Arc<dyn ClowderMintConnector>>,
+    beta_clients: HashMap<url::Url, Arc<dyn ClowderMintConnector>>,
     tx_repo: Box<dyn TransactionRepository>,
     debit: Box<dyn DebitPocketApi>,
     name: String,
@@ -43,7 +46,7 @@ pub struct Wallet {
     current_payment: Mutex<Option<PayReference>>,
     current_payment_request: Mutex<Option<PaymentRequest>>,
     clowder_id: secp256k1::PublicKey,
-    client_factory: Box<dyn Fn(cashu::MintUrl) -> Arc<dyn ClowderMintConnector> + Send + Sync>,
+    client_factory: Box<dyn Fn(url::Url) -> Arc<dyn ClowderMintConnector> + Send + Sync>,
     swap_expiry: chrono::TimeDelta,
     nostr_relays: Vec<RelayUrl>,
     nostr_cl: Arc<nostr_sdk::Client>,
@@ -61,8 +64,8 @@ impl Wallet {
         id: String,
         pub_key: secp256k1::PublicKey,
         clowder_id: secp256k1::PublicKey,
-        beta_clients: HashMap<cashu::MintUrl, Arc<dyn ClowderMintConnector>>,
-        client_factory: Box<dyn Fn(cashu::MintUrl) -> Arc<dyn ClowderMintConnector> + Send + Sync>,
+        beta_clients: HashMap<url::Url, Arc<dyn ClowderMintConnector>>,
+        client_factory: Box<dyn Fn(url::Url) -> Arc<dyn ClowderMintConnector> + Send + Sync>,
         swap_expiry: chrono::TimeDelta,
         nostr_relays: Vec<RelayUrl>,
         nostr_cl: Arc<nostr_sdk::Client>,
@@ -117,7 +120,7 @@ impl Wallet {
     // Returns (Option<(clowder_path, intermint_alpha_keyset)>, local_alpha_keyset)
     async fn get_clowder_path_and_keysets_info(
         &self,
-        mint_url: MintUrl,
+        mint_url: url::Url,
     ) -> Result<(
         Option<(ConnectedMintsResponse, Vec<KeySetInfo>)>,
         Vec<KeySetInfo>,
@@ -207,7 +210,7 @@ impl Wallet {
         req: &cashu::PaymentRequest,
     ) -> Result<(Amount, CurrencyUnit, cashu::Transport)> {
         if let Some(mints) = &req.mints
-            && !mints.contains(&self.client.mint_url())
+            && !mints.contains(&to_mint_url(&self.client.mint_url()))
         {
             return Err(Error::InterMint);
         }
@@ -353,7 +356,7 @@ impl Wallet {
         local_alpha_keysets_info: &[KeySetInfo],
         proofs: Vec<cashu::Proof>,
         unit: CurrencyUnit,
-        mint: MintUrl,
+        mint: url::Url,
         intermint_infos: Option<(ConnectedMintsResponse, Vec<KeySetInfo>)>,
         tstamp: u64,
         memo: Option<String>,
@@ -403,7 +406,7 @@ impl Wallet {
                     tracing::debug!(
                         "Offline Exchanged token: {}",
                         cashu::Token::new(
-                            substitute_beta_mint.clone(),
+                            to_mint_url(&substitute_beta_mint),
                             substitute_proofs.clone(),
                             None,
                             cashu::CurrencyUnit::Sat,
@@ -442,7 +445,7 @@ impl Wallet {
             )
             .await?;
         let tx = Transaction {
-            mint_url: self.client.mint_url(),
+            mint_url: to_mint_url(&self.client.mint_url()),
             direction: TransactionDirection::Incoming,
             fee: received_amount
                 .checked_sub(stored_amount)
@@ -489,7 +492,7 @@ impl Wallet {
     pub async fn online_exchange(
         &self,
         alpha_proofs: Vec<cashu::Proof>,
-        alpha_url: MintUrl,
+        alpha_url: url::Url,
         alpha_client: &dyn ClowderMintConnector,
         path: Vec<ConnectedMintResponse>,
         unit: CurrencyUnit,
@@ -543,7 +546,7 @@ impl Wallet {
         tracing::debug!(
             "Locked alpha token: {}",
             cashu::Token::new(
-                alpha_url.clone(),
+                to_mint_url(&alpha_url.clone()),
                 locked_alpha_proofs.clone(),
                 None,
                 cashu::CurrencyUnit::Sat,
@@ -587,7 +590,7 @@ impl Wallet {
         tracing::debug!(
             "Unlocked beta token: {}",
             cashu::Token::new(
-                self.client.mint_url(),
+                to_mint_url(&self.client.mint_url()),
                 beta_proofs.clone(),
                 None,
                 cashu::CurrencyUnit::Sat,
@@ -599,11 +602,12 @@ impl Wallet {
 
     pub async fn receive_token(&self, token: Token, tstamp: u64) -> Result<TransactionId> {
         let token_teaser = token.to_string().chars().take(20).collect::<String>();
+        let token_mint_url = from_mint_url(&token.mint_url());
         let (intermint_infos, keysets_info) = self
-            .get_clowder_path_and_keysets_info(token.mint_url())
+            .get_clowder_path_and_keysets_info(from_mint_url(&token.mint_url()))
             .await?;
 
-        let proofs = if token.mint_url() == self.client.mint_url() {
+        let proofs = if token_mint_url == self.client.mint_url() {
             token.proofs(&keysets_info)?
         } else if let Some((_, ref intermint_alpha_infos)) = intermint_infos {
             token.proofs(intermint_alpha_infos)?
@@ -633,7 +637,7 @@ impl Wallet {
                 &keysets_info,
                 proofs,
                 self.debit.unit(),
-                token.mint_url(),
+                token_mint_url,
                 intermint_infos,
                 tstamp,
                 token.memo().clone(),
@@ -659,7 +663,7 @@ impl Wallet {
             id: p_id,
             memo: partial_tx.memo.clone(),
             unit: partial_tx.unit.clone(),
-            mint: self.client.mint_url(),
+            mint: to_mint_url(&self.client.mint_url()),
             proofs,
         };
         match transport._type {
@@ -755,7 +759,7 @@ impl Wallet {
             self,
             payload.proofs,
             payload.unit,
-            payload.mint,
+            from_mint_url(&payload.mint),
             chrono::Utc::now().timestamp() as u64,
             payload.memo,
             meta,
@@ -851,7 +855,7 @@ mod tests {
 
     fn wallet_with_betas(
         mut w: Wallet,
-        betas: Vec<(cashu::MintUrl, Arc<dyn ClowderMintConnector>)>,
+        betas: Vec<(url::Url, Arc<dyn ClowderMintConnector>)>,
     ) -> Wallet {
         let mut map = HashMap::new();
         for (url, cl) in betas {
@@ -891,7 +895,7 @@ mod tests {
         ctx.client
             .expect_mint_url()
             .times(1)
-            .returning(|| cashu::MintUrl::from_str("https://mint.example").unwrap());
+            .returning(|| url::Url::from_str("https://mint.example").unwrap());
 
         let wlt = wallet(ctx);
         let cfg = wlt.config().expect("config works");
@@ -900,7 +904,7 @@ mod tests {
         assert_eq!(cfg.name, "wallet-1");
         assert_eq!(cfg.network, bitcoin::Network::Testnet);
         assert_eq!(cfg.debit, CurrencyUnit::Sat);
-        assert_eq!(cfg.mint.to_string(), "https://mint.example");
+        assert_eq!(cfg.mint.to_string(), "https://mint.example/");
         assert_eq!(cfg.pub_key, test_pub_key());
         assert_eq!(cfg.clowder_id, test_pub_key());
         assert!(cfg.betas.is_empty());
@@ -928,11 +932,11 @@ mod tests {
         ctx.client
             .expect_mint_url()
             .times(1)
-            .returning(|| cashu::MintUrl::from_str("https://mint.example").unwrap());
+            .returning(|| url::Url::from_str("https://mint.example").unwrap());
 
         let wlt = wallet(ctx);
         let url = wlt.mint_url().unwrap();
-        assert_eq!(url.to_string(), "https://mint.example");
+        assert_eq!(url.to_string(), "https://mint.example/");
     }
 
     #[tokio::test]
@@ -941,11 +945,11 @@ mod tests {
         ctx.client
             .expect_mint_url()
             .times(1)
-            .returning(|| cashu::MintUrl::from_str("https://mint.example").unwrap());
+            .returning(|| url::Url::from_str("https://mint.example").unwrap());
         let mut wlt = wallet(ctx);
 
-        let b1 = cashu::MintUrl::from_str("https://beta1.example").unwrap();
-        let b2 = cashu::MintUrl::from_str("https://beta2.example").unwrap();
+        let b1 = url::Url::from_str("https://beta1.example").unwrap();
+        let b2 = url::Url::from_str("https://beta2.example").unwrap();
 
         let beta1: Arc<dyn ClowderMintConnector> = Arc::new(MockMintConnector::new());
         let beta2: Arc<dyn ClowderMintConnector> = Arc::new(MockMintConnector::new());
@@ -957,10 +961,10 @@ mod tests {
         assert!(betas.contains(&b1));
         assert!(betas.contains(&b2));
 
-        let urls = wlt.mint_urls().unwrap();
+        let urls = wlt.mint_urls();
         assert!(urls.contains(&b1));
         assert!(urls.contains(&b2));
-        assert!(urls.contains(&cashu::MintUrl::from_str("https://mint.example").unwrap()));
+        assert!(urls.contains(&url::Url::from_str("https://mint.example").unwrap()));
         assert_eq!(urls.len(), 3);
     }
 
@@ -998,7 +1002,7 @@ mod tests {
         ctx.client
             .expect_mint_url()
             .times(1)
-            .returning(|| cashu::MintUrl::from_str("https://mint.example").unwrap());
+            .returning(|| url::Url::from_str("https://mint.example").unwrap());
 
         let wlt = wallet(ctx);
         let req = wlt
@@ -1107,9 +1111,9 @@ mod tests {
         let ctx = wallet_ctx();
         let mut wlt = wallet(ctx);
 
-        let b1 = cashu::MintUrl::from_str("https://b1.example").unwrap();
-        let b2 = cashu::MintUrl::from_str("https://b2.example").unwrap();
-        let b3 = cashu::MintUrl::from_str("https://b3.example").unwrap();
+        let b1 = url::Url::from_str("https://b1.example").unwrap();
+        let b2 = url::Url::from_str("https://b2.example").unwrap();
+        let b3 = url::Url::from_str("https://b3.example").unwrap();
 
         let mut m1 = MockMintConnector::new();
         let mut m2 = MockMintConnector::new();
@@ -1145,8 +1149,8 @@ mod tests {
         let ctx = wallet_ctx();
         let mut wlt = wallet(ctx);
 
-        let b1 = cashu::MintUrl::from_str("https://b1.example").unwrap();
-        let b2 = cashu::MintUrl::from_str("https://b2.example").unwrap();
+        let b1 = url::Url::from_str("https://b1.example").unwrap();
+        let b2 = url::Url::from_str("https://b2.example").unwrap();
 
         let mut m1 = MockMintConnector::new();
         let mut m2 = MockMintConnector::new();
@@ -1173,12 +1177,12 @@ mod tests {
         let ctx = wallet_ctx();
         let mut wlt = wallet(ctx);
 
-        let b1 = cashu::MintUrl::from_str("https://b1.example").unwrap();
-        let b2 = cashu::MintUrl::from_str("https://b2.example").unwrap();
-        let b3 = cashu::MintUrl::from_str("https://b3.example").unwrap();
+        let b1 = url::Url::from_str("https://b1.example").unwrap();
+        let b2 = url::Url::from_str("https://b2.example").unwrap();
+        let b3 = url::Url::from_str("https://b3.example").unwrap();
 
-        let substitute = cashu::MintUrl::from_str("https://sub.example").unwrap();
-        let other = cashu::MintUrl::from_str("https://other.example").unwrap();
+        let substitute = url::Url::from_str("https://sub.example").unwrap();
+        let other = url::Url::from_str("https://other.example").unwrap();
 
         let mut m1 = MockMintConnector::new();
         let mut m2 = MockMintConnector::new();
@@ -1264,7 +1268,7 @@ mod tests {
         ctx.client
             .expect_mint_url()
             .times(2) // token creation + tx mint_url
-            .returning(|| cashu::MintUrl::from_str("https://mint.example").unwrap());
+            .returning(|| url::Url::from_str("https://mint.example").unwrap());
 
         ctx.debit
             .expect_unit()
@@ -1333,11 +1337,11 @@ mod tests {
         ctx.debit
             .expect_recover_pending_stale_proofs()
             .times(1)
-            .returning(|_, _, _, _| Ok(Amount::from(10u64)));
+            .returning(|_, _, _, _| Ok(Amount::from(10)));
 
         let wlt = wallet(ctx);
         let recovered = wlt.recover_pending_stale_proofs(&[]).await.unwrap();
-        assert_eq!(recovered, Amount::from(10u64));
+        assert_eq!(recovered, Amount::from(10));
     }
 
     #[tokio::test]
@@ -1355,7 +1359,7 @@ mod tests {
                 String::from(TRANSACTION_STATUS_METADATA_KEY),
                 TransactionStatus::Settled.to_string(),
             )]),
-            ..reclaimable_tx(Amount::from(10u64))
+            ..reclaimable_tx(Amount::from(10))
         };
 
         ctx.tx_repo
@@ -1376,7 +1380,7 @@ mod tests {
     async fn test_reclaim_tx_sets_settled_if_nothing_reclaimed() {
         let mut ctx = wallet_ctx();
         let tx_id = TransactionId::new(vec![]);
-        let tx = reclaimable_tx(Amount::from(10u64));
+        let tx = reclaimable_tx(Amount::from(10));
 
         ctx.client
             .expect_get_mint_keysets()
@@ -1422,7 +1426,7 @@ mod tests {
     async fn test_reclaim_tx_sets_canceled_without_fee_if_fully_reclaimed() {
         let mut ctx = wallet_ctx();
         let tx_id = TransactionId::new(vec![]);
-        let tx = reclaimable_tx(Amount::from(10u64));
+        let tx = reclaimable_tx(Amount::from(10));
 
         ctx.client
             .expect_get_mint_keysets()
@@ -1447,7 +1451,7 @@ mod tests {
         ctx.debit
             .expect_reclaim_proofs()
             .times(1)
-            .returning(|_, _, _, _| Ok(Amount::from(10u64)));
+            .returning(|_, _, _, _| Ok(Amount::from(10)));
 
         ctx.tx_repo
             .expect_update_metadata()
@@ -1463,14 +1467,14 @@ mod tests {
         let wlt = wallet(ctx);
         let amount = wlt.reclaim_tx(tx_id).await.unwrap();
 
-        assert_eq!(amount, Amount::from(10u64));
+        assert_eq!(amount, Amount::from(10));
     }
 
     #[tokio::test]
     async fn test_reclaim_tx_sets_canceled_and_fee_if_partially_reclaimed() {
         let mut ctx = wallet_ctx();
         let tx_id = TransactionId::new(vec![]);
-        let tx = reclaimable_tx(Amount::from(10u64));
+        let tx = reclaimable_tx(Amount::from(10));
 
         ctx.client
             .expect_get_mint_keysets()
@@ -1495,7 +1499,7 @@ mod tests {
         ctx.debit
             .expect_reclaim_proofs()
             .times(1)
-            .returning(|_, _, _, _| Ok(Amount::from(7u64)));
+            .returning(|_, _, _, _| Ok(Amount::from(7)));
 
         ctx.tx_repo
             .expect_update_metadata()
@@ -1509,12 +1513,12 @@ mod tests {
         ctx.tx_repo
             .expect_update_fee()
             .times(1)
-            .withf(|_, fee| *fee == Amount::from(3u64))
+            .withf(|_, fee| *fee == Amount::from(3))
             .returning(|_, _| Ok(()));
 
         let wlt = wallet(ctx);
         let amount = wlt.reclaim_tx(tx_id).await.unwrap();
 
-        assert_eq!(amount, Amount::from(7u64));
+        assert_eq!(amount, Amount::from(7));
     }
 }

--- a/crates/bcr-wallet-cli/Cargo.toml
+++ b/crates/bcr-wallet-cli/Cargo.toml
@@ -22,3 +22,4 @@ toml = "1.1"
 tracing-log.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
+url.workspace = true

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -24,7 +24,7 @@ pub struct CliSettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletSettings {
-    pub mint_url: bcr_common::cashu::MintUrl,
+    pub mint_url: url::Url,
     pub mnemonic: bip39::Mnemonic,
     pub network: bitcoin::Network,
     pub nostr_relays: Vec<RelayUrl>,

--- a/crates/bcr-wallet-core/Cargo.toml
+++ b/crates/bcr-wallet-core/Cargo.toml
@@ -14,4 +14,5 @@ serde.workspace = true
 strum = {workspace = true, features = ["derive"]}
 thiserror = {workspace = true }
 uuid = {workspace = true }
+url = {workspace = true}
 

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -1,5 +1,5 @@
 use bcr_common::{
-    cashu::{Amount, CurrencyUnit, KeySetInfo, MintUrl},
+    cashu::{Amount, CurrencyUnit, KeySetInfo},
     cdk_common::wallet::TransactionId,
 };
 use bitcoin::{address::NetworkUnchecked, secp256k1};
@@ -34,12 +34,12 @@ pub struct WalletConfig {
     pub wallet_id: String,
     pub name: String,
     pub network: bitcoin::Network,
-    pub mint: MintUrl,
+    pub mint: url::Url,
     pub mint_keyset_infos: Vec<KeySetInfo>,
     pub clowder_id: secp256k1::PublicKey,
     pub debit: CurrencyUnit,
     pub pub_key: secp256k1::PublicKey,
-    pub betas: Vec<MintUrl>,
+    pub betas: Vec<url::Url>,
     pub nostr_relays: Vec<RelayUrl>,
 }
 

--- a/crates/bcr-wallet-core/src/util.rs
+++ b/crates/bcr-wallet-core/src/util.rs
@@ -1,3 +1,6 @@
+use std::str::FromStr;
+
+use bcr_common::cashu;
 use bitcoin::{
     hashes::{Hash, HashEngine, sha256},
     hex::DisplayHex,
@@ -30,4 +33,12 @@ pub fn keypair_from_seed(seed: Seed) -> Keypair {
 pub fn keypair_from_mnemonic(mnemonic: &bip39::Mnemonic) -> Keypair {
     let seed = seed_from_mnemonic(mnemonic);
     keypair_from_seed(seed)
+}
+
+pub fn to_mint_url(url: &url::Url) -> cashu::MintUrl {
+    cashu::MintUrl::from_str(url.as_ref()).expect("valid urls are valid mint urls")
+}
+
+pub fn from_mint_url(mint_url: &cashu::MintUrl) -> url::Url {
+    url::Url::from_str(&mint_url.to_string()).expect("valid mint urls are valid urls")
 }

--- a/crates/bcr-wallet-ffi/Cargo.toml
+++ b/crates/bcr-wallet-ffi/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = {version = "1.21"}
 tokio = {workspace = true}
 tokio-util = {workspace = true}
 uuid = {workspace = true}
+url = {workspace = true}
 
 [lints.rust]
 unexpected_cfgs = {level = "warn", check-cfg = ['cfg(frb_expand)']}

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -10,7 +10,7 @@ use tokio_util::sync::CancellationToken;
 #[cfg(target_os = "android")]
 use android_logger::FilterBuilder;
 use bcr_common::{
-    cashu::{self, MintUrl},
+    cashu::{self},
     cdk_common,
 };
 use bcr_wallet_api::{
@@ -218,7 +218,7 @@ fn init_panic_hook() {
 #[frb]
 pub async fn wallet_add(req: CreateWalletRequest) -> Result<AddWalletResponse, WalletError> {
     let name = Uuid::new_v4().to_string();
-    let parsed_url = MintUrl::from_str(&req.default_mint_url).expect("Not a valid mint URL");
+    let parsed_url = url::Url::from_str(&req.default_mint_url).expect("Not a valid mint URL");
     let parsed_mnemonic =
         bip39::Mnemonic::from_str(&req.mnemonic).expect("Not a valid bip39 mnemonic");
     let parsed_nostr_relays: Vec<RelayUrl> = req
@@ -252,7 +252,7 @@ pub async fn wallet_restore(
     req: CreateWalletRequest,
 ) -> Result<RestoreWalletResponse, WalletError> {
     let name = Uuid::new_v4().to_string();
-    let parsed_url = MintUrl::from_str(&req.default_mint_url).expect("Not a valid mint URL");
+    let parsed_url = url::Url::from_str(&req.default_mint_url).expect("Not a valid mint URL");
     let parsed_mnemonic =
         bip39::Mnemonic::from_str(&req.mnemonic).expect("Not a valid bip39 mnemonic");
     let parsed_nostr_relays: Vec<RelayUrl> = req
@@ -1288,7 +1288,6 @@ pub enum WalletErrorCode {
     InsufficientOnChainMintAmount,
     NoDevMode,
     InvalidBitcoinAddress,
-    InvalidMintUrl,
     InvalidMnemonic,
     MnemonicNotFound,
     WalletUniqueName,
@@ -1389,9 +1388,6 @@ impl From<BcrWalletError> for WalletError {
             }
             BcrWalletError::InvalidMnemonic => {
                 WalletError::bad_request(value.to_string(), WalletErrorCode::InvalidMnemonic)
-            }
-            BcrWalletError::InvalidMintUrl(_, _) => {
-                WalletError::bad_request(value.to_string(), WalletErrorCode::InvalidMintUrl)
             }
             BcrWalletError::InvalidBitcoinAddress(_) => {
                 WalletError::bad_request(value.to_string(), WalletErrorCode::InvalidBitcoinAddress)

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -2362,11 +2362,10 @@ impl SseDecode for crate::api::WalletErrorCode {
             20 => crate::api::WalletErrorCode::InsufficientOnChainMintAmount,
             21 => crate::api::WalletErrorCode::NoDevMode,
             22 => crate::api::WalletErrorCode::InvalidBitcoinAddress,
-            23 => crate::api::WalletErrorCode::InvalidMintUrl,
-            24 => crate::api::WalletErrorCode::InvalidMnemonic,
-            25 => crate::api::WalletErrorCode::MnemonicNotFound,
-            26 => crate::api::WalletErrorCode::WalletUniqueName,
-            27 => crate::api::WalletErrorCode::WalletUniqueId,
+            23 => crate::api::WalletErrorCode::InvalidMnemonic,
+            24 => crate::api::WalletErrorCode::MnemonicNotFound,
+            25 => crate::api::WalletErrorCode::WalletUniqueName,
+            26 => crate::api::WalletErrorCode::WalletUniqueId,
             _ => unreachable!("Invalid variant for WalletErrorCode: {}", inner),
         };
     }
@@ -3438,11 +3437,10 @@ impl flutter_rust_bridge::IntoDart for crate::api::WalletErrorCode {
             Self::InsufficientOnChainMintAmount => 20.into_dart(),
             Self::NoDevMode => 21.into_dart(),
             Self::InvalidBitcoinAddress => 22.into_dart(),
-            Self::InvalidMintUrl => 23.into_dart(),
-            Self::InvalidMnemonic => 24.into_dart(),
-            Self::MnemonicNotFound => 25.into_dart(),
-            Self::WalletUniqueName => 26.into_dart(),
-            Self::WalletUniqueId => 27.into_dart(),
+            Self::InvalidMnemonic => 23.into_dart(),
+            Self::MnemonicNotFound => 24.into_dart(),
+            Self::WalletUniqueName => 25.into_dart(),
+            Self::WalletUniqueId => 26.into_dart(),
             _ => unreachable!(),
         }
     }
@@ -4665,11 +4663,10 @@ impl SseEncode for crate::api::WalletErrorCode {
                 crate::api::WalletErrorCode::InsufficientOnChainMintAmount => 20,
                 crate::api::WalletErrorCode::NoDevMode => 21,
                 crate::api::WalletErrorCode::InvalidBitcoinAddress => 22,
-                crate::api::WalletErrorCode::InvalidMintUrl => 23,
-                crate::api::WalletErrorCode::InvalidMnemonic => 24,
-                crate::api::WalletErrorCode::MnemonicNotFound => 25,
-                crate::api::WalletErrorCode::WalletUniqueName => 26,
-                crate::api::WalletErrorCode::WalletUniqueId => 27,
+                crate::api::WalletErrorCode::InvalidMnemonic => 23,
+                crate::api::WalletErrorCode::MnemonicNotFound => 24,
+                crate::api::WalletErrorCode::WalletUniqueName => 25,
+                crate::api::WalletErrorCode::WalletUniqueId => 26,
                 _ => {
                     unimplemented!("");
                 }

--- a/crates/bcr-wallet-persistence/Cargo.toml
+++ b/crates/bcr-wallet-persistence/Cargo.toml
@@ -23,6 +23,7 @@ thiserror.workspace = true
 tokio = {workspace = true}
 tracing.workspace = true
 uuid = {workspace = true }
+url = {workspace = true }
 
 [dev-dependencies]
 bcr-common = {workspace = true, features = ["test-utils"]}

--- a/crates/bcr-wallet-persistence/src/redb/purse.rs
+++ b/crates/bcr-wallet-persistence/src/redb/purse.rs
@@ -3,7 +3,7 @@ use crate::{
     error::{Error, Result},
 };
 use async_trait::async_trait;
-use bcr_common::cashu::{CurrencyUnit, MintUrl};
+use bcr_common::cashu::CurrencyUnit;
 use bcr_wallet_core::types::WalletConfig;
 use bitcoin::secp256k1;
 use nostr_sdk::RelayUrl;
@@ -17,12 +17,12 @@ struct WalletEntry {
     wallet_id: String,
     name: String,
     network: bitcoin::Network,
-    mint: bcr_common::cashu::MintUrl,
+    mint: url::Url,
     mint_keyset_infos: Vec<bcr_common::cashu::KeySetInfo>,
     clowder_id: secp256k1::PublicKey,
     pub_key: secp256k1::PublicKey,
     debit: CurrencyUnit,
-    betas: Vec<MintUrl>,
+    betas: Vec<url::Url>,
     nostr_relays: Vec<RelayUrl>,
 }
 impl std::convert::From<WalletConfig> for WalletEntry {
@@ -193,7 +193,7 @@ mod tests {
             name: name.to_owned(),
 
             network: bitcoin::Network::Bitcoin,
-            mint: MintUrl::from_str("https://example.com").expect("valid mint url"),
+            mint: url::Url::from_str("https://example.com").expect("valid mint url"),
             mint_keyset_infos: vec![],
             clowder_id: test_clowder_id,
             pub_key: test_pub_key(),

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -728,7 +728,6 @@ enum WalletErrorCode {
   insufficientOnChainMintAmount,
   noDevMode,
   invalidBitcoinAddress,
-  invalidMintUrl,
   invalidMnemonic,
   mnemonicNotFound,
   walletUniqueName,


### PR DESCRIPTION
* Upgrade to latest bcr-common (triggering the `MintUrl` -> `url::Url` switch)
* Calculate Melt Fees based on the result of onchain melt quote
* Add tests for `prepare_onchain_melt`