### PR TITLE
Add fees overview by month to transaction list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     * There is a `limit`, to set the amount of items returned, clamped between 5 - 100 per call
     * A `TransactionCursor` is returned per call, which can be passed into the next request to get the next page
         * if the `next_cursor` is empty, all results have been returned
+* Add a `fees_by_month` field to the result of `wallet_get_transactions`, which sums up the fees for the distinct months present in the returned transactions by UTC time, sorted descending
 
 # 0.9.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bcr-common"
 version = "0.7.0"
-source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=0f22a5667583b813602d6f6c4bf2b67d469fc43d#0f22a5667583b813602d6f6c4bf2b67d469fc43d"
+source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=f37981f209b9360ea03bd4dd0ede7e89cafeff78#f37981f209b9360ea03bd4dd0ede7e89cafeff78"
 dependencies = [
  "async-trait",
  "bdk_wallet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ strip = "symbols"
 
 [workspace.dependencies]
 async-trait = {version = "0.1"}
-bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "0f22a5667583b813602d6f6c4bf2b67d469fc43d"}
+bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "f37981f209b9360ea03bd4dd0ede7e89cafeff78"}
 bcr-wallet-core = {path = "./crates/bcr-wallet-core"}
 bcr-wallet-api = {path = "./crates/bcr-wallet-api"}
 bcr-wallet-persistence = {path = "./crates/bcr-wallet-persistence"}

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -9,8 +9,8 @@ use bcr_common::{
     wallet::Token,
 };
 use bcr_wallet_core::types::{
-    self, MintSummary, PaymentResultCallback, PaymentSummary, Seed, TransactionCursor,
-    TransactionFilters, TransactionSort, WalletConfig,
+    self, ListTransactionsResult, MintSummary, PaymentResultCallback, PaymentSummary, Seed,
+    TransactionCursor, TransactionFilters, TransactionSort, WalletConfig,
 };
 use bcr_wallet_core::util::{build_wallet_id, keypair_from_mnemonic, seed_from_mnemonic};
 use bcr_wallet_persistence::redb::{Database, build_pursedb, build_wallet_dbs, create_db};
@@ -529,7 +529,7 @@ impl AppState {
         sort: TransactionSort,
         limit: usize,
         cursor: Option<TransactionCursor>,
-    ) -> Result<(Vec<Transaction>, Option<TransactionCursor>)> {
+    ) -> Result<ListTransactionsResult> {
         tracing::debug!("wallet_list_txs({id}, {filter:?}, {sort:?}, {limit}, {cursor:?})");
 
         let wallet = self.get_wallet(&id).await?;

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -23,7 +23,8 @@ use bcr_common::{
 };
 use bcr_wallet_core::{
     types::{
-        PaymentType, TransactionCursor, TransactionFilters, TransactionSort, TransactionStatus,
+        ListTransactionsResult, PaymentType, TransactionCursor, TransactionFilters,
+        TransactionSort, TransactionStatus, extract_fees_per_month,
     },
     util::{from_mint_url, to_mint_url},
 };
@@ -123,7 +124,7 @@ impl Wallet {
         sort: TransactionSort,
         limit: usize,
         cursor: Option<TransactionCursor>,
-    ) -> Result<(Vec<Transaction>, Option<TransactionCursor>)> {
+    ) -> Result<ListTransactionsResult> {
         if let Some(ref cursor) = cursor
             && !cursor.matches_sort(sort)
         {
@@ -171,7 +172,12 @@ impl Wallet {
         } else {
             None
         };
-        Ok((res, next_cursor))
+        let fees_by_month = extract_fees_per_month(&res);
+        Ok(ListTransactionsResult {
+            txs: res,
+            next_cursor,
+            fees_by_month,
+        })
     }
 
     // Returns (Option<(clowder_path, intermint_alpha_keyset)>, local_alpha_keyset)
@@ -1332,8 +1338,8 @@ mod tests {
             )
             .await
             .unwrap();
-        assert!(res.0.is_empty());
-        assert!(res.1.is_none());
+        assert!(res.txs.is_empty());
+        assert!(res.next_cursor.is_none());
     }
 
     #[tokio::test]
@@ -1789,12 +1795,14 @@ mod tests {
                 .returning(move || Ok(txs.clone()));
 
             let wlt = wallet(ctx);
-            let (res, next_cursor) = wlt
+            let ListTransactionsResult {
+                txs, next_cursor, ..
+            } = wlt
                 .list_txs(TransactionFilters::default(), sort, 20, None)
                 .await
                 .unwrap();
 
-            assert_eq!(tx_ids(&res), tx_ids(&expected));
+            assert_eq!(tx_ids(&txs), tx_ids(&expected));
             assert!(next_cursor.is_none());
         }
     }
