### PR TITLE
Introduce Transport Crate for Nostr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "bcr-common",
  "bcr-wallet-core",
  "bcr-wallet-persistence",
+ "bcr-wallet-transport",
  "bip39",
  "bitcoin",
  "borsh",
@@ -305,7 +306,7 @@ dependencies = [
  "futures",
  "mockall",
  "nostr",
- "nostr-sdk",
+ "nostr-relay-builder",
  "rand 0.9.4",
  "reqwest",
  "secp256k1",
@@ -332,7 +333,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
- "nostr-sdk",
+ "nostr",
  "serde",
  "tokio",
  "tokio-util",
@@ -351,7 +352,7 @@ dependencies = [
  "bip39",
  "bitcoin",
  "chrono",
- "nostr-sdk",
+ "nostr",
  "serde",
  "strum",
  "thiserror 2.0.18",
@@ -370,13 +371,29 @@ dependencies = [
  "chrono",
  "ciborium",
  "mockall",
- "nostr-sdk",
+ "nostr",
  "redb",
  "serde",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
+ "uuid",
+]
+
+[[package]]
+name = "bcr-wallet-transport"
+version = "0.9.3"
+dependencies = [
+ "bcr-common",
+ "bcr-wallet-core",
+ "bip39",
+ "nostr",
+ "nostr-sdk",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -2020,6 +2037,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nostr-relay-builder"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "019df99035f53643078e4733b9559f6d5a2f666d576e26254aa3ab8a043eb86e"
+dependencies = [
+ "async-utility",
+ "async-wsocket",
+ "atomic-destructor",
+ "negentropy",
+ "nostr",
+ "nostr-database",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "nostr-relay-pool"
 version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3578,7 +3611,7 @@ dependencies = [
  "env_logger",
  "flutter_rust_bridge",
  "log",
- "nostr-sdk",
+ "nostr",
  "once_cell",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 [workspace]
 resolver = "3"
 
-members = ["crates/bcr-wallet-core", "crates/bcr-wallet-cli", "crates/bcr-wallet-persistence", "crates/bcr-wallet-api", "crates/bcr-wallet-ffi"]
+members = ["crates/bcr-wallet-core", "crates/bcr-wallet-cli", "crates/bcr-wallet-persistence", "crates/bcr-wallet-api","crates/bcr-wallet-transport", "crates/bcr-wallet-ffi"]
 
 [profile.release]
 opt-level = "s"
@@ -20,6 +20,7 @@ bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev =
 bcr-wallet-core = {path = "./crates/bcr-wallet-core"}
 bcr-wallet-api = {path = "./crates/bcr-wallet-api"}
 bcr-wallet-persistence = {path = "./crates/bcr-wallet-persistence"}
+bcr-wallet-transport = {path = "./crates/bcr-wallet-transport"}
 bip39 = {version = "2.1", features = ["rand"]}
 bitcoin = {version = "0.32"}
 borsh = {version = "1"}

--- a/crates/bcr-wallet-api/Cargo.toml
+++ b/crates/bcr-wallet-api/Cargo.toml
@@ -9,13 +9,13 @@ async-trait.workspace = true
 bcr-common = {workspace = true}
 bcr-wallet-core = {workspace = true}
 bcr-wallet-persistence = {workspace = true, features = ["db-redb"]}
+bcr-wallet-transport = {workspace = true}
 bip39.workspace = true
 bitcoin.workspace = true
 borsh.workspace = true
 chrono = {workspace = true}
 futures = {workspace = true}
 nostr = {workspace = true}
-nostr-sdk = {workspace = true, features = ["nip06"]}
 rand = {workspace = true}
 reqwest = {workspace = true}
 secp256k1.workspace = true
@@ -32,3 +32,4 @@ uuid = {workspace = true }
 bcr-common = {workspace = true, features = ["test-utils"]}
 bcr-wallet-persistence = {workspace = true, features = ["test-utils", "db-redb"]}
 mockall = { workspace = true}
+nostr-relay-builder = "0.43"

--- a/crates/bcr-wallet-api/src/config.rs
+++ b/crates/bcr-wallet-api/src/config.rs
@@ -1,7 +1,5 @@
+use nostr::RelayUrl;
 use std::{collections::HashMap, path::PathBuf};
-
-use crate::error::Result;
-use nostr_sdk::{Keys, RelayUrl, nips::nip06::FromMnemonic, nips::nip19::Nip19Profile};
 
 pub const LOCK_REDUCTION_SECONDS_PER_HOP: u64 = 600;
 pub const MAX_INTERMINT_ATTEMPTS: u64 = 3;
@@ -22,23 +20,4 @@ pub struct CreateWalletConfig {
     pub nostr_relays: Vec<RelayUrl>,
     pub mnemonic: bip39::Mnemonic,
     pub default_mint_url: url::Url,
-}
-
-#[derive(Debug, Clone)]
-pub struct NostrConfig {
-    pub nprofile: Nip19Profile,
-    pub nostr_signer: Keys,
-    pub relays: Vec<RelayUrl>,
-}
-
-impl NostrConfig {
-    pub fn new(mnemonic: bip39::Mnemonic, nostr_relays: Vec<RelayUrl>) -> Result<Self> {
-        let keys = Keys::from_mnemonic(mnemonic.to_string(), None)?;
-
-        Ok(Self {
-            nprofile: Nip19Profile::new(keys.public_key, nostr_relays.clone()),
-            nostr_signer: keys,
-            relays: nostr_relays,
-        })
-    }
 }

--- a/crates/bcr-wallet-api/src/error.rs
+++ b/crates/bcr-wallet-api/src/error.rs
@@ -43,12 +43,6 @@ pub enum Error {
     BtcBip32(#[from] bitcoin::bip32::Error),
     #[error("uuid:: {0}")]
     Uuid(#[from] uuid::Error),
-    #[error("nostr::nip19 {0}")]
-    Nip19(#[from] nostr_sdk::nips::nip19::Error),
-    #[error("nostr::nip06 {0}")]
-    Nip06(#[from] nostr_sdk::nips::nip06::Error),
-    #[error("nostr-sdk::client {0}")]
-    NostrClient(#[from] nostr_sdk::client::Error),
     #[error("serde_json: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("reqwest::Url {0}")]
@@ -129,6 +123,8 @@ pub enum Error {
     InsufficientOnChainMintAmount(u64),
     #[error("Database Error: {0}")]
     Database(#[from] bcr_wallet_persistence::error::Error),
+    #[error("Transport Error: {0}")]
+    Transport(#[from] bcr_wallet_transport::error::Error),
     #[error("External Error: {0}")]
     External(#[from] crate::external::Error),
     #[error("Dev Mode is disabled")]

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::config::{AppStateConfig, CreateWalletConfig};
 use crate::external::mint::{ClowderMintConnector, HttpClientExt};
+use crate::wallet::api::WalletApi;
 use crate::wallet::types::{WalletBalance, WalletDetailedBalanceEntry, WalletProtestResult};
-use crate::{config::NostrConfig, wallet::api::WalletApi};
 use bcr_common::cdk_common::wallet::Transaction;
 use bcr_common::{
     cashu::{self, CurrencyUnit},
@@ -14,9 +14,8 @@ use bcr_wallet_core::types::{
 };
 use bcr_wallet_core::util::{build_wallet_id, keypair_from_mnemonic, seed_from_mnemonic};
 use bcr_wallet_persistence::redb::{Database, build_pursedb, build_wallet_dbs, create_db};
+use bcr_wallet_transport::NostrClient;
 use error::{Error, Result};
-use nostr::nips::nip19::Nip19Profile;
-use nostr::types::RelayUrl;
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
@@ -78,7 +77,7 @@ impl AppState {
             let seed = seed_from_mnemonic(mnemonic);
 
             let client = HttpClientExt::new(w_cfg.mint.clone());
-            let (nostr_cl, nprofile) = setup_nostr_client(mnemonic, &w_cfg.nostr_relays).await?;
+            let nostr_cl = NostrClient::new(mnemonic, &w_cfg.nostr_relays).await?;
 
             // Attempt to fetch clowder id/betas/keyset infos and fall back to saved ones
             match client.get_clowder_id().await {
@@ -127,7 +126,6 @@ impl AppState {
                 db.clone(),
                 seed,
                 nostr_cl,
-                nprofile,
             )
             .await?;
             purse.add_wallet(wallet).await?;
@@ -828,7 +826,7 @@ async fn create_new_wallet(
         }
     };
 
-    let (nostr_cl, nprofile) = setup_nostr_client(&cfg.mnemonic, &cfg.nostr_relays).await?;
+    let nostr_cl = NostrClient::new(&cfg.mnemonic, &cfg.nostr_relays).await?;
 
     let w_cfg = WalletConfig {
         wallet_id,
@@ -842,37 +840,7 @@ async fn create_new_wallet(
         betas,
         nostr_relays: cfg.nostr_relays,
     };
-    build_wallet(
-        w_cfg,
-        client,
-        db_version,
-        swap_expiry,
-        db,
-        seed,
-        nostr_cl,
-        nprofile,
-    )
-    .await
-}
-
-async fn setup_nostr_client(
-    mnemonic: &bip39::Mnemonic,
-    nostr_relays: &[RelayUrl],
-) -> Result<(Arc<nostr_sdk::Client>, Nip19Profile)> {
-    let nostr_cfg = NostrConfig::new(mnemonic.to_owned(), nostr_relays.to_owned())?;
-    let nostr_filter = nostr_sdk::Filter::new()
-        .kind(nostr_sdk::Kind::GiftWrap)
-        .pubkey(nostr_cfg.nostr_signer.public_key());
-    let nostr_cl = Arc::new(nostr_sdk::Client::new(nostr_cfg.nostr_signer));
-    for nostr_relay in &nostr_cfg.relays {
-        nostr_cl.add_relay(nostr_relay).await?;
-    }
-    nostr_cl.connect().await;
-
-    // create long-running subscription
-    nostr_cl.subscribe(nostr_filter, None).await?;
-
-    Ok((nostr_cl, nostr_cfg.nprofile))
+    build_wallet(w_cfg, client, db_version, swap_expiry, db, seed, nostr_cl).await
 }
 
 async fn build_wallet(
@@ -882,8 +850,7 @@ async fn build_wallet(
     swap_expiry: chrono::TimeDelta,
     db: Arc<Database>,
     seed: Seed,
-    nostr_cl: Arc<nostr_sdk::Client>,
-    nostr_profile: Nip19Profile,
+    nostr_cl: NostrClient,
 ) -> Result<wallet::Wallet> {
     // building wallet dbs
     let (tx_repo, (debitdb, mintmeltdb)) =
@@ -928,7 +895,6 @@ async fn build_wallet(
         swap_expiry,
         w_cfg.nostr_relays,
         nostr_cl,
-        nostr_profile,
     )
     .await?;
     Ok(new_wallet)

--- a/crates/bcr-wallet-api/src/pocket/test_utils.rs
+++ b/crates/bcr-wallet-api/src/pocket/test_utils.rs
@@ -9,7 +9,6 @@ pub mod tests {
     use crate::wallet::types::SwapConfig;
     use async_trait::async_trait;
     use bcr_common::cdk_common::mint::MintKeySetInfo;
-    use bcr_common::wire::melt as wire_melt;
     use std::collections::HashMap;
     use std::sync::Arc;
     use uuid::Uuid;

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -6,7 +6,10 @@ use crate::{
         MintSummary, PAYMENT_TYPE_METADATA_KEY, PaymentSummary, TRANSACTION_STATUS_METADATA_KEY,
         WalletConfig,
     },
-    wallet::types::{PayReference, WalletPaymentType, WalletProtestResult},
+    wallet::{
+        api,
+        types::{PayReference, WalletPaymentType, WalletProtestResult},
+    },
 };
 use async_trait::async_trait;
 use bcr_common::{
@@ -17,14 +20,15 @@ use bcr_common::{
 };
 use bcr_wallet_core::{
     SendSync,
-    types::{BTC_TX_ID_TYPE_METADATA_KEY, PaymentResultCallback, PaymentType, TransactionStatus},
-    util::to_mint_url,
+    types::{
+        BTC_TX_ID_TYPE_METADATA_KEY, PaymentResultCallback,
+        PaymentType, TransactionStatus,
+    },
+    util::{from_mint_url, to_mint_url},
 };
 use bitcoin::secp256k1;
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
-use nostr::nips::nip19::ToBech32;
-use nostr_sdk::RelayPoolNotification;
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -202,11 +206,7 @@ impl WalletApi for super::Wallet {
         unit: CurrencyUnit,
         description: Option<String>,
     ) -> Result<cdk18::PaymentRequest> {
-        let nostr_transport = cdk18::Transport {
-            _type: cdk18::TransportType::Nostr,
-            target: self.nostr_profile.to_bech32()?,
-            tags: Some(vec![vec![String::from("n"), String::from("17")]]),
-        };
+        let nostr_transport = self.nostr_cl.transport().await?;
         let mints = self
             .mint_urls()
             .into_iter()
@@ -243,10 +243,9 @@ impl WalletApi for super::Wallet {
         }
 
         let start = tokio::time::Instant::now();
-        let signer = self.nostr_cl.signer().await?;
 
         tracing::debug!("Subscribing to events from Nostr...");
-        let mut events = self.nostr_cl.notifications();
+        let mut events = self.nostr_cl.events_channel();
         let deadline = start + max_wait;
 
         loop {
@@ -267,24 +266,38 @@ impl WalletApi for super::Wallet {
                         result_callback(None);
                         return Ok(());
                     };
-                    if let RelayPoolNotification::Event { event, .. } = received_evt {
-                    match self
-                        .handle_event(*event, signer.clone(), p_id, req.amount.unwrap_or_default())
-                        .await
-                        {
-                            Ok(None) => {
-                                // do nothing
-                                continue;
-                            }
-                            Ok(Some(tx_id)) => {
-                                result_callback(Some(tx_id));
-                                return Ok(());
-                            }
-                            Err(e) => {
-                                tracing::error!("Error while handling Nostr event: {e}");
-                                continue;
-                            }
-                        };
+                    match self.nostr_cl.handle_event(received_evt, p_id, req.amount.unwrap_or_default()).await {
+                        Ok(None) => {
+                            // do nothing
+                            continue;
+                        }
+                        Ok(Some((payload, meta))) => {
+                            let response = <Self as api::WalletApi>::receive_proofs(
+                                self,
+                                payload.proofs,
+                                payload.unit,
+                                from_mint_url(&payload.mint),
+                                chrono::Utc::now().timestamp() as u64,
+                                payload.memo,
+                                meta,
+                            )
+                                .await;
+
+                            match response {
+                                Ok(txid) => {
+                                    result_callback(Some(txid));
+                                    return Ok(());
+                                },
+                                Err(e) => {
+                                    tracing::error!("Error while handling Nostr event: {e}");
+                                    continue;
+                                },
+                            };
+                        }
+                        Err(e) => {
+                            tracing::error!("Error while handling Nostr event: {e}");
+                            continue;
+                        }
                     }
                 }
             }

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -13,10 +13,7 @@ use crate::{
     },
 };
 use bcr_common::{
-    cashu::{
-        self, Amount, CurrencyUnit, KeySetInfo, PaymentRequest, Proof, ProofsMethods,
-        nut18 as cdk18,
-    },
+    cashu::{self, Amount, CurrencyUnit, KeySetInfo, PaymentRequest, Proof, ProofsMethods},
     cdk_common::wallet::{Transaction, TransactionDirection, TransactionId},
     wallet::Token,
     wire::clowder::{ConnectedMintResponse, ConnectedMintsResponse},
@@ -29,15 +26,14 @@ use bcr_wallet_core::{
     util::{from_mint_url, to_mint_url},
 };
 use bcr_wallet_persistence::TransactionRepository;
+use bcr_wallet_transport::NostrClient;
 use bitcoin::{
     hashes::{Hash, sha256::Hash as Sha256},
     secp256k1,
 };
-use nostr::{nips::nip59::UnwrappedGift, signer::NostrSigner, types::RelayUrl};
-use nostr_sdk::nips::nip19::{FromBech32, Nip19Profile};
+use nostr::types::RelayUrl;
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 use tokio::sync::Mutex;
-use uuid::Uuid;
 
 pub struct Wallet {
     network: bitcoin::Network,
@@ -55,8 +51,7 @@ pub struct Wallet {
     client_factory: Box<dyn Fn(url::Url) -> Arc<dyn ClowderMintConnector> + Send + Sync>,
     swap_expiry: chrono::TimeDelta,
     nostr_relays: Vec<RelayUrl>,
-    nostr_cl: Arc<nostr_sdk::Client>,
-    nostr_profile: Nip19Profile,
+    nostr_cl: NostrClient,
 }
 
 impl Wallet {
@@ -74,8 +69,7 @@ impl Wallet {
         client_factory: Box<dyn Fn(url::Url) -> Arc<dyn ClowderMintConnector> + Send + Sync>,
         swap_expiry: chrono::TimeDelta,
         nostr_relays: Vec<RelayUrl>,
-        nostr_cl: Arc<nostr_sdk::Client>,
-        nostr_profile: Nip19Profile,
+        nostr_cl: NostrClient,
     ) -> Result<Self> {
         Ok(Self {
             network,
@@ -94,7 +88,6 @@ impl Wallet {
             swap_expiry,
             nostr_relays,
             nostr_cl,
-            nostr_profile,
         })
     }
 
@@ -744,7 +737,7 @@ impl Wallet {
     async fn pay_nut18(
         &self,
         proofs: Vec<cashu::Proof>,
-        nostr_cl: &nostr_sdk::Client,
+        nostr_cl: &NostrClient,
         http_cl: &reqwest::Client,
         transport: cashu::Transport,
         p_id: Option<String>,
@@ -765,101 +758,14 @@ impl Wallet {
             }
             cashu::TransportType::Nostr => {
                 let payload = serde_json::to_string(&payload)?;
-                let receiver = Nip19Profile::from_bech32(&transport.target)?;
-                let output = nostr_cl
-                    .send_private_msg_to(
-                        receiver.relays,
-                        receiver.public_key,
-                        payload,
-                        std::iter::empty(),
-                    )
-                    .await?;
+                let event_id = nostr_cl.send_private_msg(transport.target, payload).await?;
                 partial_tx
                     .metadata
-                    .insert(String::from("nostr::event_id"), output.id().to_string());
+                    .insert(String::from("nostr::event_id"), event_id.to_string());
             }
         }
         let txid = self.tx_repo.store_tx(partial_tx).await?;
         Ok(txid)
-    }
-
-    pub async fn handle_event(
-        &self,
-        event: nostr_sdk::Event,
-        signer: Arc<dyn NostrSigner>,
-        payment_id: Uuid,
-        expected: Amount,
-    ) -> Result<Option<TransactionId>> {
-        if event.kind != nostr_sdk::Kind::GiftWrap {
-            tracing::debug!("handle event, but no GiftWrap - {}", event.kind);
-            return Ok(None);
-        }
-
-        let payload = match UnwrappedGift::from_gift_wrap(&signer, &event).await {
-            Ok(UnwrappedGift { rumor, .. }) => {
-                if rumor.kind == nostr_sdk::Kind::PrivateDirectMessage {
-                    match serde_json::from_str::<cdk18::PaymentRequestPayload>(&rumor.content) {
-                        Ok(payload) => payload,
-                        Err(e) => {
-                            tracing::error!("Parsing Payment Request failed: {e}");
-                            return Ok(None);
-                        }
-                    }
-                } else {
-                    tracing::debug!(
-                        "handle event, but rumor no PrivateDirectMessage - {}",
-                        rumor.kind
-                    );
-                    return Ok(None);
-                }
-            }
-            Err(e) => {
-                tracing::error!("Unwrapping gift wrap failed: {e}");
-                return Ok(None);
-            }
-        };
-
-        if payload.id.unwrap_or_default() != payment_id.to_string() {
-            tracing::debug!("handle event, payment id doesn't match");
-            return Ok(None);
-        }
-
-        let amount = payload.proofs.total_amount()?;
-        if amount < expected {
-            tracing::warn!(
-                "Received amount {} is less than expected {}",
-                amount,
-                expected
-            );
-            return Ok(None);
-        }
-        let meta = HashMap::from([
-            (String::from("sender"), event.pubkey.to_string()),
-            (String::from("payment_id"), payment_id.to_string()),
-            (String::from("nostr_event_id"), event.id.to_string()),
-            (
-                String::from(PAYMENT_TYPE_METADATA_KEY),
-                PaymentType::Cdk18.to_string(),
-            ),
-            (
-                String::from(TRANSACTION_STATUS_METADATA_KEY),
-                TransactionStatus::Settled.to_string(),
-            ),
-        ]);
-        let response = <Self as api::WalletApi>::receive_proofs(
-            self,
-            payload.proofs,
-            payload.unit,
-            from_mint_url(&payload.mint),
-            chrono::Utc::now().timestamp() as u64,
-            payload.memo,
-            meta,
-        )
-        .await;
-        match response {
-            Ok(txid) => Ok(Some(txid)),
-            Err(e) => Err(e),
-        }
     }
 
     pub async fn dev_mode_detailed_balance(&self) -> Result<Vec<WalletDetailedBalanceEntry>> {
@@ -899,6 +805,7 @@ mod tests {
     };
     use secp256k1::SECP256K1;
     use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
 
     use super::*;
     use crate::{
@@ -906,6 +813,7 @@ mod tests {
         pocket::{PocketBalance, test_utils::tests::MockDebitPocket},
         wallet::{api::WalletApi, types::WalletPaymentType},
     };
+    use nostr_relay_builder::MockRelay;
 
     struct MockWalletCtx {
         pub client: MockClowderMintConnector,
@@ -922,9 +830,12 @@ mod tests {
         }
     }
 
-    fn wallet(ctx: MockWalletCtx) -> Wallet {
+    pub async fn get_mock_relay() -> MockRelay {
+        MockRelay::run().await.expect("could not create mock relay")
+    }
+
+    async fn wallet(ctx: MockWalletCtx) -> Wallet {
         let arc_client: Arc<dyn ClowderMintConnector> = Arc::new(ctx.client);
-        let nostr_keys = nostr_sdk::Keys::generate();
         let mut beta_mock = crate::external::mint::MockClowderMintConnector::new();
         beta_mock.expect_get_alpha_status().returning(|_| {
             Ok(bcr_common::wire::clowder::AlphaStateResponse {
@@ -939,6 +850,8 @@ mod tests {
         let beta_url = url::Url::parse("https://beta.test").unwrap();
         let mut beta_clients: HashMap<url::Url, Arc<dyn ClowderMintConnector>> = HashMap::new();
         beta_clients.insert(beta_url, Arc::new(beta_mock));
+
+        let relay = get_mock_relay().await;
         Wallet {
             network: bitcoin::Network::Testnet,
             client: arc_client,
@@ -955,8 +868,12 @@ mod tests {
             client_factory: Box::new(|url| Arc::new(HttpClientExt::new(url))),
             swap_expiry: chrono::TimeDelta::seconds(60),
             nostr_relays: vec![],
-            nostr_cl: Arc::new(nostr_sdk::Client::new(nostr_keys.clone())),
-            nostr_profile: Nip19Profile::new(nostr_keys.public_key(), vec![]),
+            nostr_cl: NostrClient::new(
+                &bip39::Mnemonic::generate(12).unwrap(),
+                &[RelayUrl::from_str(&relay.url()).unwrap()],
+            )
+            .await
+            .unwrap(),
         }
     }
 
@@ -1124,7 +1041,7 @@ mod tests {
             .times(1)
             .return_const(url::Url::from_str("https://mint.example").unwrap());
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         let cfg = wlt.config().expect("config works");
 
         assert_eq!(cfg.wallet_id, "w-1");
@@ -1140,7 +1057,7 @@ mod tests {
     #[tokio::test]
     async fn test_name() {
         let ctx = wallet_ctx();
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
 
         let res = wlt.name();
         assert_eq!(res, "wallet-1".to_owned());
@@ -1149,7 +1066,7 @@ mod tests {
     #[tokio::test]
     async fn test_id() {
         let ctx = wallet_ctx();
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         assert_eq!(wlt.id(), "w-1".to_string());
     }
 
@@ -1161,7 +1078,7 @@ mod tests {
             .times(1)
             .return_const(url::Url::from_str("https://mint.example").unwrap());
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         let url = wlt.mint_url();
         assert_eq!(url.to_string(), "https://mint.example/");
     }
@@ -1173,7 +1090,7 @@ mod tests {
             .expect_mint_url()
             .times(1)
             .return_const(url::Url::from_str("https://mint.example").unwrap());
-        let mut wlt = wallet(ctx);
+        let mut wlt = wallet(ctx).await;
 
         let b1 = url::Url::from_str("https://beta1.example").unwrap();
         let b2 = url::Url::from_str("https://beta2.example").unwrap();
@@ -1198,7 +1115,7 @@ mod tests {
     #[tokio::test]
     async fn test_clowder_id() {
         let ctx = wallet_ctx();
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         assert_eq!(wlt.clowder_id(), test_pub_key());
     }
 
@@ -1209,7 +1126,7 @@ mod tests {
             .expect_get_mint_keysets()
             .times(1)
             .returning(|| Ok(vec![]));
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
 
         let err = wlt
             .prepare_pay("not-a-request".to_string())
@@ -1231,7 +1148,7 @@ mod tests {
             .times(1)
             .return_const(url::Url::from_str("https://mint.example").unwrap());
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         let req = wlt
             .prepare_payment_request(
                 cashu::Amount::from(123),
@@ -1253,7 +1170,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_received_payment_errors_if_no_current_request() {
         let ctx = wallet_ctx();
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
 
         let callback: PaymentResultCallback = Arc::new(move |_| {});
         let cancel_token = CancellationToken::new();
@@ -1282,7 +1199,7 @@ mod tests {
             .expect_unit()
             .times(1)
             .returning(|| CurrencyUnit::Sat);
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
 
         let res = wlt.debit_unit();
         assert_eq!(res, CurrencyUnit::Sat);
@@ -1299,7 +1216,7 @@ mod tests {
             .expect_balance()
             .times(1)
             .returning(|_| Ok(PocketBalance::default()));
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
 
         let res = wlt.balance().await.expect("balance works");
         assert_eq!(res.debit, Amount::ZERO);
@@ -1314,7 +1231,7 @@ mod tests {
             .expect_list_tx_ids()
             .times(1)
             .returning(|| Ok(vec![]));
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
 
         let res = wlt.list_tx_ids().await.unwrap();
         assert!(res.is_empty());
@@ -1327,7 +1244,7 @@ mod tests {
             .expect_list_txs()
             .times(1)
             .returning(|| Ok(vec![]));
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
 
         let res = wlt
             .list_txs(
@@ -1345,7 +1262,7 @@ mod tests {
     #[tokio::test]
     async fn test_is_wallet_mint_offline_majority_true() {
         let ctx = wallet_ctx();
-        let mut wlt = wallet(ctx);
+        let mut wlt = wallet(ctx).await;
 
         let b1 = url::Url::from_str("https://b1.example").unwrap();
         let b2 = url::Url::from_str("https://b2.example").unwrap();
@@ -1383,7 +1300,7 @@ mod tests {
     #[tokio::test]
     async fn test_is_wallet_mint_rabid_majority_false() {
         let ctx = wallet_ctx();
-        let mut wlt = wallet(ctx);
+        let mut wlt = wallet(ctx).await;
 
         let b1 = url::Url::from_str("https://b1.example").unwrap();
         let b2 = url::Url::from_str("https://b2.example").unwrap();
@@ -1411,7 +1328,7 @@ mod tests {
     #[tokio::test]
     async fn test_mint_substitute_returns_some_on_majority_vote() {
         let ctx = wallet_ctx();
-        let mut wlt = wallet(ctx);
+        let mut wlt = wallet(ctx).await;
 
         let b1 = url::Url::from_str("https://b1.example").unwrap();
         let b2 = url::Url::from_str("https://b2.example").unwrap();
@@ -1471,7 +1388,7 @@ mod tests {
             .expect_unit()
             .times(1)
             .returning(|| CurrencyUnit::Sat);
-        let mut wlt = wallet(ctx);
+        let mut wlt = wallet(ctx).await;
         wlt.beta_clients.clear();
 
         let err = wlt
@@ -1521,7 +1438,7 @@ mod tests {
             .times(1)
             .returning(|_tx| Ok(TransactionId::new(vec![])));
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         *wlt.current_payment.lock().await = Some(PayReference {
             request_id: pid,
             unit: CurrencyUnit::Sat,
@@ -1558,7 +1475,7 @@ mod tests {
                 })
             });
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         let _ = wlt.mint(bitcoin::Amount::from_sat(1000)).await.unwrap();
     }
 
@@ -1578,7 +1495,7 @@ mod tests {
 
         ctx.tx_repo.expect_list_txs().returning(|| Ok(vec![]));
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         let recovered = wlt.recover_pending_stale_proofs().await.unwrap();
         assert_eq!(recovered, Amount::from(10));
     }
@@ -1606,7 +1523,7 @@ mod tests {
             .times(2)
             .returning(move |_| Ok(tx.clone()));
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         let err = wlt.reclaim_tx(tx_id).await.unwrap_err();
 
         match err {
@@ -1655,7 +1572,7 @@ mod tests {
             })
             .returning(|_, _, _| Ok(None));
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         let amount = wlt.reclaim_tx(tx_id).await.unwrap();
 
         assert_eq!(amount, Amount::ZERO);
@@ -1703,7 +1620,7 @@ mod tests {
 
         ctx.tx_repo.expect_update_fee().times(0);
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         let amount = wlt.reclaim_tx(tx_id).await.unwrap();
 
         assert_eq!(amount, Amount::from(10));
@@ -1755,7 +1672,7 @@ mod tests {
             .withf(|_, fee| *fee == Amount::from(3))
             .returning(|_, _| Ok(()));
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         let amount = wlt.reclaim_tx(tx_id).await.unwrap();
 
         assert_eq!(amount, Amount::from(7));
@@ -1770,7 +1687,7 @@ mod tests {
             .times(2)
             .returning(move |_, _| Ok(None));
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         wlt.edit_tx_memo(tx_id, Some("new_memo".to_owned()))
             .await
             .unwrap();
@@ -1794,7 +1711,7 @@ mod tests {
                 .times(1)
                 .returning(move || Ok(txs.clone()));
 
-            let wlt = wallet(ctx);
+            let wlt = wallet(ctx).await;
             let ListTransactionsResult {
                 txs, next_cursor, ..
             } = wlt
@@ -1818,7 +1735,7 @@ mod tests {
             .times(3)
             .returning(move || Ok(txs.clone()));
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
 
         let res1 = wlt
             .list_txs(
@@ -1918,7 +1835,7 @@ mod tests {
             .times(1)
             .returning(move || Ok(txs.clone()));
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         let ListTransactionsResult {
             txs, next_cursor, ..
         } = wlt
@@ -1942,7 +1859,7 @@ mod tests {
             .times(1)
             .returning(move || Ok(txs.clone()));
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
 
         let ListTransactionsResult {
             txs, next_cursor, ..
@@ -1998,7 +1915,7 @@ mod tests {
             .times(1)
             .returning(move || Ok(txs_without_cursor.clone()));
 
-        let wlt = wallet(ctx);
+        let wlt = wallet(ctx).await;
         let ListTransactionsResult { txs, .. } = wlt
             .list_txs(
                 TransactionFilters::default(),

--- a/crates/bcr-wallet-cli/Cargo.toml
+++ b/crates/bcr-wallet-cli/Cargo.toml
@@ -14,7 +14,7 @@ bitcoin.workspace = true
 chrono.workspace = true
 clap = {version = "4.0", features = ["derive"]}
 config = {version="0.15"}
-nostr-sdk = {workspace = true, features = ["nip06"]}
+nostr = {workspace = true}
 serde.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -5,7 +5,7 @@ use bcr_wallet_api::{
     AppState, config::AppStateConfig, generate_random_mnemonic, get_wallet_id, is_valid_token,
 };
 use clap::{Parser, Subcommand};
-use nostr_sdk::RelayUrl;
+use nostr::RelayUrl;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 use tracing_subscriber::{

--- a/crates/bcr-wallet-core/Cargo.toml
+++ b/crates/bcr-wallet-core/Cargo.toml
@@ -9,7 +9,7 @@ bcr-common = {workspace = true}
 bip39.workspace = true
 bitcoin.workspace = true
 chrono = {workspace = true}
-nostr-sdk = {workspace = true, features = ["nip06"]}
+nostr = {workspace = true}
 serde.workspace = true
 strum = {workspace = true, features = ["derive"]}
 thiserror = {workspace = true }

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -4,7 +4,7 @@ use bcr_common::{
 };
 use bitcoin::{address::NetworkUnchecked, secp256k1};
 use chrono::{DateTime, Datelike, Utc};
-use nostr_sdk::RelayUrl;
+use nostr::RelayUrl;
 use std::{
     collections::{BTreeMap, HashMap},
     str::FromStr,

--- a/crates/bcr-wallet-ffi/Cargo.toml
+++ b/crates/bcr-wallet-ffi/Cargo.toml
@@ -18,7 +18,7 @@ chrono = {workspace = true}
 env_logger = {version = "0.11"}
 flutter_rust_bridge = { version = "=2.12.0", default-features = false, features = ["anyhow", "dart-opaque", "portable-atomic", "rust-async", "thread-pool", "user-utils", "wasm-start"] }
 log = {version = "0.4"}
-nostr-sdk = {workspace = true}
+nostr = {workspace = true}
 once_cell = {version = "1.21"}
 tokio = {workspace = true}
 tokio-util = {workspace = true}

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -2,7 +2,7 @@ use bcr_wallet_core::types::{
     ListTransactionsResult, PaymentResultCallback, get_btc_tx_id, get_payment_type,
     get_transaction_status,
 };
-use nostr_sdk::RelayUrl;
+use nostr::RelayUrl;
 use once_cell::sync::Lazy;
 use std::{collections::HashMap, panic, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 use tokio_util::sync::CancellationToken;
@@ -1550,9 +1550,6 @@ impl From<BcrWalletError> for WalletError {
             BcrWalletError::CdkDhke(_) => WalletError::internal(value.to_string()),
             BcrWalletError::BtcBip32(_) => WalletError::internal(value.to_string()),
             BcrWalletError::Uuid(_) => WalletError::internal(value.to_string()),
-            BcrWalletError::Nip19(_) => WalletError::internal(value.to_string()),
-            BcrWalletError::Nip06(_) => WalletError::internal(value.to_string()),
-            BcrWalletError::NostrClient(_) => WalletError::network(value.to_string()),
             BcrWalletError::SerdeJson(_) => WalletError::internal(value.to_string()),
             BcrWalletError::Url(_) => {
                 WalletError::bad_request(value.to_string(), WalletErrorCode::Url)
@@ -1652,6 +1649,7 @@ impl From<BcrWalletError> for WalletError {
             BcrWalletError::InterMintButNoClowderPath => WalletError::internal(value.to_string()),
             BcrWalletError::SchnorrSignature(_) => WalletError::internal(value.to_string()),
             BcrWalletError::Database(_) => WalletError::internal(value.to_string()),
+            BcrWalletError::Transport(_) => WalletError::internal(value.to_string()),
             BcrWalletError::Swap(_) => WalletError::internal(value.to_string()),
             BcrWalletError::NoBetas => WalletError::internal(value.to_string()),
             BcrWalletError::NoDevMode => {

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -28,7 +28,7 @@
 
 use crate::api::*;
 use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
-use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
 use flutter_rust_bridge::{Handler, IntoIntoDart};
 
 // Section: boilerplate
@@ -5578,7 +5578,7 @@ mod io {
     use flutter_rust_bridge::for_generated::byteorder::{
         NativeEndian, ReadBytesExt, WriteBytesExt,
     };
-    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate
@@ -5617,7 +5617,7 @@ mod web {
     };
     use flutter_rust_bridge::for_generated::wasm_bindgen;
     use flutter_rust_bridge::for_generated::wasm_bindgen::prelude::*;
-    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
+    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate

--- a/crates/bcr-wallet-persistence/Cargo.toml
+++ b/crates/bcr-wallet-persistence/Cargo.toml
@@ -16,7 +16,7 @@ bitcoin.workspace = true
 chrono = {workspace = true}
 ciborium = {workspace = true}
 mockall = {workspace = true, optional = true}
-nostr-sdk = {workspace = true, features = ["nip06"]}
+nostr = {workspace = true}
 redb = {version = "4.1.0", optional = true}
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/bcr-wallet-persistence/src/redb/purse.rs
+++ b/crates/bcr-wallet-persistence/src/redb/purse.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use bcr_common::cashu::{self, CurrencyUnit};
 use bcr_wallet_core::types::WalletConfig;
 use bitcoin::secp256k1;
-use nostr_sdk::RelayUrl;
+use nostr::RelayUrl;
 use redb::{Database, ReadableDatabase, TableDefinition, TableError};
 use std::{collections::HashMap, sync::Arc};
 use tokio::task::spawn_blocking;

--- a/crates/bcr-wallet-transport/Cargo.toml
+++ b/crates/bcr-wallet-transport/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bcr-wallet-transport"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+bcr-common = {workspace = true}
+bcr-wallet-core = {workspace = true}
+bip39.workspace = true
+nostr = {workspace = true}
+nostr-sdk = {workspace = true, features = ["nip06", "nip59"]}
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = {workspace = true}
+tracing.workspace = true
+uuid = {workspace = true }
+

--- a/crates/bcr-wallet-transport/src/error.rs
+++ b/crates/bcr-wallet-transport/src/error.rs
@@ -1,0 +1,18 @@
+use bcr_common::cashu;
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("nostr::nip19 {0}")]
+    Nip19(#[from] nostr_sdk::nips::nip19::Error),
+    #[error("nostr::nip06 {0}")]
+    Nip06(#[from] nostr_sdk::nips::nip06::Error),
+    #[error("nostr-sdk::client {0}")]
+    NostrClient(#[from] nostr_sdk::client::Error),
+    #[error("serde_json: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("cashu::nut00: {0}")]
+    Cdk00(#[from] cashu::nut00::Error),
+}

--- a/crates/bcr-wallet-transport/src/lib.rs
+++ b/crates/bcr-wallet-transport/src/lib.rs
@@ -1,0 +1,174 @@
+use std::{collections::HashMap, sync::Arc};
+
+use bcr_common::cashu::{Amount, ProofsMethods, nut18 as cdk18};
+use bcr_wallet_core::types::{
+    PAYMENT_TYPE_METADATA_KEY, PaymentType, TRANSACTION_STATUS_METADATA_KEY, TransactionStatus,
+};
+use error::Result;
+use nostr::{
+    event::EventId,
+    nips::{
+        nip19::{FromBech32, Nip19Profile, ToBech32},
+        nip59::UnwrappedGift,
+    },
+    signer::NostrSigner,
+    types::RelayUrl,
+};
+use nostr_sdk::{Client, Keys, RelayPoolNotification, nips::nip06::FromMnemonic};
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+pub mod error;
+
+#[derive(Clone)]
+pub struct NostrClient {
+    client: Client,
+    profile: Nip19Profile,
+}
+
+impl NostrClient {
+    pub async fn new(mnemonic: &bip39::Mnemonic, nostr_relays: &[RelayUrl]) -> Result<Self> {
+        let nostr_cfg = NostrConfig::new(mnemonic.to_owned(), nostr_relays.to_owned())?;
+        let nostr_filter = nostr_sdk::Filter::new()
+            .kind(nostr_sdk::Kind::GiftWrap)
+            .pubkey(nostr_cfg.nostr_signer.public_key());
+        let nostr_cl = nostr_sdk::Client::new(nostr_cfg.nostr_signer);
+        for nostr_relay in &nostr_cfg.relays {
+            nostr_cl.add_relay(nostr_relay).await?;
+        }
+        nostr_cl.connect().await;
+
+        // create long-running subscription
+        nostr_cl.subscribe(nostr_filter, None).await?;
+
+        Ok(Self {
+            client: nostr_cl,
+            profile: nostr_cfg.nprofile,
+        })
+    }
+
+    pub async fn send_private_msg(&self, target: String, payload: String) -> Result<EventId> {
+        let receiver = Nip19Profile::from_bech32(&target)?;
+        let output = self
+            .client
+            .send_private_msg_to(
+                receiver.relays,
+                receiver.public_key,
+                payload,
+                std::iter::empty(),
+            )
+            .await?;
+        Ok(output.id().to_owned())
+    }
+
+    pub async fn transport(&self) -> Result<cdk18::Transport> {
+        Ok(cdk18::Transport {
+            _type: cdk18::TransportType::Nostr,
+            target: self.profile.to_bech32()?,
+            tags: Some(vec![vec![String::from("n"), String::from("17")]]),
+        })
+    }
+
+    pub async fn signer(&self) -> Result<Arc<dyn NostrSigner>> {
+        let signer = self.client.signer().await?;
+        Ok(signer)
+    }
+
+    pub fn events_channel(&self) -> broadcast::Receiver<RelayPoolNotification> {
+        self.client.notifications()
+    }
+
+    pub async fn shutdown(&self) {
+        self.client.shutdown().await;
+    }
+
+    pub async fn handle_event(
+        &self,
+        received_evt: RelayPoolNotification,
+        payment_id: Uuid,
+        expected: Amount,
+    ) -> Result<Option<(cdk18::PaymentRequestPayload, HashMap<String, String>)>> {
+        let signer = self.signer().await?;
+        let RelayPoolNotification::Event { event, .. } = received_evt else {
+            return Ok(None);
+        };
+        if event.kind != nostr_sdk::Kind::GiftWrap {
+            tracing::debug!("handle event, but no GiftWrap - {}", event.kind);
+            return Ok(None);
+        }
+
+        let UnwrappedGift { rumor, .. } = match UnwrappedGift::from_gift_wrap(&signer, &event).await
+        {
+            Ok(gift) => gift,
+            Err(e) => {
+                tracing::error!("Unwrapping gift wrap failed: {e}");
+                return Ok(None);
+            }
+        };
+
+        let payload = if rumor.kind == nostr_sdk::Kind::PrivateDirectMessage {
+            match serde_json::from_str::<cdk18::PaymentRequestPayload>(&rumor.content) {
+                Ok(payload) => payload,
+                Err(e) => {
+                    tracing::error!("Parsing Payment Request failed: {e}");
+                    return Ok(None);
+                }
+            }
+        } else {
+            tracing::debug!(
+                "handle event, but rumor no PrivateDirectMessage - {}",
+                rumor.kind
+            );
+            return Ok(None);
+        };
+
+        if payload.id != Some(payment_id.to_string()) {
+            tracing::debug!("handle event, payment id doesn't match");
+            return Ok(None);
+        }
+
+        let amount = payload.proofs.total_amount()?;
+        if amount < expected {
+            tracing::warn!(
+                "Received amount {} is less than expected {}",
+                amount,
+                expected
+            );
+            return Ok(None);
+        }
+        let meta = HashMap::from([
+            (String::from("sender"), event.pubkey.to_string()),
+            (String::from("payment_id"), payment_id.to_string()),
+            (String::from("nostr_event_id"), event.id.to_string()),
+            (
+                String::from(PAYMENT_TYPE_METADATA_KEY),
+                PaymentType::Cdk18.to_string(),
+            ),
+            (
+                String::from(TRANSACTION_STATUS_METADATA_KEY),
+                TransactionStatus::Settled.to_string(),
+            ),
+        ]);
+
+        Ok(Some((payload, meta)))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NostrConfig {
+    pub nprofile: Nip19Profile,
+    pub nostr_signer: Keys,
+    pub relays: Vec<RelayUrl>,
+}
+
+impl NostrConfig {
+    pub fn new(mnemonic: bip39::Mnemonic, nostr_relays: Vec<RelayUrl>) -> Result<Self> {
+        let keys = Keys::from_mnemonic(mnemonic.to_string(), None)?;
+
+        Ok(Self {
+            nprofile: Nip19Profile::new(keys.public_key, nostr_relays.clone()),
+            nostr_signer: keys,
+            relays: nostr_relays,
+        })
+    }
+}


### PR DESCRIPTION
First step of introducing a proper Nostr setup

* Create a `bcr-wallet-transport` crate that will contain all nostr-specific logic
* Creata a `NostrClient` abstraction and move existing logic there

Next steps:

* persistence for nostr events inbox/outbox
* proper metadata publishing and handling like in E-Bill

All in preparation of implementing pay-to-nostr-contact