### PR TITLE
Nostr Event Storage & Nostr Consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.9.4
 
 * Fix commitment for intermint exchange
+* Improve Nostr Setup
 
 # 0.9.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,16 +412,16 @@ dependencies = [
 name = "bcr-wallet-transport"
 version = "0.9.4"
 dependencies = [
+ "async-trait",
  "bcr-common",
  "bcr-wallet-core",
- "bip39",
+ "bcr-wallet-persistence",
  "nostr",
  "nostr-sdk",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "uuid",
 ]
 
 [[package]]

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -14,9 +14,12 @@ use bcr_wallet_core::types::{
     self, ListTransactionsResult, MintSummary, PaymentResultCallback, PaymentSummary, Seed,
     TransactionCursor, TransactionFilters, TransactionSort, WalletConfig,
 };
-use bcr_wallet_core::util::{build_wallet_id, keypair_from_mnemonic, seed_from_mnemonic};
+use bcr_wallet_core::util::{
+    build_wallet_id, keypair_from_mnemonic, keypair_from_seed, seed_from_mnemonic,
+};
 use bcr_wallet_persistence::redb::{Database, build_pursedb, build_wallet_dbs, create_db};
-use bcr_wallet_transport::NostrClient;
+use bcr_wallet_transport::NostrEventChannel;
+use bcr_wallet_transport::nostr;
 use error::{Error, Result};
 use std::{
     collections::{HashMap, HashSet},
@@ -77,9 +80,11 @@ impl AppState {
                 return Err(Error::MnemonicNotFound(wid.to_owned()));
             };
             let seed = seed_from_mnemonic(mnemonic);
+            let keypair = keypair_from_seed(seed);
 
             let client = HttpClientExt::new(w_cfg.mint.clone());
-            let nostr_cl = NostrClient::new(mnemonic, &w_cfg.nostr_relays).await?;
+            let nostr_cl =
+                Arc::new(nostr::Client::new(&keypair, w_cfg.nostr_relays.clone()).await?);
 
             // Attempt to fetch clowder id/betas/keyset infos and fall back to saved ones
             match client.get_clowder_id().await {
@@ -835,7 +840,7 @@ async fn create_new_wallet(
         }
     };
 
-    let nostr_cl = NostrClient::new(&cfg.mnemonic, &cfg.nostr_relays).await?;
+    let nostr_cl = Arc::new(nostr::Client::new(&keypair, cfg.nostr_relays.clone()).await?);
 
     let w_cfg = WalletConfig {
         wallet_id,
@@ -859,11 +864,19 @@ async fn build_wallet(
     swap_expiry: chrono::TimeDelta,
     db: Arc<Database>,
     seed: Seed,
-    nostr_cl: NostrClient,
+    nostr_cl: Arc<nostr::Client>,
 ) -> Result<wallet::Wallet> {
     // building wallet dbs
-    let (tx_repo, (debitdb, mintmeltdb)) =
+    let (tx_repo, (debitdb, mintmeltdb), nostrdb) =
         build_wallet_dbs(db_version, &w_cfg.wallet_id, &w_cfg.debit, db).await?;
+
+    let nostr_repo = Arc::new(nostrdb);
+    let nostr_event_channel = NostrEventChannel::new();
+    let nostr_consumer = nostr::Consumer::new(
+        nostr_cl.clone(),
+        nostr_repo.clone(),
+        nostr_event_channel.clone(),
+    );
 
     // building the debit pocket
     let mut beta_clients = HashMap::<url::Url, Arc<dyn ClowderMintConnector>>::new();
@@ -889,6 +902,25 @@ async fn build_wallet(
         let cl = external::mint::SentinelClient::new(client);
         Arc::new(cl) as Arc<dyn ClowderMintConnector>
     };
+
+    let wallet_id = w_cfg.wallet_id.clone();
+    let nostr_handle = tokio::spawn(async move {
+        match nostr_consumer.start().await {
+            Ok(mut handle) => {
+                tracing::info!("Nostr transport connected for {}", wallet_id);
+                while let Some(result) = handle.join_next().await {
+                    match result {
+                        Ok(()) => tracing::info!("Nostr consumer task shutdown with success"),
+                        Err(e) => tracing::warn!("Nostr consumer task shutdown with error: {e}"),
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Could not start Nostr consumer: {e}");
+            }
+        };
+    });
+
     let new_wallet: wallet::Wallet = wallet::Wallet::new(
         w_cfg.network,
         client,
@@ -904,7 +936,10 @@ async fn build_wallet(
         swap_expiry,
         w_cfg.nostr_relays,
         nostr_cl,
-    )
-    .await?;
+        nostr_handle,
+        nostr_event_channel,
+        nostr_repo,
+    );
+
     Ok(new_wallet)
 }

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -23,10 +23,12 @@ use bcr_wallet_core::{
     types::{BTC_TX_ID_TYPE_METADATA_KEY, PaymentResultCallback, PaymentType, TransactionStatus},
     util::{from_mint_url, to_mint_url},
 };
+use bcr_wallet_transport::NostrWalletEvent;
 use bitcoin::secp256k1;
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use std::{collections::HashMap, str::FromStr, sync::Arc};
+use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -213,7 +215,7 @@ impl WalletApi for super::Wallet {
         unit: CurrencyUnit,
         description: Option<String>,
     ) -> Result<cdk18::PaymentRequest> {
-        let nostr_transport = self.nostr_cl.transport().await?;
+        let nostr_transport = self.nostr_cl.cdk18_transport().await?;
         let mints = self
             .mint_urls()
             .into_iter()
@@ -248,12 +250,13 @@ impl WalletApi for super::Wallet {
         if req.payment_id != Some(p_id.to_string()) {
             return Err(Error::NoPrepareRef(p_id));
         }
+        let expected = req.amount.unwrap_or_default();
 
         let start = tokio::time::Instant::now();
 
         tracing::debug!("Subscribing to events from Nostr...");
-        let mut events = self.nostr_cl.events_channel();
         let deadline = start + max_wait;
+        let mut nostr_receiver = self.nostr_event_channel.subscribe();
 
         loop {
             tokio::select! {
@@ -267,45 +270,71 @@ impl WalletApi for super::Wallet {
                     result_callback(None);
                     return Ok(());
                 },
-                evt = events.recv() => {
-                    let Ok(received_evt) = evt else {
-                        tracing::warn!("check_received_payment channel closed: {p_id}");
-                        result_callback(None);
-                        return Ok(());
-                    };
-                    match self.nostr_cl.handle_event(received_evt, p_id, req.amount.unwrap_or_default()).await {
-                        Ok(None) => {
-                            // do nothing
+                evt = nostr_receiver.recv() => {
+                    let received_evt = match evt {
+                        Ok(e) => e,
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                            tracing::warn!("check_received_payment channel lagged behind: {p_id}");
                             continue;
-                        }
-                        Ok(Some((payload, meta))) => {
-                            let response = <Self as api::WalletApi>::receive_proofs(
-                                self,
-                                payload.proofs,
-                                payload.unit,
-                                from_mint_url(&payload.mint),
-                                chrono::Utc::now().timestamp() as u64,
-                                payload.memo,
-                                meta,
-                            )
-                                .await;
+                        },
+                        Err(broadcast::error::RecvError::Closed) => {
+                            tracing::warn!("check_received_payment channel closed: {p_id}");
+                            result_callback(None);
+                            return Ok(());
+                        },
+                    };
 
-                            match response {
-                                Ok(txid) => {
-                                    result_callback(Some(txid));
-                                    return Ok(());
-                                },
-                                Err(e) => {
-                                    tracing::error!("Error while handling Nostr event: {e}");
-                                    continue;
-                                },
-                            };
-                        }
+                    let NostrWalletEvent::Cdk18Payment { event_id, payload, sender } = received_evt;
+
+                    if payload.id != Some(p_id.to_string()) {
+                        tracing::debug!("handle event, payment id doesn't match");
+                        continue;
+                    }
+
+                    let amount = payload.proofs.total_amount()?;
+                    if amount < expected {
+                        tracing::warn!(
+                            "Received amount {} is less than expected {}",
+                            amount,
+                            expected
+                        );
+                        continue;
+                    }
+                    let meta = HashMap::from([
+                        (String::from("sender"), sender.to_string()),
+                        (String::from("payment_id"), p_id.to_string()),
+                        (String::from("nostr_event_id"), event_id.to_string()),
+                        (
+                            String::from(PAYMENT_TYPE_METADATA_KEY),
+                            PaymentType::Cdk18.to_string(),
+                        ),
+                        (
+                            String::from(TRANSACTION_STATUS_METADATA_KEY),
+                            TransactionStatus::Settled.to_string(),
+                        ),
+                    ]);
+
+                    let response = <Self as api::WalletApi>::receive_proofs(
+                        self,
+                        payload.proofs,
+                        payload.unit,
+                        from_mint_url(&payload.mint),
+                        chrono::Utc::now().timestamp() as u64,
+                        payload.memo,
+                        meta,
+                    )
+                        .await;
+
+                    match response {
+                        Ok(txid) => {
+                            result_callback(Some(txid));
+                            return Ok(());
+                        },
                         Err(e) => {
                             tracing::error!("Error while handling Nostr event: {e}");
                             continue;
-                        }
-                    }
+                        },
+                    };
                 }
             }
         }
@@ -1040,6 +1069,8 @@ impl WalletApi for super::Wallet {
     }
 
     async fn delete(&self) -> Result<()> {
+        // shut down nostr consumer
+        self.nostr_handle.abort();
         // shut down nostr client
         self.nostr_cl.shutdown().await;
         // delete debit pocket
@@ -1053,6 +1084,11 @@ impl WalletApi for super::Wallet {
                 "Error deleting transaction DB for wallet {}: {e}",
                 self.id()
             )
+        }
+
+        // delete nostr tables
+        if let Err(e) = self.nostr_repo.delete_repo().await {
+            tracing::error!("Error deleting nostr DB for wallet {}: {e}", self.id())
         }
 
         Ok(())

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -25,15 +25,15 @@ use bcr_wallet_core::{
     },
     util::{from_mint_url, to_mint_url},
 };
-use bcr_wallet_persistence::TransactionRepository;
-use bcr_wallet_transport::NostrClient;
+use bcr_wallet_persistence::{NostrEventOffsetStoreApi, TransactionRepository};
+use bcr_wallet_transport::{NostrEventChannel, TransportClientApi};
 use bitcoin::{
     hashes::{Hash, sha256::Hash as Sha256},
     secp256k1,
 };
 use nostr::types::RelayUrl;
 use std::{collections::HashMap, str::FromStr, sync::Arc};
-use tokio::sync::Mutex;
+use tokio::{sync::Mutex, task::JoinHandle};
 
 pub struct Wallet {
     network: bitcoin::Network,
@@ -51,11 +51,14 @@ pub struct Wallet {
     client_factory: Box<dyn Fn(url::Url) -> Arc<dyn ClowderMintConnector> + Send + Sync>,
     swap_expiry: chrono::TimeDelta,
     nostr_relays: Vec<RelayUrl>,
-    nostr_cl: NostrClient,
+    nostr_cl: Arc<dyn TransportClientApi>,
+    nostr_handle: JoinHandle<()>,
+    nostr_event_channel: NostrEventChannel,
+    nostr_repo: Arc<dyn NostrEventOffsetStoreApi>,
 }
 
 impl Wallet {
-    pub async fn new(
+    pub fn new(
         network: bitcoin::Network,
         client: Arc<dyn ClowderMintConnector>,
         mint_keyset_infos: HashMap<cashu::Id, KeySetInfo>,
@@ -69,9 +72,12 @@ impl Wallet {
         client_factory: Box<dyn Fn(url::Url) -> Arc<dyn ClowderMintConnector> + Send + Sync>,
         swap_expiry: chrono::TimeDelta,
         nostr_relays: Vec<RelayUrl>,
-        nostr_cl: NostrClient,
-    ) -> Result<Self> {
-        Ok(Self {
+        nostr_cl: Arc<dyn TransportClientApi>,
+        nostr_handle: JoinHandle<()>,
+        nostr_event_channel: NostrEventChannel,
+        nostr_repo: Arc<dyn NostrEventOffsetStoreApi>,
+    ) -> Self {
+        Self {
             network,
             client,
             mint_keyset_infos,
@@ -88,7 +94,10 @@ impl Wallet {
             swap_expiry,
             nostr_relays,
             nostr_cl,
-        })
+            nostr_handle,
+            nostr_event_channel,
+            nostr_repo,
+        }
     }
 
     pub fn name(&self) -> String {
@@ -743,7 +752,7 @@ impl Wallet {
     async fn pay_nut18(
         &self,
         proofs: Vec<cashu::Proof>,
-        nostr_cl: &NostrClient,
+        nostr_cl: &Arc<dyn TransportClientApi>,
         http_cl: &reqwest::Client,
         transport: cashu::Transport,
         p_id: Option<String>,
@@ -806,9 +815,10 @@ mod tests {
         MintSummary, PaymentResultCallback, TimeRange, get_payment_type, get_transaction_status,
     };
     use bcr_wallet_persistence::{
-        MockTransactionRepository,
+        MockNostrEventOffsetStoreApi, MockTransactionRepository,
         test_utils::tests::{test_pub_key, valid_payment_address_testnet},
     };
+    use bcr_wallet_transport::{NostrEventChannel, nostr::Client};
     use secp256k1::SECP256K1;
     use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
@@ -825,6 +835,7 @@ mod tests {
         pub client: MockClowderMintConnector,
         pub tx_repo: MockTransactionRepository,
         pub debit: MockDebitPocket,
+        pub nostr_repo: MockNostrEventOffsetStoreApi,
     }
 
     fn wallet_ctx() -> MockWalletCtx {
@@ -833,6 +844,7 @@ mod tests {
             client,
             tx_repo: MockTransactionRepository::new(),
             debit: MockDebitPocket::new(),
+            nostr_repo: MockNostrEventOffsetStoreApi::new(),
         }
     }
 
@@ -857,6 +869,9 @@ mod tests {
         let mut beta_clients: HashMap<url::Url, Arc<dyn ClowderMintConnector>> = HashMap::new();
         beta_clients.insert(beta_url, Arc::new(beta_mock));
 
+        let nostr_event_channel = NostrEventChannel::new();
+        let keypair = secp256k1::Keypair::new_global(&mut secp256k1::rand::thread_rng());
+
         let relay = get_mock_relay().await;
         Wallet {
             network: bitcoin::Network::Testnet,
@@ -874,12 +889,14 @@ mod tests {
             client_factory: Box::new(|url| Arc::new(HttpClientExt::new(url))),
             swap_expiry: chrono::TimeDelta::seconds(60),
             nostr_relays: vec![],
-            nostr_cl: NostrClient::new(
-                &bip39::Mnemonic::generate(12).unwrap(),
-                &[RelayUrl::from_str(&relay.url()).unwrap()],
-            )
-            .await
-            .unwrap(),
+            nostr_cl: Arc::new(
+                Client::new(&keypair, vec![RelayUrl::from_str(&relay.url()).unwrap()])
+                    .await
+                    .unwrap(),
+            ),
+            nostr_handle: tokio::spawn(async move {}),
+            nostr_event_channel,
+            nostr_repo: Arc::new(ctx.nostr_repo),
         }
     }
 

--- a/crates/bcr-wallet-cli/bob.toml
+++ b/crates/bcr-wallet-cli/bob.toml
@@ -12,3 +12,4 @@ network = "testnet"
 nostr_relays = ["wss://relay.wildcat0.clowder-dev.minibill.tech", "wss://relay.wildcat1.clowder-dev.minibill.tech"]
 mint_url = "https://mint.wildcat0.clowder-dev.minibill.tech"
 mnemonic = "mechanic save web pigeon cricket unable abuse winner gallery slide blush polar"
+

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -130,6 +130,7 @@ async fn main() -> Result<()> {
             md.target().starts_with("bcr_wallet_cli")
                 || md.target().starts_with("bcr_wallet_core")
                 || md.target().starts_with("bcr_wallet_persistence")
+                || md.target().starts_with("bcr_wallet_transport")
                 || md.target().starts_with("bcr_wallet_api")
         }));
     let subscriber = tracing_subscriber::registry().with(stdout_log);

--- a/crates/bcr-wallet-core/src/util.rs
+++ b/crates/bcr-wallet-core/src/util.rs
@@ -29,6 +29,7 @@ pub fn seed_from_mnemonic(mnemonic: &bip39::Mnemonic) -> Seed {
 
 pub fn keypair_from_seed(seed: Seed) -> Keypair {
     let (key, _) = seed.split_at(secp256k1::constants::SECRET_KEY_SIZE);
+
     Keypair::from_seckey_slice(SECP256K1, key).expect("key to be correct size")
 }
 

--- a/crates/bcr-wallet-persistence/src/lib.rs
+++ b/crates/bcr-wallet-persistence/src/lib.rs
@@ -10,6 +10,7 @@ use bcr_common::cashu::{self, nut00 as cdk00, nut01 as cdk01, nut07 as cdk07};
 use bcr_common::cdk_common::wallet::{Transaction, TransactionId};
 use bcr_wallet_core::{SendSync, types::WalletConfig};
 use bitcoin::secp256k1;
+use nostr::types::Timestamp;
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -148,5 +149,22 @@ pub trait MintMeltRepository: SendSync {
     async fn load_melt_commitment(&self, quote_id: Uuid) -> Result<MeltCommitmentRecord>;
     async fn delete_melt_commitment(&self, quote_id: Uuid) -> Result<()>;
     async fn list_melt_commitments(&self) -> Result<Vec<MeltCommitmentRecord>>;
+    async fn delete_repo(&self) -> Result<()>;
+}
+
+//////////////////////////////////////////// Nostr
+#[derive(Debug, Clone)]
+pub struct NostrEventOffset {
+    pub event_id: String,
+    pub time: Timestamp,
+    pub success: bool,
+}
+
+#[cfg_attr(any(test, feature = "test-utils"), mockall::automock)]
+#[async_trait]
+pub trait NostrEventOffsetStoreApi: SendSync {
+    async fn current_offset(&self) -> Result<Timestamp>;
+    async fn is_processed(&self, event_id: &str) -> Result<bool>;
+    async fn add_event(&self, data: NostrEventOffset) -> Result<()>;
     async fn delete_repo(&self) -> Result<()>;
 }

--- a/crates/bcr-wallet-persistence/src/redb/mod.rs
+++ b/crates/bcr-wallet-persistence/src/redb/mod.rs
@@ -1,4 +1,5 @@
 pub mod mintmelt;
+pub mod nostr;
 pub mod pocket;
 pub mod purse;
 pub mod transaction;
@@ -26,9 +27,11 @@ pub async fn build_wallet_dbs(
 ) -> Result<(
     transaction::TransactionDB,
     (pocket::PocketDB, mintmelt::MintMeltDB),
+    nostr::NostrDB,
 )> {
     let txdb = transaction::TransactionDB::new(db.clone(), wallet_id)?;
     let debitdb = pocket::PocketDB::new(db.clone(), wallet_id, debit)?;
     let mintmeltdb = mintmelt::MintMeltDB::new(db.clone(), wallet_id, debit)?;
-    Ok((txdb, (debitdb, mintmeltdb)))
+    let nostrdb = nostr::NostrDB::new(db.clone(), wallet_id)?;
+    Ok((txdb, (debitdb, mintmeltdb), nostrdb))
 }

--- a/crates/bcr-wallet-persistence/src/redb/nostr.rs
+++ b/crates/bcr-wallet-persistence/src/redb/nostr.rs
@@ -1,0 +1,348 @@
+use crate::{NostrEventOffset, NostrEventOffsetStoreApi, error::Result};
+use async_trait::async_trait;
+use nostr::types::Timestamp;
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, TableError};
+use std::sync::Arc;
+use tokio::task::spawn_blocking;
+
+///////////////////////////////////////////// NostrEventOffsetEntry
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct NostrEventOffsetEntry {
+    pub event_id: String,
+    pub time: Timestamp,
+    pub success: bool,
+}
+
+impl From<NostrEventOffsetEntry> for NostrEventOffset {
+    fn from(value: NostrEventOffsetEntry) -> Self {
+        Self {
+            event_id: value.event_id,
+            time: value.time,
+            success: value.success,
+        }
+    }
+}
+
+impl From<NostrEventOffset> for NostrEventOffsetEntry {
+    fn from(value: NostrEventOffset) -> Self {
+        Self {
+            event_id: value.event_id,
+            time: value.time,
+            success: value.success,
+        }
+    }
+}
+
+///////////////////////////////////////////// NostrDB
+pub struct NostrDB {
+    db: Arc<Database>,
+    last_offset_table: TableDefinition<'static, &'static [u8], u64>,
+    offset_entry_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+}
+
+impl NostrDB {
+    const OFFSET_ENTRY_DB_NAME: &'static str = "offset_entry";
+    const LAST_OFFSET_DB_NAME: &'static str = "last_offset";
+    const CURRENT_OFFSET_UNIQUE_ID: &'static str = "current_offset";
+
+    pub fn new(db: Arc<Database>, wallet_id: &str) -> Result<Self> {
+        // Leak once to get static string, because of dynamically generated table names
+        let offset_entry_name: &'static str =
+            Box::leak(format!("{wallet_id}_{}", Self::OFFSET_ENTRY_DB_NAME).into_boxed_str());
+        // Leak once to get static string, because of dynamically generated table names
+        let last_offset_name: &'static str =
+            Box::leak(format!("{wallet_id}_{}", Self::LAST_OFFSET_DB_NAME).into_boxed_str());
+
+        let offset_entry_table = TableDefinition::new(offset_entry_name);
+        let last_offset_table = TableDefinition::new(last_offset_name);
+
+        Ok(Self {
+            db,
+            offset_entry_table,
+            last_offset_table,
+        })
+    }
+
+    fn current_offset_sync(
+        db: Arc<Database>,
+        last_offset_table: TableDefinition<'static, &'static [u8], u64>,
+    ) -> Result<Timestamp> {
+        let read_txn = db.begin_read()?;
+
+        match read_txn.open_table(last_offset_table) {
+            Ok(table) => {
+                let entry = table.get(Self::CURRENT_OFFSET_UNIQUE_ID.as_bytes())?;
+                match entry {
+                    Some(t) => Ok(Timestamp::from(t.value())),
+                    None => Ok(Timestamp::zero()),
+                }
+            }
+            Err(TableError::TableDoesNotExist(_)) => Ok(Timestamp::zero()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn is_processed_sync(
+        db: Arc<Database>,
+        offset_entry_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        event_id: String,
+    ) -> Result<bool> {
+        let read_txn = db.begin_read()?;
+
+        match read_txn.open_table(offset_entry_table) {
+            Ok(table) => {
+                let entry = table.get(event_id.as_bytes())?;
+                match entry {
+                    Some(e) => {
+                        let _entry: NostrEventOffsetEntry =
+                            ciborium::from_reader(e.value().as_slice())?;
+                        Ok(true)
+                    }
+                    None => Ok(false),
+                }
+            }
+            Err(TableError::TableDoesNotExist(_)) => Ok(false),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn add_event_sync(
+        db: Arc<Database>,
+        offset_entry_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        last_offset_table: TableDefinition<'static, &'static [u8], u64>,
+        entry: NostrEventOffsetEntry,
+    ) -> Result<()> {
+        let id = entry.event_id.clone();
+        let write_txn = db.begin_write()?;
+
+        {
+            let mut table = write_txn.open_table(offset_entry_table)?;
+
+            let mut serialized = Vec::new();
+            ciborium::into_writer(&entry, &mut serialized)?;
+            table.insert(id.as_bytes(), serialized)?;
+        }
+
+        {
+            let mut table = write_txn.open_table(last_offset_table)?;
+            let offset = table
+                .get(Self::CURRENT_OFFSET_UNIQUE_ID.as_bytes())?
+                .map(|v| v.value())
+                .unwrap_or_default();
+            let next = offset.max(entry.time.as_u64());
+            table.insert(Self::CURRENT_OFFSET_UNIQUE_ID.as_bytes(), next)?;
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    fn delete_repo(
+        db: Arc<Database>,
+        offset_entry_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        last_offset_table: TableDefinition<'static, &'static [u8], u64>,
+    ) -> Result<()> {
+        let write_txn = db.begin_write()?;
+
+        {
+            if write_txn.open_table(offset_entry_table).is_ok() {
+                write_txn.delete_table(offset_entry_table)?;
+            }
+
+            if write_txn.open_table(last_offset_table).is_ok() {
+                write_txn.delete_table(last_offset_table)?;
+            }
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl NostrEventOffsetStoreApi for NostrDB {
+    async fn current_offset(&self) -> Result<Timestamp> {
+        let db_clone = self.db.clone();
+        let table = self.last_offset_table;
+        let res = spawn_blocking(move || Self::current_offset_sync(db_clone, table)).await??;
+        Ok(res)
+    }
+
+    async fn is_processed(&self, event_id: &str) -> Result<bool> {
+        let db_clone = self.db.clone();
+        let table = self.offset_entry_table;
+        let event_id_clone = event_id.to_owned();
+        let res = spawn_blocking(move || Self::is_processed_sync(db_clone, table, event_id_clone))
+            .await??;
+        Ok(res)
+    }
+
+    async fn add_event(&self, data: NostrEventOffset) -> Result<()> {
+        let db_clone = self.db.clone();
+        let last_offset_table = self.last_offset_table;
+        let entry_table = self.offset_entry_table;
+        let res = spawn_blocking(move || {
+            Self::add_event_sync(db_clone, entry_table, last_offset_table, data.into())
+        })
+        .await??;
+        Ok(res)
+    }
+
+    async fn delete_repo(&self) -> Result<()> {
+        let db_clone = self.db.clone();
+        let last_offset_table = self.last_offset_table;
+        let offset_entry_table = self.offset_entry_table;
+        spawn_blocking(move || Self::delete_repo(db_clone, offset_entry_table, last_offset_table))
+            .await?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use redb::{Builder, backends::InMemoryBackend};
+
+    fn get_db(wallet_id: &str) -> NostrDB {
+        let in_mem = InMemoryBackend::new();
+        let db = Arc::new(
+            Builder::new()
+                .create_with_backend(in_mem)
+                .expect("can create in-memory redb"),
+        );
+
+        NostrDB::new(db, wallet_id).expect("can create NostrDB")
+    }
+
+    fn offset(event_id: &str, time: u64, success: bool) -> NostrEventOffset {
+        NostrEventOffset {
+            event_id: event_id.to_string(),
+            time: Timestamp::from(time),
+            success,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_current_offset_empty() {
+        let repo = get_db("wallet-empty-offset");
+        let current = repo.current_offset().await.expect("current_offset works");
+        assert_eq!(current, Timestamp::zero());
+    }
+
+    #[tokio::test]
+    async fn test_is_processed_missing_returns_false() {
+        let repo = get_db("wallet-missing-event");
+        let processed = repo
+            .is_processed("missing-event-id")
+            .await
+            .expect("is_processed works");
+        assert!(!processed);
+    }
+
+    #[tokio::test]
+    async fn test_add_event_marks_event_as_processed() {
+        let repo = get_db("wallet-processed");
+        repo.add_event(offset("event-1", 100, true))
+            .await
+            .expect("add_event works");
+        let processed = repo
+            .is_processed("event-1")
+            .await
+            .expect("is_processed works");
+
+        assert!(processed);
+    }
+
+    #[tokio::test]
+    async fn test_add_event_does_not_mark_other_events_as_processed() {
+        let repo = get_db("wallet-other-events");
+        repo.add_event(offset("event-1", 100, true))
+            .await
+            .expect("add_event works");
+        let processed = repo
+            .is_processed("event-2")
+            .await
+            .expect("is_processed works");
+        assert!(!processed);
+    }
+
+    #[tokio::test]
+    async fn test_add_event_updates_current_offset() {
+        let repo = get_db("wallet-updates-offset");
+        repo.add_event(offset("event-1", 100, true))
+            .await
+            .expect("add_event works");
+        let current = repo.current_offset().await.expect("current_offset works");
+        assert_eq!(current, Timestamp::from(100));
+    }
+
+    #[tokio::test]
+    async fn test_current_offset_keeps_highest_timestamp() {
+        let repo = get_db("wallet-max-offset");
+        repo.add_event(offset("event-1", 100, true))
+            .await
+            .expect("add_event event-1 works");
+        repo.add_event(offset("event-2", 50, true))
+            .await
+            .expect("add_event event-2 works");
+        repo.add_event(offset("event-3", 150, true))
+            .await
+            .expect("add_event event-3 works");
+        let current = repo.current_offset().await.expect("current_offset works");
+        assert_eq!(current, Timestamp::from(150));
+    }
+
+    #[tokio::test]
+    async fn test_failed_event_is_still_processed_and_updates_offset() {
+        let repo = get_db("wallet-failed-event");
+        repo.add_event(offset("event-1", 100, true))
+            .await
+            .expect("add_event event-1 works");
+        repo.add_event(offset("event-2", 200, false))
+            .await
+            .expect("add_event event-2 works");
+        let processed = repo
+            .is_processed("event-2")
+            .await
+            .expect("is_processed works");
+        let current = repo.current_offset().await.expect("current_offset works");
+        assert!(processed);
+        assert_eq!(current, Timestamp::from(200));
+    }
+
+    #[tokio::test]
+    async fn test_wallets_are_isolated() {
+        let in_mem = InMemoryBackend::new();
+        let db = Arc::new(
+            Builder::new()
+                .create_with_backend(in_mem)
+                .expect("can create in-memory redb"),
+        );
+
+        let repo_a = NostrDB::new(db.clone(), "wallet-a").expect("can create repo a");
+        let repo_b = NostrDB::new(db.clone(), "wallet-b").expect("can create repo b");
+        repo_a
+            .add_event(offset("event-1", 100, true))
+            .await
+            .expect("add_event repo a works");
+        assert!(
+            repo_a
+                .is_processed("event-1")
+                .await
+                .expect("is_processed repo a works")
+        );
+        assert!(
+            !repo_b
+                .is_processed("event-1")
+                .await
+                .expect("is_processed repo b works")
+        );
+        assert_eq!(
+            repo_a.current_offset().await.expect("repo a offset works"),
+            Timestamp::from(100)
+        );
+        assert_eq!(
+            repo_b.current_offset().await.expect("repo b offset works"),
+            Timestamp::zero()
+        );
+    }
+}

--- a/crates/bcr-wallet-transport/Cargo.toml
+++ b/crates/bcr-wallet-transport/Cargo.toml
@@ -5,14 +5,14 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+async-trait.workspace = true
 bcr-common = {workspace = true}
 bcr-wallet-core = {workspace = true}
-bip39.workspace = true
+bcr-wallet-persistence = {workspace = true, features = ["db-redb"]}
 nostr = {workspace = true}
 nostr-sdk = {workspace = true, features = ["nip06", "nip59"]}
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = {workspace = true}
 tracing.workspace = true
-uuid = {workspace = true }
 

--- a/crates/bcr-wallet-transport/src/error.rs
+++ b/crates/bcr-wallet-transport/src/error.rs
@@ -15,4 +15,8 @@ pub enum Error {
     SerdeJson(#[from] serde_json::Error),
     #[error("cashu::nut00: {0}")]
     Cdk00(#[from] cashu::nut00::Error),
+    #[error("Network error: {0}")]
+    Network(String),
+    #[error("Crypto error: {0}")]
+    Crypto(String),
 }

--- a/crates/bcr-wallet-transport/src/lib.rs
+++ b/crates/bcr-wallet-transport/src/lib.rs
@@ -1,174 +1,79 @@
-use std::{collections::HashMap, sync::Arc};
-
-use bcr_common::cashu::{Amount, ProofsMethods, nut18 as cdk18};
-use bcr_wallet_core::types::{
-    PAYMENT_TYPE_METADATA_KEY, PaymentType, TRANSACTION_STATUS_METADATA_KEY, TransactionStatus,
-};
-use error::Result;
-use nostr::{
-    event::EventId,
-    nips::{
-        nip19::{FromBech32, Nip19Profile, ToBech32},
-        nip59::UnwrappedGift,
-    },
+use crate::error::Result;
+use ::nostr::{
+    PublicKey,
+    event::{Event, EventId},
+    filter::Filter,
     signer::NostrSigner,
     types::RelayUrl,
 };
-use nostr_sdk::{Client, Keys, RelayPoolNotification, nips::nip06::FromMnemonic};
+use async_trait::async_trait;
+use bcr_common::cashu::nut18 as cdk18;
+use bcr_wallet_core::SendSync;
+use std::sync::Arc;
 use tokio::sync::broadcast;
-use uuid::Uuid;
 
 pub mod error;
+pub mod nostr;
 
-#[derive(Clone)]
-pub struct NostrClient {
-    client: Client,
-    profile: Nip19Profile,
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SortOrder {
+    Asc,
+    Desc,
 }
 
-impl NostrClient {
-    pub async fn new(mnemonic: &bip39::Mnemonic, nostr_relays: &[RelayUrl]) -> Result<Self> {
-        let nostr_cfg = NostrConfig::new(mnemonic.to_owned(), nostr_relays.to_owned())?;
-        let nostr_filter = nostr_sdk::Filter::new()
-            .kind(nostr_sdk::Kind::GiftWrap)
-            .pubkey(nostr_cfg.nostr_signer.public_key());
-        let nostr_cl = nostr_sdk::Client::new(nostr_cfg.nostr_signer);
-        for nostr_relay in &nostr_cfg.relays {
-            nostr_cl.add_relay(nostr_relay).await?;
-        }
-        nostr_cl.connect().await;
-
-        // create long-running subscription
-        nostr_cl.subscribe(nostr_filter, None).await?;
-
-        Ok(Self {
-            client: nostr_cl,
-            profile: nostr_cfg.nprofile,
-        })
-    }
-
-    pub async fn send_private_msg(&self, target: String, payload: String) -> Result<EventId> {
-        let receiver = Nip19Profile::from_bech32(&target)?;
-        let output = self
-            .client
-            .send_private_msg_to(
-                receiver.relays,
-                receiver.public_key,
-                payload,
-                std::iter::empty(),
-            )
-            .await?;
-        Ok(output.id().to_owned())
-    }
-
-    pub async fn transport(&self) -> Result<cdk18::Transport> {
-        Ok(cdk18::Transport {
-            _type: cdk18::TransportType::Nostr,
-            target: self.profile.to_bech32()?,
-            tags: vec![vec![String::from("n"), String::from("17")]],
-        })
-    }
-
-    pub async fn signer(&self) -> Result<Arc<dyn NostrSigner>> {
-        let signer = self.client.signer().await?;
-        Ok(signer)
-    }
-
-    pub fn events_channel(&self) -> broadcast::Receiver<RelayPoolNotification> {
-        self.client.notifications()
-    }
-
-    pub async fn shutdown(&self) {
-        self.client.shutdown().await;
-    }
-
-    pub async fn handle_event(
+#[async_trait]
+pub trait TransportClientApi: SendSync {
+    async fn connect(&self) -> Result<()>;
+    async fn fetch_events(
         &self,
-        received_evt: RelayPoolNotification,
-        payment_id: Uuid,
-        expected: Amount,
-    ) -> Result<Option<(cdk18::PaymentRequestPayload, HashMap<String, String>)>> {
-        let signer = self.signer().await?;
-        let RelayPoolNotification::Event { event, .. } = received_evt else {
-            return Ok(None);
-        };
-        if event.kind != nostr_sdk::Kind::GiftWrap {
-            tracing::debug!("handle event, but no GiftWrap - {}", event.kind);
-            return Ok(None);
-        }
+        filter: Filter,
+        order: Option<SortOrder>,
+        relays: Option<Vec<RelayUrl>>,
+    ) -> Result<Vec<Event>>;
+    async fn fetch_relay_list(
+        &self,
+        npub: PublicKey,
+        relays: Vec<RelayUrl>,
+    ) -> Result<Vec<RelayUrl>>;
+    async fn publish_relay_list(&self, relays: Vec<RelayUrl>) -> Result<()>;
+    async fn send_private_msg(&self, target: String, payload: String) -> Result<EventId>;
+    async fn subscribe(&self, subscription: Filter) -> Result<()>;
+    async fn signer(&self) -> Result<Arc<dyn NostrSigner>>;
+    async fn cdk18_transport(&self) -> Result<cdk18::Transport>;
+    async fn shutdown(&self);
+}
 
-        let UnwrappedGift { rumor, .. } = match UnwrappedGift::from_gift_wrap(&signer, &event).await
-        {
-            Ok(gift) => gift,
-            Err(e) => {
-                tracing::error!("Unwrapping gift wrap failed: {e}");
-                return Ok(None);
-            }
-        };
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NostrWalletEvent {
+    Cdk18Payment {
+        event_id: EventId,
+        payload: cdk18::PaymentRequestPayload,
+        sender: PublicKey,
+    },
+}
 
-        let payload = if rumor.kind == nostr_sdk::Kind::PrivateDirectMessage {
-            match serde_json::from_str::<cdk18::PaymentRequestPayload>(&rumor.content) {
-                Ok(payload) => payload,
-                Err(e) => {
-                    tracing::error!("Parsing Payment Request failed: {e}");
-                    return Ok(None);
-                }
-            }
-        } else {
-            tracing::debug!(
-                "handle event, but rumor no PrivateDirectMessage - {}",
-                rumor.kind
-            );
-            return Ok(None);
-        };
+#[derive(Clone, Debug)]
+pub struct NostrEventChannel {
+    sender: broadcast::Sender<NostrWalletEvent>,
+}
 
-        if payload.id != Some(payment_id.to_string()) {
-            tracing::debug!("handle event, payment id doesn't match");
-            return Ok(None);
-        }
+impl NostrEventChannel {
+    pub fn new() -> Self {
+        let (sender, _) = broadcast::channel(256);
+        Self { sender }
+    }
 
-        let amount = payload.proofs.total_amount()?;
-        if amount < expected {
-            tracing::warn!(
-                "Received amount {} is less than expected {}",
-                amount,
-                expected
-            );
-            return Ok(None);
-        }
-        let meta = HashMap::from([
-            (String::from("sender"), event.pubkey.to_string()),
-            (String::from("payment_id"), payment_id.to_string()),
-            (String::from("nostr_event_id"), event.id.to_string()),
-            (
-                String::from(PAYMENT_TYPE_METADATA_KEY),
-                PaymentType::Cdk18.to_string(),
-            ),
-            (
-                String::from(TRANSACTION_STATUS_METADATA_KEY),
-                TransactionStatus::Settled.to_string(),
-            ),
-        ]);
+    pub fn subscribe(&self) -> broadcast::Receiver<NostrWalletEvent> {
+        self.sender.subscribe()
+    }
 
-        Ok(Some((payload, meta)))
+    pub fn publish(&self, event: NostrWalletEvent) {
+        let _ = self.sender.send(event);
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct NostrConfig {
-    pub nprofile: Nip19Profile,
-    pub nostr_signer: Keys,
-    pub relays: Vec<RelayUrl>,
-}
-
-impl NostrConfig {
-    pub fn new(mnemonic: bip39::Mnemonic, nostr_relays: Vec<RelayUrl>) -> Result<Self> {
-        let keys = Keys::from_mnemonic(mnemonic.to_string(), None)?;
-
-        Ok(Self {
-            nprofile: Nip19Profile::new(keys.public_key, nostr_relays.clone()),
-            nostr_signer: keys,
-            relays: nostr_relays,
-        })
+impl Default for NostrEventChannel {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/bcr-wallet-transport/src/nostr.rs
+++ b/crates/bcr-wallet-transport/src/nostr.rs
@@ -1,0 +1,383 @@
+use crate::{
+    NostrEventChannel, NostrWalletEvent, SortOrder, TransportClientApi,
+    error::{Error, Result},
+};
+use async_trait::async_trait;
+use bcr_common::cashu::nut18 as cdk18;
+use bcr_wallet_persistence::{NostrEventOffset, NostrEventOffsetStoreApi};
+use nostr::{
+    PublicKey,
+    event::{Event, EventBuilder, EventId, Kind, TagKind, TagStandard},
+    filter::{Alphabet, Filter, SingleLetterTag},
+    nips::{
+        nip19::{FromBech32, Nip19Profile, ToBech32},
+        nip59::UnwrappedGift,
+        nip65::RelayMetadata,
+    },
+    secp256k1::Keypair,
+    signer::NostrSigner,
+    types::{RelayUrl, Timestamp},
+};
+use nostr_sdk::{Client as NostrClient, ClientOptions, Keys, RelayPoolNotification, pool::Output};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+use tokio::task::JoinSet;
+
+#[derive(Clone)]
+pub struct Client {
+    client: NostrClient,
+    relays: Vec<RelayUrl>,
+    signer: Keys,
+    connected: Arc<AtomicBool>,
+    default_timeout: Duration,
+}
+
+impl Client {
+    pub async fn new(keypair: &Keypair, relays: Vec<RelayUrl>) -> Result<Self> {
+        let signer = Keys::new(keypair.secret_key().into());
+
+        let default_timeout = Duration::from_secs(20);
+        let options = ClientOptions::new();
+        let client = NostrClient::builder()
+            .signer(signer.clone())
+            .opts(options)
+            .build();
+
+        for nostr_relay in relays.iter() {
+            client.add_relay(nostr_relay).await?;
+        }
+
+        Ok(Self {
+            client,
+            relays,
+            signer,
+            connected: Arc::new(AtomicBool::new(false)),
+            default_timeout,
+        })
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected.load(Ordering::SeqCst)
+    }
+
+    async fn client(&self) -> Result<&NostrClient> {
+        if !self.is_connected() {
+            self.connect().await?;
+        }
+        Ok(&self.client)
+    }
+}
+
+#[async_trait]
+impl TransportClientApi for Client {
+    async fn subscribe(&self, subscription: Filter) -> Result<()> {
+        self.client()
+            .await?
+            .subscribe(subscription, None)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to subscribe to Nostr events: {e}");
+                Error::Network("Failed to subscribe to Nostr events".to_string())
+            })?;
+        Ok(())
+    }
+
+    async fn send_private_msg(&self, target: String, payload: String) -> Result<EventId> {
+        let receiver = Nip19Profile::from_bech32(&target)?;
+
+        let output = self
+            .client
+            .send_private_msg_to(
+                receiver.relays,
+                receiver.public_key,
+                payload,
+                std::iter::empty(),
+            )
+            .await?;
+        Ok(output.id().to_owned())
+    }
+
+    async fn cdk18_transport(&self) -> Result<cdk18::Transport> {
+        Ok(cdk18::Transport {
+            _type: cdk18::TransportType::Nostr,
+            target: Nip19Profile::new(self.signer.public_key, self.relays.clone()).to_bech32()?,
+            tags: vec![vec![String::from("n"), String::from("17")]],
+        })
+    }
+
+    async fn signer(&self) -> Result<Arc<dyn NostrSigner>> {
+        let signer = self.client.signer().await?;
+        Ok(signer)
+    }
+
+    async fn shutdown(&self) {
+        self.client.shutdown().await;
+    }
+
+    async fn connect(&self) -> Result<()> {
+        if self
+            .connected
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            self.client.connect().await;
+
+            if let Err(e) = self.publish_relay_list(self.relays.clone()).await {
+                tracing::error!(
+                    "Failed to publish relay list for {}: {}",
+                    self.signer.public_key,
+                    e
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn fetch_events(
+        &self,
+        filter: Filter,
+        order: Option<SortOrder>,
+        relays: Option<Vec<RelayUrl>>,
+    ) -> Result<Vec<Event>> {
+        let events = self
+            .client()
+            .await?
+            .fetch_events_from(
+                relays.unwrap_or(self.relays.clone()),
+                filter,
+                self.default_timeout.to_owned(),
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to fetch Nostr events: {e}");
+                Error::Network("Failed to fetch Nostr events".to_string())
+            })?;
+        let mut events = events.into_iter().collect::<Vec<Event>>();
+        if Some(SortOrder::Asc) == order {
+            events.reverse();
+        }
+        Ok(events)
+    }
+
+    async fn fetch_relay_list(
+        &self,
+        npub: PublicKey,
+        relays: Vec<RelayUrl>,
+    ) -> Result<Vec<RelayUrl>> {
+        let filter = Filter::new().author(npub).kind(Kind::RelayList).limit(1);
+        let events = self.fetch_events(filter, None, Some(relays)).await?;
+        Ok(events
+            .first()
+            .map(|e| {
+                e.tags
+                    .filter_standardized(TagKind::SingleLetter(SingleLetterTag::lowercase(
+                        Alphabet::R,
+                    )))
+                    .filter_map(|f| match f {
+                        TagStandard::RelayMetadata { relay_url, .. } => Some(relay_url.clone()),
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
+    async fn publish_relay_list(&self, relays: Vec<RelayUrl>) -> Result<()> {
+        let signer = self.signer.clone();
+        let relay_list: Vec<(RelayUrl, Option<RelayMetadata>)> =
+            relays.into_iter().map(|r| (r, None)).collect();
+
+        let event = EventBuilder::relay_list(relay_list)
+            .build(signer.public_key())
+            .sign(&signer)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to sign relay list event: {e}");
+                Error::Crypto("Failed to sign relay list event".to_string())
+            })?;
+
+        let output = self.client().await?.send_event(&event).await.map_err(|e| {
+            tracing::error!("Failed to send relay list with Nostr client: {e}");
+            Error::Network("Failed to send relay list with Nostr client".to_string())
+        })?;
+        check_send_output(output, "publish_relay_list")
+    }
+}
+
+#[derive(Clone)]
+pub struct Consumer {
+    client: Arc<Client>,
+    offset_store: Arc<dyn NostrEventOffsetStoreApi>,
+    event_channel: NostrEventChannel,
+}
+
+impl Consumer {
+    pub fn new(
+        client: Arc<Client>,
+        offset_store: Arc<dyn NostrEventOffsetStoreApi>,
+        event_channel: NostrEventChannel,
+    ) -> Self {
+        Self {
+            client,
+            offset_store,
+            event_channel,
+        }
+    }
+
+    pub async fn start(&self) -> Result<JoinSet<()>> {
+        let client = self.client.clone();
+        let mut tasks = JoinSet::new();
+
+        if !client.is_connected()
+            && let Err(e) = client.connect().await
+        {
+            tracing::error!("Failed to connect Nostr client: {e}");
+        }
+
+        let mut earliest_offset = Timestamp::now();
+        let offset = get_offset(&self.offset_store).await;
+        if offset != Timestamp::zero() && offset < earliest_offset {
+            earliest_offset = offset;
+        }
+
+        let nostr_filter = nostr_sdk::Filter::new()
+            .kind(nostr_sdk::Kind::GiftWrap)
+            .pubkey(client.signer.public_key());
+
+        client.subscribe(nostr_filter).await.map_err(|e| {
+            tracing::error!("Failed to subscribe to Nostr public events: {e}");
+            Error::Network("Failed to subscribe to Nostr public events".to_string())
+        })?;
+
+        let offset_store_clone = self.offset_store.clone();
+        let signer = self.client.signer().await?;
+        let event_channel = self.event_channel.clone();
+        tasks.spawn(async move {
+            client
+                .client
+                .handle_notifications(move |note| {
+                    let offset_store = offset_store_clone.clone();
+                    let signer = signer.clone();
+                    let event_channel = event_channel.clone();
+                    async move {
+                        if let RelayPoolNotification::Event { event, .. } = note
+                            && should_process(event.clone(), &offset_store, earliest_offset).await
+                        {
+                            let (success, time) =
+                                process_event(event.clone(), signer.clone(), event_channel.clone())
+                                    .await?;
+                            add_offset(&offset_store, event.id, time, success).await;
+                        }
+                        Ok(false) // keep looping
+                    }
+                })
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::error!("Nostr notification handler failed: {e}");
+                });
+        });
+
+        Ok(tasks)
+    }
+}
+
+async fn add_offset(
+    db: &Arc<dyn NostrEventOffsetStoreApi>,
+    event_id: EventId,
+    time: Timestamp,
+    success: bool,
+) {
+    db.add_event(NostrEventOffset {
+        event_id: event_id.to_hex(),
+        time,
+        success,
+    })
+    .await
+    .map_err(|e| tracing::error!("Could not store event offset: {e}"))
+    .ok();
+}
+
+async fn get_offset(db: &Arc<dyn NostrEventOffsetStoreApi>) -> Timestamp {
+    db.current_offset().await.unwrap_or_else(|e| {
+        tracing::error!("Could not get event offset: {e}");
+        Timestamp::zero()
+    })
+}
+
+fn check_send_output(output: Output<EventId>, context: &str) -> Result<()> {
+    for (relay, error) in &output.failed {
+        tracing::warn!("{context}: relay {relay} failed: {error}");
+    }
+    if output.success.is_empty() {
+        tracing::error!("{context}: all relays failed to accept the event");
+        return Err(Error::Network(format!(
+            "{context}: all relays failed to accept the event"
+        )));
+    }
+    Ok(())
+}
+
+async fn process_event(
+    event: Box<Event>,
+    signer: Arc<dyn NostrSigner>,
+    event_channel: NostrEventChannel,
+) -> Result<(bool, Timestamp)> {
+    tracing::debug!("Processing Nostr event with id: {}", event.id);
+    let UnwrappedGift { rumor, .. } = match UnwrappedGift::from_gift_wrap(&signer, &event).await {
+        Ok(gift) => gift,
+        Err(e) => {
+            tracing::error!("Unwrapping gift wrap failed: {e}");
+            return Ok((false, Timestamp::zero()));
+        }
+    };
+
+    let payload = if rumor.kind == nostr_sdk::Kind::PrivateDirectMessage {
+        match serde_json::from_str::<cdk18::PaymentRequestPayload>(&rumor.content) {
+            Ok(payload) => payload,
+            Err(e) => {
+                tracing::error!("Parsing Payment Request failed: {e}");
+                return Ok((false, Timestamp::zero()));
+            }
+        }
+    } else {
+        tracing::debug!(
+            "handle event, but rumor no PrivateDirectMessage - {}",
+            rumor.kind
+        );
+        return Ok((false, Timestamp::zero()));
+    };
+
+    event_channel.publish(NostrWalletEvent::Cdk18Payment {
+        event_id: event.id,
+        payload,
+        sender: event.pubkey,
+    });
+
+    Ok((true, event.created_at))
+}
+
+async fn should_process(
+    event: Box<Event>,
+    offset_store: &Arc<dyn NostrEventOffsetStoreApi>,
+    since: Timestamp,
+) -> bool {
+    valid_time(event.kind, event.created_at, since)
+        && !offset_store
+            .is_processed(&event.id.to_hex())
+            .await
+            .unwrap_or(false)
+}
+
+fn valid_time(kind: Kind, created: Timestamp, since: Timestamp) -> bool {
+    if !matches!(kind, Kind::EncryptedDirectMessage | Kind::GiftWrap) {
+        created >= since
+    } else {
+        true
+    }
+}


### PR DESCRIPTION
* Add proper `NostrClient` and `NostrConsumer` abstractions with useful utilities (heavily ~copied~ inspired by E-Bill)
* Move event handling to `NostrConsumer`
  * Communication between the app and the nostr consumer happens via a channel
* Add a mechanism to avoid handling events multiple times (event offset)
* Fix nostr private key derivation differing from E-Bill


Next steps:

* Expose `connected` state to frontend
* Retry Queue
* Proper Relay list synchronization as to not conflict with E-Bill there
* Contacts etc.