@@ -1812,7 +1820,7 @@ mod tests {
 
         let wlt = wallet(ctx);
 
-        let (page1, cursor1) = wlt
+        let res1 = wlt
             .list_txs(
                 TransactionFilters::default(),
                 TransactionSort::TimeDesc,
@@ -1821,6 +1829,8 @@ mod tests {
             )
             .await
             .unwrap();
+        let page1 = res1.txs;
+        let cursor1 = res1.next_cursor;
 
         assert_eq!(tx_ids(&page1), tx_ids(&expected[0..2]));
         assert_eq!(
@@ -1831,7 +1841,7 @@ mod tests {
             ))
         );
 
-        let (page2, cursor2) = wlt
+        let res2 = wlt
             .list_txs(
                 TransactionFilters::default(),
                 TransactionSort::TimeDesc,
@@ -1840,6 +1850,8 @@ mod tests {
             )
             .await
             .unwrap();
+        let page2 = res2.txs;
+        let cursor2 = res2.next_cursor;
 
         assert_eq!(tx_ids(&page2), tx_ids(&expected[2..4]));
         assert_eq!(
@@ -1850,7 +1862,7 @@ mod tests {
             ))
         );
 
-        let (page3, cursor3) = wlt
+        let res3 = wlt
             .list_txs(
                 TransactionFilters::default(),
                 TransactionSort::TimeDesc,
@@ -1859,6 +1871,8 @@ mod tests {
             )
             .await
             .unwrap();
+        let page3 = res3.txs;
+        let cursor3 = res3.next_cursor;
 
         assert_eq!(tx_ids(&page3), tx_ids(&expected[4..6]));
         assert!(cursor3.is_none());
@@ -1905,14 +1919,16 @@ mod tests {
             .returning(move || Ok(txs.clone()));
 
         let wlt = wallet(ctx);
-        let (res, next_cursor) = wlt
+        let ListTransactionsResult {
+            txs, next_cursor, ..
+        } = wlt
             .list_txs(filters, TransactionSort::TimeDesc, 2, None)
             .await
             .unwrap();
 
-        assert_eq!(tx_ids(&res), tx_ids(&expected));
+        assert_eq!(tx_ids(&txs), tx_ids(&expected));
         assert!(next_cursor.is_none());
-        assert!(res.iter().any(|tx| tx.timestamp == 300));
+        assert!(txs.iter().any(|tx| tx.timestamp == 300));
     }
 
     #[tokio::test]
@@ -1928,7 +1944,9 @@ mod tests {
 
         let wlt = wallet(ctx);
 
-        let (page, next_cursor) = wlt
+        let ListTransactionsResult {
+            txs, next_cursor, ..
+        } = wlt
             .list_txs(
                 TransactionFilters::default(),
                 TransactionSort::TimeDesc,
@@ -1938,11 +1956,11 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(tx_ids(&page), tx_ids(&expected[0..5]));
+        assert_eq!(tx_ids(&txs), tx_ids(&expected[0..5]));
         assert_eq!(
             next_cursor,
             Some(TransactionCursor::from_tx(
-                page.last().unwrap(),
+                txs.last().unwrap(),
                 TransactionSort::TimeDesc,
             ))
         );
@@ -1981,7 +1999,7 @@ mod tests {
             .returning(move || Ok(txs_without_cursor.clone()));
 
         let wlt = wallet(ctx);
-        let (page, _next_cursor) = wlt
+        let ListTransactionsResult { txs, .. } = wlt
             .list_txs(
                 TransactionFilters::default(),
                 TransactionSort::TimeDesc,
@@ -1991,6 +2009,6 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(tx_ids(&page), tx_ids(&expected_after_cursor));
+        assert_eq!(tx_ids(&txs), tx_ids(&expected_after_cursor));
     }
 }

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -47,13 +47,13 @@ pub async fn cmd_info(app_state: &AppState) -> Result<String> {
                 )
                 .await?;
 
-            transactions.extend(res.0);
+            transactions.extend(res.txs);
 
-            if res.1.is_none() {
+            if res.next_cursor.is_none() {
                 break;
             }
 
-            cursor = res.1;
+            cursor = res.next_cursor;
         }
 
         res.push_str(&format!("Name: {name}\n"));

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -3,8 +3,13 @@ use bcr_common::{
     cdk_common::wallet::{Transaction, TransactionDirection, TransactionId},
 };
 use bitcoin::{address::NetworkUnchecked, secp256k1};
+use chrono::{DateTime, Datelike, Utc};
 use nostr_sdk::RelayUrl;
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    str::FromStr,
+    sync::Arc,
+};
 use uuid::Uuid;
 
 pub type Seed = [u8; 64];
@@ -275,5 +280,111 @@ impl TransactionCursor {
                 tx.amount < *amount || (tx.amount == *amount && tx.id() < *id)
             }
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ListTransactionsResult {
+    pub txs: Vec<Transaction>,
+    pub next_cursor: Option<TransactionCursor>,
+    pub fees_by_month: Vec<FeesByMonth>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeesByMonth {
+    pub year: i32,
+    pub month: u32,
+    pub fees: Amount,
+}
+
+// Sums up fees per month for a given set of transactions
+pub fn extract_fees_per_month(transactions: &[Transaction]) -> Vec<FeesByMonth> {
+    let mut fees_by_month: BTreeMap<(i32, u32), Amount> = BTreeMap::new();
+
+    for tx in transactions {
+        let Some(dt) = DateTime::<Utc>::from_timestamp(tx.timestamp as i64, 0) else {
+            continue;
+        };
+
+        let year = dt.year();
+        let month = dt.month();
+
+        fees_by_month
+            .entry((year, month))
+            .and_modify(|fees| *fees += tx.fee)
+            .or_insert(tx.fee);
+    }
+
+    fees_by_month
+        .into_iter()
+        .rev()
+        .map(|((year, month), fees)| FeesByMonth { year, month, fees })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn ts(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> u64 {
+        Utc.with_ymd_and_hms(year, month, day, hour, min, sec)
+            .unwrap()
+            .timestamp() as u64
+    }
+
+    fn tx(timestamp: u64, fee: Amount) -> Transaction {
+        Transaction {
+            mint_url: cashu::MintUrl::from_str("https://mint.example").unwrap(),
+            direction: TransactionDirection::Incoming,
+            amount: Amount::from(0),
+            fee,
+            unit: CurrencyUnit::Sat,
+            ys: vec![],
+            timestamp,
+            memo: None,
+            metadata: HashMap::new(),
+            quote_id: None,
+        }
+    }
+
+    #[test]
+    fn test_empty_vec() {
+        let result = extract_fees_per_month(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_fees_by_month() {
+        let transactions = vec![
+            tx(ts(2025, 2, 1, 12, 0, 0), Amount::from(10)),
+            tx(ts(2025, 2, 15, 12, 0, 0), Amount::from(20)),
+            tx(ts(2025, 3, 1, 12, 0, 0), Amount::from(5)),
+        ];
+        let result = extract_fees_per_month(&transactions);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].year, 2025);
+        assert_eq!(result[0].month, 3);
+        assert_eq!(result[0].fees, Amount::from(5));
+        assert_eq!(result[1].year, 2025);
+        assert_eq!(result[1].month, 2);
+        assert_eq!(result[1].fees, Amount::from(30));
+    }
+
+    #[test]
+    fn sorts_by_year_and_month_descending() {
+        let transactions = vec![
+            tx(ts(2024, 12, 15, 12, 0, 0), Amount::from(1)),
+            tx(ts(2025, 1, 15, 12, 0, 0), Amount::from(2)),
+            tx(ts(2025, 3, 15, 12, 0, 0), Amount::from(3)),
+            tx(ts(2025, 2, 15, 12, 0, 0), Amount::from(4)),
+        ];
+        let result = extract_fees_per_month(&transactions);
+        let year_months: Vec<(i32, u32)> =
+            result.iter().map(|item| (item.year, item.month)).collect();
+        assert_eq!(
+            year_months,
+            vec![(2025, 3), (2025, 2), (2025, 1), (2024, 12),]
+        );
     }
 }

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -1,6 +1,6 @@
 use bcr_wallet_core::types::{
-    PaymentResultCallback, get_btc_alpha_tx_id, get_btc_beta_tx_id, get_payment_type,
-    get_transaction_status,
+    ListTransactionsResult, PaymentResultCallback, get_btc_alpha_tx_id, get_btc_beta_tx_id,
+    get_payment_type, get_transaction_status,
 };
 use nostr_sdk::RelayUrl;
 use once_cell::sync::Lazy;
@@ -643,7 +643,11 @@ pub async fn wallet_get_transactions(
 ) -> Result<WalletListTransactionsResponse, WalletError> {
     let app_state = get_app_state().await;
     let limit = req.limit.clamp(5, 100);
-    let (txs, next_cursor) = app_state
+    let ListTransactionsResult {
+        txs,
+        next_cursor,
+        fees_by_month,
+    } = app_state
         .wallet_list_txs(
             req.wallet_id,
             req.filter.into(),
@@ -655,6 +659,7 @@ pub async fn wallet_get_transactions(
     Ok(WalletListTransactionsResponse {
         txs: txs.into_iter().map(|t| t.into()).collect(),
         next_cursor: next_cursor.map(|nc| nc.into()),
+        fees_by_month: fees_by_month.into_iter().map(|fbm| fbm.into()).collect(),
     })
 }
 
@@ -803,6 +808,7 @@ pub struct WalletListTransactionsRequest {
 pub struct WalletListTransactionsResponse {
     pub txs: Vec<Transaction>,
     pub next_cursor: Option<TransactionCursor>,
+    pub fees_by_month: Vec<FeesByMonth>,
 }
 
 #[derive(Debug, Clone)]
@@ -1158,6 +1164,23 @@ impl From<bcr_wallet_core::types::TransactionCursor> for TransactionCursor {
                     id: id.to_string(),
                 }
             }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeesByMonth {
+    pub year: i32,
+    pub month: u32,
+    pub fees: u64,
+}
+
+impl From<bcr_wallet_core::types::FeesByMonth> for FeesByMonth {
+    fn from(value: bcr_wallet_core::types::FeesByMonth) -> Self {
+        FeesByMonth {
+            year: value.year,
+            month: value.month,
+            fees: u64::from(value.fees),
         }
     }
 }

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -1988,6 +1988,20 @@ impl SseDecode for crate::api::CreateWalletRequest {
     }
 }
 
+impl SseDecode for crate::api::FeesByMonth {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_year = <i32>::sse_decode(deserializer);
+        let mut var_month = <u32>::sse_decode(deserializer);
+        let mut var_fees = <u64>::sse_decode(deserializer);
+        return crate::api::FeesByMonth {
+            year: var_year,
+            month: var_month,
+            fees: var_fees,
+        };
+    }
+}
+
 impl SseDecode for i32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2033,6 +2047,18 @@ impl SseDecode for Vec<String> {
         let mut ans_ = Vec::with_capacity(len_ as usize);
         for idx_ in 0..len_ {
             ans_.push(<String>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<crate::api::FeesByMonth> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::FeesByMonth>::sse_decode(deserializer));
         }
         return ans_;
     }
@@ -2700,9 +2726,11 @@ impl SseDecode for crate::api::WalletListTransactionsResponse {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_txs = <Vec<crate::api::Transaction>>::sse_decode(deserializer);
         let mut var_nextCursor = <Option<crate::api::TransactionCursor>>::sse_decode(deserializer);
+        let mut var_feesByMonth = <Vec<crate::api::FeesByMonth>>::sse_decode(deserializer);
         return crate::api::WalletListTransactionsResponse {
             txs: var_txs,
             next_cursor: var_nextCursor,
+            fees_by_month: var_feesByMonth,
         };
     }
 }
@@ -3235,6 +3263,23 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::CreateWalletRequest>
     for crate::api::CreateWalletRequest
 {
     fn into_into_dart(self) -> crate::api::CreateWalletRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::FeesByMonth {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.year.into_into_dart().into_dart(),
+            self.month.into_into_dart().into_dart(),
+            self.fees.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::FeesByMonth {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::FeesByMonth> for crate::api::FeesByMonth {
+    fn into_into_dart(self) -> crate::api::FeesByMonth {
         self
     }
 }
@@ -3959,6 +4004,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::WalletListTransactionsRespons
         [
             self.txs.into_into_dart().into_dart(),
             self.next_cursor.into_into_dart().into_dart(),
+            self.fees_by_month.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -4685,6 +4731,15 @@ impl SseEncode for crate::api::CreateWalletRequest {
     }
 }
 
+impl SseEncode for crate::api::FeesByMonth {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.year, serializer);
+        <u32>::sse_encode(self.month, serializer);
+        <u64>::sse_encode(self.fees, serializer);
+    }
+}
+
 impl SseEncode for i32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4725,6 +4780,16 @@ impl SseEncode for Vec<String> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <String>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<crate::api::FeesByMonth> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::FeesByMonth>::sse_encode(item, serializer);
         }
     }
 }
@@ -5276,6 +5341,7 @@ impl SseEncode for crate::api::WalletListTransactionsResponse {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <Vec<crate::api::Transaction>>::sse_encode(self.txs, serializer);
         <Option<crate::api::TransactionCursor>>::sse_encode(self.next_cursor, serializer);
+        <Vec<crate::api::FeesByMonth>>::sse_encode(self.fees_by_month, serializer);
     }
 }
 

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `get_app_state`, `init_logging`, `init_panic_hook`, `new`, `reset_runtime`, `start_jobs`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `WalletCleanLocalDbResponse`, `WalletRuntime`, `WalletsNamesResponse`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
 
 Future<void> initWalletFfi({required WalletFfiConfig conf}) =>
     RustLib.instance.api.crateApiInitWalletFfi(conf: conf);
@@ -210,6 +210,30 @@ class CreateWalletRequest {
           bitcoinNetwork == other.bitcoinNetwork &&
           mnemonic == other.mnemonic &&
           nostrRelays == other.nostrRelays;
+}
+
+class FeesByMonth {
+  final int year;
+  final int month;
+  final BigInt fees;
+
+  const FeesByMonth({
+    required this.year,
+    required this.month,
+    required this.fees,
+  });
+
+  @override
+  int get hashCode => year.hashCode ^ month.hashCode ^ fees.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FeesByMonth &&
+          runtimeType == other.runtimeType &&
+          year == other.year &&
+          month == other.month &&
+          fees == other.fees;
 }
 
 class IsValidTokenRequest {
@@ -1008,11 +1032,16 @@ class WalletListTransactionsRequest {
 class WalletListTransactionsResponse {
   final List<Transaction> txs;
   final TransactionCursor? nextCursor;
+  final List<FeesByMonth> feesByMonth;
 
-  const WalletListTransactionsResponse({required this.txs, this.nextCursor});
+  const WalletListTransactionsResponse({
+    required this.txs,
+    this.nextCursor,
+    required this.feesByMonth,
+  });
 
   @override
-  int get hashCode => txs.hashCode ^ nextCursor.hashCode;
+  int get hashCode => txs.hashCode ^ nextCursor.hashCode ^ feesByMonth.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -1020,7 +1049,8 @@ class WalletListTransactionsResponse {
       other is WalletListTransactionsResponse &&
           runtimeType == other.runtimeType &&
           txs == other.txs &&
-          nextCursor == other.nextCursor;
+          nextCursor == other.nextCursor &&
+          feesByMonth == other.feesByMonth;
 }
 
 class WalletMaybeTransactionIdResponse {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -2223,6 +2223,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  FeesByMonth dco_decode_fees_by_month(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return FeesByMonth(
+      year: dco_decode_i_32(arr[0]),
+      month: dco_decode_u_32(arr[1]),
+      fees: dco_decode_u_64(arr[2]),
+    );
+  }
+
+  @protected
   int dco_decode_i_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as int;
@@ -2261,6 +2274,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<String> dco_decode_list_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_String).toList();
+  }
+
+  @protected
+  List<FeesByMonth> dco_decode_list_fees_by_month(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_fees_by_month).toList();
   }
 
   @protected
@@ -2769,11 +2788,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return WalletListTransactionsResponse(
       txs: dco_decode_list_transaction(arr[0]),
       nextCursor: dco_decode_opt_box_autoadd_transaction_cursor(arr[1]),
+      feesByMonth: dco_decode_list_fees_by_month(arr[2]),
     );
   }
 
@@ -3506,6 +3526,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  FeesByMonth sse_decode_fees_by_month(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_year = sse_decode_i_32(deserializer);
+    var var_month = sse_decode_u_32(deserializer);
+    var var_fees = sse_decode_u_64(deserializer);
+    return FeesByMonth(year: var_year, month: var_month, fees: var_fees);
+  }
+
+  @protected
   int sse_decode_i_32(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getInt32();
@@ -3551,6 +3580,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var ans_ = <String>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_String(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<FeesByMonth> sse_decode_list_fees_by_month(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <FeesByMonth>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_fees_by_month(deserializer));
     }
     return ans_;
   }
@@ -4140,9 +4183,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_nextCursor = sse_decode_opt_box_autoadd_transaction_cursor(
       deserializer,
     );
+    var var_feesByMonth = sse_decode_list_fees_by_month(deserializer);
     return WalletListTransactionsResponse(
       txs: var_txs,
       nextCursor: var_nextCursor,
+      feesByMonth: var_feesByMonth,
     );
   }
 
@@ -4867,6 +4912,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_fees_by_month(FeesByMonth self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.year, serializer);
+    sse_encode_u_32(self.month, serializer);
+    sse_encode_u_64(self.fees, serializer);
+  }
+
+  @protected
   void sse_encode_i_32(int self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putInt32(self);
@@ -4905,6 +4958,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
       sse_encode_String(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_fees_by_month(
+    List<FeesByMonth> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_fees_by_month(item, serializer);
     }
   }
 
@@ -5426,6 +5491,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_list_transaction(self.txs, serializer);
     sse_encode_opt_box_autoadd_transaction_cursor(self.nextCursor, serializer);
+    sse_encode_list_fees_by_month(self.feesByMonth, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -177,6 +177,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   CreateWalletRequest dco_decode_create_wallet_request(dynamic raw);
 
   @protected
+  FeesByMonth dco_decode_fees_by_month(dynamic raw);
+
+  @protected
   int dco_decode_i_32(dynamic raw);
 
   @protected
@@ -190,6 +193,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
+  List<FeesByMonth> dco_decode_list_fees_by_month(dynamic raw);
 
   @protected
   List<PaymentType> dco_decode_list_payment_type(dynamic raw);
@@ -683,6 +689,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  FeesByMonth sse_decode_fees_by_month(SseDeserializer deserializer);
+
+  @protected
   int sse_decode_i_32(SseDeserializer deserializer);
 
   @protected
@@ -700,6 +709,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
+  List<FeesByMonth> sse_decode_list_fees_by_month(SseDeserializer deserializer);
 
   @protected
   List<PaymentType> sse_decode_list_payment_type(SseDeserializer deserializer);
@@ -1291,6 +1303,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_fees_by_month(FeesByMonth self, SseSerializer serializer);
+
+  @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
 
   @protected
@@ -1310,6 +1325,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_fees_by_month(
+    List<FeesByMonth> self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_list_payment_type(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -179,6 +179,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   CreateWalletRequest dco_decode_create_wallet_request(dynamic raw);
 
   @protected
+  FeesByMonth dco_decode_fees_by_month(dynamic raw);
+
+  @protected
   int dco_decode_i_32(dynamic raw);
 
   @protected
@@ -192,6 +195,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
+  List<FeesByMonth> dco_decode_list_fees_by_month(dynamic raw);
 
   @protected
   List<PaymentType> dco_decode_list_payment_type(dynamic raw);
@@ -685,6 +691,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  FeesByMonth sse_decode_fees_by_month(SseDeserializer deserializer);
+
+  @protected
   int sse_decode_i_32(SseDeserializer deserializer);
 
   @protected
@@ -702,6 +711,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
+  List<FeesByMonth> sse_decode_list_fees_by_month(SseDeserializer deserializer);
 
   @protected
   List<PaymentType> sse_decode_list_payment_type(SseDeserializer deserializer);
@@ -1293,6 +1305,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_fees_by_month(FeesByMonth self, SseSerializer serializer);
+
+  @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
 
   @protected
@@ -1312,6 +1327,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_fees_by_month(
+    List<FeesByMonth> self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_list_payment_type(


### PR DESCRIPTION
* Add a `fees_by_month` field to the result of `wallet_get_transactions`, which sums up the fees for the distinct months present in the returned transactions by UTC time, sorted descending
