### PR TITLE
Nostr Retry Queue and other improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
+# 0.9.5
+
+* Improve Nostr Setup
+    * Add a deduplication table
+    * Decouple Wallet code from Nostr code
+    * Fix nostr key derivation to match wallet's & E-Bill's
+    * Add a retry-mechanism
+    * Expose nostr connection status to frontend
+    * Synchronize with published relay-list
+    * Add a background-receiver for incoming nostr payments 
+
 # 0.9.4
 
 * Fix commitment for intermint exchange
-* Improve Nostr Setup
 
 # 0.9.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-api"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bcr-common",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-cli"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "bcr-common",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-core"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "bcr-common",
  "bip39",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-persistence"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bcr-common",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-transport"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bcr-common",
@@ -422,6 +422,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3874,7 +3875,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wallet_ffi"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "android_logger",
  "bcr-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 license = "MIT"
 

--- a/crates/bcr-wallet-api/Cargo.toml
+++ b/crates/bcr-wallet-api/Cargo.toml
@@ -26,7 +26,7 @@ tokio = {workspace = true}
 tokio-util = {workspace = true}
 tracing.workspace = true
 url = {workspace = true}
-uuid = {workspace = true }
+uuid = {workspace = true}
 
 [dev-dependencies]
 bcr-common = {workspace = true, features = ["test-utils"]}

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -157,6 +157,12 @@ impl AppState {
     }
 
     //////////////////////////////////////////////////// Purse-Level API methods
+    pub async fn purse_wallets_nostr_connected(&self) -> HashMap<String, bool> {
+        tracing::debug!("purse_wallets_nostr_connected");
+        let purse = self.get_purse();
+        purse.wallets_nostr_connected().await
+    }
+
     pub async fn purse_wallets_ids(&self) -> Result<Vec<String>> {
         tracing::debug!("get_wallet_ids");
         let purse = self.get_purse();
@@ -603,6 +609,15 @@ impl AppState {
         Ok(cleaned_up)
     }
 
+    // Retry Nostr Messages
+    pub async fn wallet_retry_nostr_messages(&self, id: String) -> Result<usize> {
+        tracing::debug!("wallet_retry_nostr_messages({id})");
+        let wallet = self.get_wallet(&id).await?;
+        let wlt = wallet.read().await;
+        let retried = wlt.retry_nostr_messages().await?;
+        Ok(retried)
+    }
+
     // Refreshes the state of all pending transactions of the given wallet
     pub async fn wallet_refresh_txs(&self, id: String) -> Result<usize> {
         tracing::debug!("wallet_refresh_txs({id})");
@@ -743,6 +758,17 @@ impl AppState {
                     );
                 }
             }
+            match self.wallet_retry_nostr_messages(wallet_id.to_owned()).await {
+                Ok(retried) => {
+                    tracing::info!("Retried {retried} nostr messages for wallet {wallet_id}");
+                }
+                Err(e) => {
+                    job_failed = true;
+                    tracing::error!(
+                        "Error running wallet_refresh_txs job for wallet {wallet_id}: {e}"
+                    );
+                }
+            };
         }
 
         // successful = true
@@ -867,7 +893,7 @@ async fn build_wallet(
     nostr_cl: Arc<nostr::Client>,
 ) -> Result<wallet::Wallet> {
     // building wallet dbs
-    let (tx_repo, (debitdb, mintmeltdb), nostrdb) =
+    let (tx_repo, debitdb, mintmeltdb, nostrdb) =
         build_wallet_dbs(db_version, &w_cfg.wallet_id, &w_cfg.debit, db).await?;
 
     let nostr_repo = Arc::new(nostrdb);
@@ -877,6 +903,7 @@ async fn build_wallet(
         nostr_repo.clone(),
         nostr_event_channel.clone(),
     );
+    let nostr_transport = nostr::Transport::new(nostr_cl, nostr_repo.clone());
 
     // building the debit pocket
     let mut beta_clients = HashMap::<url::Url, Arc<dyn ClowderMintConnector>>::new();
@@ -903,24 +930,6 @@ async fn build_wallet(
         Arc::new(cl) as Arc<dyn ClowderMintConnector>
     };
 
-    let wallet_id = w_cfg.wallet_id.clone();
-    let nostr_handle = tokio::spawn(async move {
-        match nostr_consumer.start().await {
-            Ok(mut handle) => {
-                tracing::info!("Nostr transport connected for {}", wallet_id);
-                while let Some(result) = handle.join_next().await {
-                    match result {
-                        Ok(()) => tracing::info!("Nostr consumer task shutdown with success"),
-                        Err(e) => tracing::warn!("Nostr consumer task shutdown with error: {e}"),
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::warn!("Could not start Nostr consumer: {e}");
-            }
-        };
-    });
-
     let new_wallet: wallet::Wallet = wallet::Wallet::new(
         w_cfg.network,
         client,
@@ -934,12 +943,12 @@ async fn build_wallet(
         beta_clients,
         Box::new(|url| Arc::new(external::mint::HttpClientExt::new(url))),
         swap_expiry,
-        w_cfg.nostr_relays,
-        nostr_cl,
-        nostr_handle,
+        Arc::new(nostr_transport),
         nostr_event_channel,
         nostr_repo,
-    );
+        nostr_consumer,
+    )
+    .await;
 
     Ok(new_wallet)
 }

--- a/crates/bcr-wallet-api/src/purse/mod.rs
+++ b/crates/bcr-wallet-api/src/purse/mod.rs
@@ -110,6 +110,21 @@ where
 
         Ok(res)
     }
+
+    pub async fn wallets_nostr_connected(&self) -> HashMap<String, bool> {
+        let mut res = HashMap::new();
+        let wallets: HashMap<_, _> = {
+            let wlts = self.wallets.read().await;
+            wlts.clone()
+        };
+        for (wallet_id, wlt) in wallets.iter() {
+            res.insert(
+                wallet_id.to_owned(),
+                wlt.read().await.is_nostr_connected().await,
+            );
+        }
+        res
+    }
 }
 
 #[cfg(test)]

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -110,6 +110,7 @@ pub trait WalletApi: SendSync {
         memo: Option<String>,
         now: u64,
     ) -> Result<(TransactionId, Option<Token>)>;
+    async fn is_nostr_connected(&self) -> bool;
     async fn delete(&self) -> Result<()>;
 }
 
@@ -126,7 +127,7 @@ impl WalletApi for super::Wallet {
             clowder_id: self.clowder_id,
             pub_key: self.pub_key,
             betas: self.betas(),
-            nostr_relays: self.nostr_relays.clone(),
+            nostr_relays: self.nostr_transport.relays().to_owned(),
         })
     }
 
@@ -135,7 +136,7 @@ impl WalletApi for super::Wallet {
             name: self.name.clone(),
             network: self.network,
             default_mint_url: self.client.mint_url().to_owned(),
-            nostr_relays: self.nostr_relays.clone(),
+            nostr_relays: self.nostr_transport.relays().to_owned(),
         }
     }
 
@@ -215,7 +216,7 @@ impl WalletApi for super::Wallet {
         unit: CurrencyUnit,
         description: Option<String>,
     ) -> Result<cdk18::PaymentRequest> {
-        let nostr_transport = self.nostr_cl.cdk18_transport().await?;
+        let nostr_transport = self.nostr_transport.cdk18_transport().await?;
         let mints = self
             .mint_urls()
             .into_iter()
@@ -407,7 +408,14 @@ impl WalletApi for super::Wallet {
                     saga_id: None,
                 };
                 let tx_id = self
-                    .pay_nut18(proofs, &self.nostr_cl, http_cl, transport, id, partial_tx)
+                    .pay_nut18(
+                        proofs,
+                        &self.nostr_transport,
+                        http_cl,
+                        transport,
+                        id,
+                        partial_tx,
+                    )
                     .await?;
                 Ok((tx_id, None))
             }
@@ -1068,11 +1076,18 @@ impl WalletApi for super::Wallet {
         }
     }
 
+    async fn is_nostr_connected(&self) -> bool {
+        self.nostr_transport.has_connected_relays().await
+            && *self.nostr_consumer_running.lock().await
+    }
+
     async fn delete(&self) -> Result<()> {
-        // shut down nostr consumer
-        self.nostr_handle.abort();
         // shut down nostr client
-        self.nostr_cl.shutdown().await;
+        self.nostr_transport.shutdown().await;
+        // shut down nostr handle
+        if let Some(ref handle) = self.nostr_handle {
+            handle.abort();
+        }
         // delete debit pocket
         if let Err(e) = self.debit.delete().await {
             tracing::error!("Error deleting pocket for wallet {}: {e}", self.id())

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -1084,10 +1084,8 @@ impl WalletApi for super::Wallet {
     async fn delete(&self) -> Result<()> {
         // shut down nostr client
         self.nostr_transport.shutdown().await;
-        // shut down nostr handle
-        if let Some(ref handle) = self.nostr_handle {
-            handle.abort();
-        }
+        // shut down nostr consumer
+        self.nostr_shutdown.cancel();
         // delete debit pocket
         if let Err(e) = self.debit.delete().await {
             tracing::error!("Error deleting pocket for wallet {}: {e}", self.id())

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -32,10 +32,8 @@ use bitcoin::{
     secp256k1,
 };
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
-use tokio::{
-    sync::{Mutex, broadcast},
-    task::JoinHandle,
-};
+use tokio::sync::{Mutex, broadcast};
+use tokio_util::sync::CancellationToken;
 
 pub struct Wallet {
     network: bitcoin::Network,
@@ -56,7 +54,7 @@ pub struct Wallet {
     nostr_event_channel: NostrEventChannel,
     nostr_repo: Arc<dyn NostrRepository>,
     nostr_consumer_running: Arc<Mutex<bool>>,
-    nostr_handle: Option<JoinHandle<()>>,
+    nostr_shutdown: CancellationToken,
 }
 
 impl Wallet {
@@ -78,7 +76,8 @@ impl Wallet {
         nostr_repo: Arc<dyn NostrRepository>,
         nostr_consumer: nostr::Consumer,
     ) -> Self {
-        let mut wallet = Self {
+        let cancel = CancellationToken::new();
+        let wallet = Self {
             network,
             client,
             mint_keyset_infos,
@@ -97,44 +96,86 @@ impl Wallet {
             nostr_event_channel,
             nostr_repo,
             nostr_consumer_running: Arc::new(Mutex::new(false)),
-            nostr_handle: None,
+            nostr_shutdown: cancel.clone(),
         };
-        wallet.nostr_connect(nostr_consumer).await;
+        wallet.nostr_connect(nostr_consumer, cancel).await;
         wallet.start_nostr_event_listener().await;
         wallet
     }
 
-    async fn nostr_connect(&mut self, nostr_consumer: nostr::Consumer) {
+    async fn nostr_connect(&self, nostr_consumer: nostr::Consumer, cancel: CancellationToken) {
         let wallet_id = self.id.clone();
         let nostr_consumer_running = self.nostr_consumer_running.clone();
-        let nostr_handle = tokio::spawn(async move {
+        tokio::spawn(async move {
             *nostr_consumer_running.lock().await = false;
+            // attempt to start nostr consumer
             loop {
-                match nostr_consumer.start().await {
-                    Ok(mut handle) => {
-                        *nostr_consumer_running.lock().await = true;
-                        tracing::info!("Nostr transport connected for {}", wallet_id);
+                let mut handle = tokio::select! {
+                    _ = cancel.cancelled() => {
+                        tracing::info!("Nostr consumer cancelled for {}", wallet_id);
+                        break;
+                    }
+
+                    result = nostr_consumer.start() => match result {
+                        Ok(handle) => handle,
+                        Err(e) => {
+                            tracing::warn!("Could not start Nostr consumer: {e}");
+
+                            tokio::select! {
+                                _ = cancel.cancelled() => break,
+                                _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+                            }
+
+                            continue;
+                        }
+                    },
+                };
+
+                *nostr_consumer_running.lock().await = true;
+                tracing::info!("Nostr transport connected for {}", wallet_id);
+
+                // wait for nostr consumer to fail and restart, or cancel the whole process
+                tokio::select! {
+                    _ = cancel.cancelled() => {
+                        tracing::info!("Nostr consumer cancelled for {}", wallet_id);
+                        handle.abort_all();
+                        *nostr_consumer_running.lock().await = false;
+                        break;
+                    }
+
+                    _ = async {
                         while let Some(result) = handle.join_next().await {
                             match result {
                                 Ok(()) => {
-                                    tracing::info!("Nostr consumer task shutdown with success")
+                                    tracing::info!("Nostr consumer task shutdown with success");
+                                }
+                                Err(e) if e.is_cancelled() => {
+                                    tracing::info!("Nostr consumer task was cancelled");
                                 }
                                 Err(e) => {
-                                    tracing::warn!("Nostr consumer task shutdown with error: {e}")
+                                    tracing::warn!("Nostr consumer task shutdown with error: {e}");
                                 }
                             }
                         }
-                        tracing::warn!("Nostr consumer stopped, reconnecting in 10 seconds...");
+                    } => {
+                        *nostr_consumer_running.lock().await = false;
+                        tracing::warn!("Nostr consumer stopped, reconnecting in 5 seconds...");
                     }
-                    Err(e) => {
-                        tracing::warn!("Could not start Nostr consumer: {e}");
+                }
+
+                // reconnect or cancel
+                tokio::select! {
+                    _ = cancel.cancelled() => {
+                        tracing::info!("Nostr reconnect cancelled for {}", wallet_id);
+                        break;
                     }
-                };
-                *nostr_consumer_running.lock().await = false;
-                tokio::time::sleep(Duration::from_secs(10)).await;
+
+                    _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+                }
             }
+
+            *nostr_consumer_running.lock().await = false;
         });
-        self.nostr_handle = Some(nostr_handle);
     }
 
     async fn start_nostr_event_listener(&self) {
@@ -990,7 +1031,7 @@ mod tests {
             nostr_event_channel,
             nostr_repo: Arc::new(ctx.nostr_repo),
             nostr_consumer_running: Arc::new(Mutex::new(true)),
-            nostr_handle: None,
+            nostr_shutdown: CancellationToken::new(),
         }
     }
 

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -25,15 +25,17 @@ use bcr_wallet_core::{
     },
     util::{from_mint_url, to_mint_url},
 };
-use bcr_wallet_persistence::{NostrEventOffsetStoreApi, TransactionRepository};
-use bcr_wallet_transport::{NostrEventChannel, TransportClientApi};
+use bcr_wallet_persistence::{NostrRepository, TransactionRepository};
+use bcr_wallet_transport::{NostrEventChannel, TransportApi, nostr};
 use bitcoin::{
     hashes::{Hash, sha256::Hash as Sha256},
     secp256k1,
 };
-use nostr::types::RelayUrl;
-use std::{collections::HashMap, str::FromStr, sync::Arc};
-use tokio::{sync::Mutex, task::JoinHandle};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
+use tokio::{
+    sync::{Mutex, broadcast},
+    task::JoinHandle,
+};
 
 pub struct Wallet {
     network: bitcoin::Network,
@@ -50,15 +52,15 @@ pub struct Wallet {
     clowder_id: secp256k1::PublicKey,
     client_factory: Box<dyn Fn(url::Url) -> Arc<dyn ClowderMintConnector> + Send + Sync>,
     swap_expiry: chrono::TimeDelta,
-    nostr_relays: Vec<RelayUrl>,
-    nostr_cl: Arc<dyn TransportClientApi>,
-    nostr_handle: JoinHandle<()>,
+    nostr_transport: Arc<dyn TransportApi>,
     nostr_event_channel: NostrEventChannel,
-    nostr_repo: Arc<dyn NostrEventOffsetStoreApi>,
+    nostr_repo: Arc<dyn NostrRepository>,
+    nostr_consumer_running: Arc<Mutex<bool>>,
+    nostr_handle: Option<JoinHandle<()>>,
 }
 
 impl Wallet {
-    pub fn new(
+    pub async fn new(
         network: bitcoin::Network,
         client: Arc<dyn ClowderMintConnector>,
         mint_keyset_infos: HashMap<cashu::Id, KeySetInfo>,
@@ -71,13 +73,12 @@ impl Wallet {
         beta_clients: HashMap<url::Url, Arc<dyn ClowderMintConnector>>,
         client_factory: Box<dyn Fn(url::Url) -> Arc<dyn ClowderMintConnector> + Send + Sync>,
         swap_expiry: chrono::TimeDelta,
-        nostr_relays: Vec<RelayUrl>,
-        nostr_cl: Arc<dyn TransportClientApi>,
-        nostr_handle: JoinHandle<()>,
+        nostr_transport: Arc<dyn TransportApi>,
         nostr_event_channel: NostrEventChannel,
-        nostr_repo: Arc<dyn NostrEventOffsetStoreApi>,
+        nostr_repo: Arc<dyn NostrRepository>,
+        nostr_consumer: nostr::Consumer,
     ) -> Self {
-        Self {
+        let mut wallet = Self {
             network,
             client,
             mint_keyset_infos,
@@ -92,12 +93,76 @@ impl Wallet {
             clowder_id,
             client_factory,
             swap_expiry,
-            nostr_relays,
-            nostr_cl,
-            nostr_handle,
+            nostr_transport,
             nostr_event_channel,
             nostr_repo,
-        }
+            nostr_consumer_running: Arc::new(Mutex::new(false)),
+            nostr_handle: None,
+        };
+        wallet.nostr_connect(nostr_consumer).await;
+        wallet.start_nostr_event_listener().await;
+        wallet
+    }
+
+    async fn nostr_connect(&mut self, nostr_consumer: nostr::Consumer) {
+        let wallet_id = self.id.clone();
+        let nostr_consumer_running = self.nostr_consumer_running.clone();
+        let nostr_handle = tokio::spawn(async move {
+            *nostr_consumer_running.lock().await = false;
+            loop {
+                match nostr_consumer.start().await {
+                    Ok(mut handle) => {
+                        *nostr_consumer_running.lock().await = true;
+                        tracing::info!("Nostr transport connected for {}", wallet_id);
+                        while let Some(result) = handle.join_next().await {
+                            match result {
+                                Ok(()) => {
+                                    tracing::info!("Nostr consumer task shutdown with success")
+                                }
+                                Err(e) => {
+                                    tracing::warn!("Nostr consumer task shutdown with error: {e}")
+                                }
+                            }
+                        }
+                        tracing::warn!("Nostr consumer stopped, reconnecting in 10 seconds...");
+                    }
+                    Err(e) => {
+                        tracing::warn!("Could not start Nostr consumer: {e}");
+                    }
+                };
+                *nostr_consumer_running.lock().await = false;
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            }
+        });
+        self.nostr_handle = Some(nostr_handle);
+    }
+
+    async fn start_nostr_event_listener(&self) {
+        let mut nostr_receiver = self.nostr_event_channel.subscribe();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    evt = nostr_receiver.recv() => {
+                        let received_evt = match evt {
+                            Ok(e) => e,
+                            Err(broadcast::error::RecvError::Lagged(_)) => {
+                                tracing::warn!("start_nostr_event_listener channel lagged behind");
+                                continue;
+                            },
+                            Err(broadcast::error::RecvError::Closed) => {
+                                tracing::warn!("start_nostr_event_listener channel closed");
+                                return;
+                            },
+                        };
+                        match received_evt {
+                            bcr_wallet_transport::NostrWalletEvent::Cdk18Payment { .. } => {
+                                // ignore - cdk18 payments are handled by explicitly awaiting them
+                            },
+                        };
+                    }
+                }
+            }
+        });
     }
 
     pub fn name(&self) -> String {
@@ -401,6 +466,11 @@ impl Wallet {
             )
             .await?;
         Ok(recovered)
+    }
+
+    pub async fn retry_nostr_messages(&self) -> Result<usize> {
+        let retried = self.nostr_transport.retry_messages().await?;
+        Ok(retried)
     }
 
     pub async fn clean_up_spent_proofs(&self) -> Result<usize> {
@@ -752,7 +822,7 @@ impl Wallet {
     async fn pay_nut18(
         &self,
         proofs: Vec<cashu::Proof>,
-        nostr_cl: &Arc<dyn TransportClientApi>,
+        nostr_cl: &Arc<dyn TransportApi>,
         http_cl: &reqwest::Client,
         transport: cashu::Transport,
         p_id: Option<String>,
@@ -773,7 +843,24 @@ impl Wallet {
             }
             cashu::TransportType::Nostr => {
                 let payload = serde_json::to_string(&payload)?;
-                let event_id = nostr_cl.send_private_msg(transport.target, payload).await?;
+                let event_id = match nostr_cl
+                    .send_private_msg(transport.target.clone(), payload.clone())
+                    .await
+                {
+                    Ok(event_id) => event_id,
+                    Err(e) => {
+                        tracing::error!("Failed to send nut18 payment, queuing for retry: {e}");
+                        match e {
+                            bcr_wallet_transport::error::Error::NostrSendPrivateMsg(event_id) => {
+                                self.nostr_transport
+                                    .queue_retry_message(Some(transport.target), payload)
+                                    .await?;
+                                event_id
+                            }
+                            e => return Err(e.into()),
+                        }
+                    }
+                };
                 partial_tx
                     .metadata
                     .insert(String::from("nostr::event_id"), event_id.to_string());
@@ -810,15 +897,19 @@ impl Wallet {
 
 #[cfg(test)]
 mod tests {
+    use ::nostr::types::RelayUrl;
     use bcr_common::wire::clowder as wire_clowder;
     use bcr_wallet_core::types::{
         MintSummary, PaymentResultCallback, TimeRange, get_payment_type, get_transaction_status,
     };
     use bcr_wallet_persistence::{
-        MockNostrEventOffsetStoreApi, MockTransactionRepository,
+        MockNostrRepository, MockTransactionRepository,
         test_utils::tests::{test_pub_key, valid_payment_address_testnet},
     };
-    use bcr_wallet_transport::{NostrEventChannel, nostr::Client};
+    use bcr_wallet_transport::{
+        NostrEventChannel,
+        nostr::{Client, Transport},
+    };
     use secp256k1::SECP256K1;
     use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
@@ -835,7 +926,7 @@ mod tests {
         pub client: MockClowderMintConnector,
         pub tx_repo: MockTransactionRepository,
         pub debit: MockDebitPocket,
-        pub nostr_repo: MockNostrEventOffsetStoreApi,
+        pub nostr_repo: MockNostrRepository,
     }
 
     fn wallet_ctx() -> MockWalletCtx {
@@ -844,7 +935,7 @@ mod tests {
             client,
             tx_repo: MockTransactionRepository::new(),
             debit: MockDebitPocket::new(),
-            nostr_repo: MockNostrEventOffsetStoreApi::new(),
+            nostr_repo: MockNostrRepository::new(),
         }
     }
 
@@ -888,15 +979,18 @@ mod tests {
             clowder_id: test_pub_key(),
             client_factory: Box::new(|url| Arc::new(HttpClientExt::new(url))),
             swap_expiry: chrono::TimeDelta::seconds(60),
-            nostr_relays: vec![],
-            nostr_cl: Arc::new(
-                Client::new(&keypair, vec![RelayUrl::from_str(&relay.url()).unwrap()])
-                    .await
-                    .unwrap(),
-            ),
-            nostr_handle: tokio::spawn(async move {}),
+            nostr_transport: Arc::new(Transport::new(
+                Arc::new(
+                    Client::new(&keypair, vec![RelayUrl::from_str(&relay.url()).unwrap()])
+                        .await
+                        .unwrap(),
+                ),
+                Arc::new(MockNostrRepository::new()),
+            )),
             nostr_event_channel,
             nostr_repo: Arc::new(ctx.nostr_repo),
+            nostr_consumer_running: Arc::new(Mutex::new(true)),
+            nostr_handle: None,
         }
     }
 

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -106,6 +106,19 @@ pub async fn cmd_info(app_state: &AppState) -> Result<String> {
     Ok(res)
 }
 
+pub async fn cmd_status(app_state: &AppState) -> Result<String> {
+    let mut res = String::new();
+    // wait until nostr is connected
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    let nostr_connected = app_state.purse_wallets_nostr_connected().await;
+    push_break(&mut res);
+    for (wid, connected) in nostr_connected {
+        res.push_str(&format!("Wallet {} connected: {}", wid, connected));
+        push_break(&mut res);
+    }
+    Ok(res)
+}
+
 pub async fn cmd_add_wallet(
     app_state: &AppState,
     name: &str,

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -44,6 +44,8 @@ struct Cli {
 enum Commands {
     #[command(name = "info")]
     Info,
+    #[command(name = "status")]
+    Status,
     #[command(name = "add_wallet")]
     AddWallet { id: String },
     #[command(name = "delete_wallet")]
@@ -157,6 +159,13 @@ async fn main() -> Result<()> {
                 "Info for {}: {}",
                 cli.wallet,
                 command::cmd_info(&app_state).await?
+            );
+        }
+        Commands::Status => {
+            info!(
+                "Status for {}: {}",
+                cli.wallet,
+                command::cmd_status(&app_state).await?
             );
         }
         Commands::Receive { id, token } => {

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -173,17 +173,16 @@ fn start_jobs(
         loop {
             tokio::select! {
                 _ = ticker.tick() => {
+                let app_state = get_app_state().await;
 
-            let app_state = get_app_state().await;
-
-            info!("Running jobs");
-            if let Err(e) = app_state.run_jobs().await {
-                error!("Error running jobs: {e}");
-            } else {
-                info!("Jobs ran successfully");
-            }
-                },
-                _ = cancel.cancelled() => break,
+                info!("Running jobs");
+                if let Err(e) = app_state.run_jobs().await {
+                    error!("Error running jobs: {e}");
+                } else {
+                    info!("Jobs ran successfully");
+                }
+            },
+            _ = cancel.cancelled() => break,
             }
         }
     })

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -747,8 +747,12 @@ pub async fn is_valid_token(req: IsValidTokenRequest) -> Result<IsValidTokenResp
 
 #[frb]
 pub async fn wallet_get_status() -> Result<StatusResponse, WalletError> {
+    // nostr connection status for each wallet
+    let app_state = get_app_state().await;
+    let nostr_connected_map = app_state.purse_wallets_nostr_connected().await;
     Ok(StatusResponse {
         app_version: VERSION.to_owned(),
+        nostr_connected: nostr_connected_map,
     })
 }
 
@@ -1419,6 +1423,7 @@ pub struct MnemonicResponse {
 #[derive(Debug, Clone)]
 pub struct StatusResponse {
     pub app_version: String,
+    pub nostr_connected: HashMap<String, bool>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -1971,6 +1971,14 @@ impl SseDecode for std::collections::HashMap<String, String> {
     }
 }
 
+impl SseDecode for std::collections::HashMap<String, bool> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <Vec<(String, bool)>>::sse_decode(deserializer);
+        return inner.into_iter().collect();
+    }
+}
+
 impl SseDecode
     for RustOpaqueMoi<
         flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>,
@@ -2119,6 +2127,18 @@ impl SseDecode for Vec<u8> {
         let mut ans_ = Vec::with_capacity(len_ as usize);
         for idx_ in 0..len_ {
             ans_.push(<u8>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<(String, bool)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<(String, bool)>::sse_decode(deserializer));
         }
         return ans_;
     }
@@ -2342,6 +2362,15 @@ impl SseDecode for crate::api::ProtestStatus {
     }
 }
 
+impl SseDecode for (String, bool) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <String>::sse_decode(deserializer);
+        let mut var_field1 = <bool>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
 impl SseDecode for (String, String) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2365,8 +2394,11 @@ impl SseDecode for crate::api::StatusResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_appVersion = <String>::sse_decode(deserializer);
+        let mut var_nostrConnected =
+            <std::collections::HashMap<String, bool>>::sse_decode(deserializer);
         return crate::api::StatusResponse {
             app_version: var_appVersion,
+            nostr_connected: var_nostrConnected,
         };
     }
 }
@@ -3543,7 +3575,11 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::RestoreWalletResponse>
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::StatusResponse {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [self.app_version.into_into_dart().into_dart()].into_dart()
+        [
+            self.app_version.into_into_dart().into_dart(),
+            self.nostr_connected.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::StatusResponse {}
@@ -4735,6 +4771,13 @@ impl SseEncode for std::collections::HashMap<String, String> {
     }
 }
 
+impl SseEncode for std::collections::HashMap<String, bool> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<(String, bool)>>::sse_encode(self.into_iter().collect(), serializer);
+    }
+}
+
 impl SseEncode
     for RustOpaqueMoi<
         flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>,
@@ -4858,6 +4901,16 @@ impl SseEncode for Vec<u8> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <u8>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<(String, bool)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <(String, bool)>::sse_encode(item, serializer);
         }
     }
 }
@@ -5045,6 +5098,14 @@ impl SseEncode for crate::api::ProtestStatus {
     }
 }
 
+impl SseEncode for (String, bool) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.0, serializer);
+        <bool>::sse_encode(self.1, serializer);
+    }
+}
+
 impl SseEncode for (String, String) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5064,6 +5125,7 @@ impl SseEncode for crate::api::StatusResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.app_version, serializer);
+        <std::collections::HashMap<String, bool>>::sse_encode(self.nostr_connected, serializer);
     }
 }
 

--- a/crates/bcr-wallet-persistence/src/lib.rs
+++ b/crates/bcr-wallet-persistence/src/lib.rs
@@ -160,11 +160,23 @@ pub struct NostrEventOffset {
     pub success: bool,
 }
 
+#[derive(Clone, Debug)]
+pub struct NostrQueuedMessage {
+    pub id: String,
+    /// `Some(target)` for private messages, `None` for public broadcast messages.
+    pub recipient: Option<String>,
+    pub payload: String,
+}
+
 #[cfg_attr(any(test, feature = "test-utils"), mockall::automock)]
 #[async_trait]
-pub trait NostrEventOffsetStoreApi: SendSync {
+pub trait NostrRepository: SendSync {
     async fn current_offset(&self) -> Result<Timestamp>;
     async fn is_processed(&self, event_id: &str) -> Result<bool>;
     async fn add_event(&self, data: NostrEventOffset) -> Result<()>;
+    async fn add_retry_message(&self, message: NostrQueuedMessage, max_retries: i32) -> Result<()>;
+    async fn get_retry_messages(&self, limit: u64) -> Result<Vec<NostrQueuedMessage>>;
+    async fn fail_retry(&self, id: &str) -> Result<()>;
+    async fn succeed_retry(&self, id: &str) -> Result<()>;
     async fn delete_repo(&self) -> Result<()>;
 }

--- a/crates/bcr-wallet-persistence/src/redb/mod.rs
+++ b/crates/bcr-wallet-persistence/src/redb/mod.rs
@@ -26,12 +26,13 @@ pub async fn build_wallet_dbs(
     db: Arc<Database>,
 ) -> Result<(
     transaction::TransactionDB,
-    (pocket::PocketDB, mintmelt::MintMeltDB),
+    pocket::PocketDB,
+    mintmelt::MintMeltDB,
     nostr::NostrDB,
 )> {
     let txdb = transaction::TransactionDB::new(db.clone(), wallet_id)?;
     let debitdb = pocket::PocketDB::new(db.clone(), wallet_id, debit)?;
     let mintmeltdb = mintmelt::MintMeltDB::new(db.clone(), wallet_id, debit)?;
     let nostrdb = nostr::NostrDB::new(db.clone(), wallet_id)?;
-    Ok((txdb, (debitdb, mintmeltdb), nostrdb))
+    Ok((txdb, debitdb, mintmeltdb, nostrdb))
 }

--- a/crates/bcr-wallet-persistence/src/redb/nostr.rs
+++ b/crates/bcr-wallet-persistence/src/redb/nostr.rs
@@ -78,12 +78,14 @@ pub struct NostrDB {
     last_offset_table: TableDefinition<'static, &'static [u8], u64>,
     offset_entry_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
     queued_message_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+    dead_letter_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
 }
 
 impl NostrDB {
     const OFFSET_ENTRY_DB_NAME: &'static str = "offset_entry";
     const LAST_OFFSET_DB_NAME: &'static str = "last_offset";
     const QUEUED_MESSAGE_DB_NAME: &'static str = "queued_message";
+    const DEAD_LETTER_DB_NAME: &'static str = "dead_letter";
     const CURRENT_OFFSET_UNIQUE_ID: &'static str = "current_offset";
     const NOSTR_QUEUE_PROCESSING_TIMEOUT_SECS: i64 = 60;
 
@@ -97,16 +99,21 @@ impl NostrDB {
         // Leak once to get static string, because of dynamically generated table names
         let queued_message_name: &'static str =
             Box::leak(format!("{wallet_id}_{}", Self::QUEUED_MESSAGE_DB_NAME).into_boxed_str());
+        // Leak once to get static string, because of dynamically generated table names
+        let dead_letter_name: &'static str =
+            Box::leak(format!("{wallet_id}_{}", Self::DEAD_LETTER_DB_NAME).into_boxed_str());
 
         let offset_entry_table = TableDefinition::new(offset_entry_name);
         let last_offset_table = TableDefinition::new(last_offset_name);
         let queued_message_table = TableDefinition::new(queued_message_name);
+        let dead_letter_table = TableDefinition::new(dead_letter_name);
 
         Ok(Self {
             db,
             offset_entry_table,
             last_offset_table,
             queued_message_table,
+            dead_letter_table,
         })
     }
 
@@ -249,6 +256,7 @@ impl NostrDB {
     fn fail_retry_sync(
         db: Arc<Database>,
         queued_message_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        dead_letter_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
         id: String,
     ) -> Result<()> {
         let write_txn = db.begin_write()?;
@@ -263,7 +271,15 @@ impl NostrDB {
 
                 entry.num_retries += 1;
                 if entry.num_retries >= entry.max_retries {
+                    // remove from retry entries
                     table.remove(id.as_bytes())?;
+
+                    // add to dead letter table for book keeping
+                    let mut table = write_txn.open_table(dead_letter_table)?;
+
+                    let mut serialized = Vec::new();
+                    ciborium::into_writer(&entry, &mut serialized)?;
+                    table.insert(id.as_bytes(), serialized)?;
                 } else {
                     entry.last_try = Utc::now();
                     entry.processing_started_at = DateTime::from_timestamp(0, 0).expect("valid");
@@ -301,6 +317,7 @@ impl NostrDB {
         offset_entry_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
         last_offset_table: TableDefinition<'static, &'static [u8], u64>,
         queued_message_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        dead_letter_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
     ) -> Result<()> {
         let write_txn = db.begin_write()?;
 
@@ -315,6 +332,10 @@ impl NostrDB {
 
             if write_txn.open_table(queued_message_table).is_ok() {
                 write_txn.delete_table(queued_message_table)?;
+            }
+
+            if write_txn.open_table(dead_letter_table).is_ok() {
+                write_txn.delete_table(dead_letter_table)?;
             }
         }
 
@@ -357,12 +378,14 @@ impl NostrRepository for NostrDB {
         let last_offset_table = self.last_offset_table;
         let offset_entry_table = self.offset_entry_table;
         let queued_message_table = self.queued_message_table;
+        let dead_letter_table = self.dead_letter_table;
         spawn_blocking(move || {
             Self::delete_repo_sync(
                 db_clone,
                 offset_entry_table,
                 last_offset_table,
                 queued_message_table,
+                dead_letter_table,
             )
         })
         .await?
@@ -393,9 +416,12 @@ impl NostrRepository for NostrDB {
     async fn fail_retry(&self, id: &str) -> Result<()> {
         let db_clone = self.db.clone();
         let table = self.queued_message_table;
+        let dead_letter_table = self.dead_letter_table;
         let id_clone = id.to_owned();
-        let res =
-            spawn_blocking(move || Self::fail_retry_sync(db_clone, table, id_clone)).await??;
+        let res = spawn_blocking(move || {
+            Self::fail_retry_sync(db_clone, table, dead_letter_table, id_clone)
+        })
+        .await??;
         Ok(res)
     }
 

--- a/crates/bcr-wallet-persistence/src/redb/nostr.rs
+++ b/crates/bcr-wallet-persistence/src/redb/nostr.rs
@@ -1,5 +1,6 @@
-use crate::{NostrEventOffset, NostrEventOffsetStoreApi, error::Result};
+use crate::{NostrEventOffset, NostrQueuedMessage, NostrRepository, error::Result};
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use nostr::types::Timestamp;
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, TableError};
 use std::sync::Arc;
@@ -33,17 +34,58 @@ impl From<NostrEventOffset> for NostrEventOffsetEntry {
     }
 }
 
+///////////////////////////////////////////// NostrQueuedMessageEntry
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct NostrQueuedMessageEntry {
+    pub id: String,
+    pub recipient: Option<String>,
+    pub payload: String,
+    pub created: DateTime<Utc>,
+    pub last_try: DateTime<Utc>,
+    pub num_retries: i32,
+    pub max_retries: i32,
+    pub processing_started_at: DateTime<Utc>,
+}
+
+impl From<NostrQueuedMessageEntry> for NostrQueuedMessage {
+    fn from(value: NostrQueuedMessageEntry) -> Self {
+        Self {
+            id: value.id,
+            recipient: value.recipient,
+            payload: value.payload,
+        }
+    }
+}
+
+impl NostrQueuedMessageEntry {
+    fn from(value: NostrQueuedMessage, max_retries: i32) -> Self {
+        Self {
+            id: value.id,
+            recipient: value.recipient,
+            payload: value.payload,
+            created: Utc::now(),
+            last_try: DateTime::from_timestamp(0, 0).expect("valid"),
+            num_retries: 0,
+            max_retries,
+            processing_started_at: DateTime::from_timestamp(0, 0).expect("valid"),
+        }
+    }
+}
+
 ///////////////////////////////////////////// NostrDB
 pub struct NostrDB {
     db: Arc<Database>,
     last_offset_table: TableDefinition<'static, &'static [u8], u64>,
     offset_entry_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+    queued_message_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
 }
 
 impl NostrDB {
     const OFFSET_ENTRY_DB_NAME: &'static str = "offset_entry";
     const LAST_OFFSET_DB_NAME: &'static str = "last_offset";
+    const QUEUED_MESSAGE_DB_NAME: &'static str = "queued_message";
     const CURRENT_OFFSET_UNIQUE_ID: &'static str = "current_offset";
+    const NOSTR_QUEUE_PROCESSING_TIMEOUT_SECS: i64 = 60;
 
     pub fn new(db: Arc<Database>, wallet_id: &str) -> Result<Self> {
         // Leak once to get static string, because of dynamically generated table names
@@ -52,17 +94,23 @@ impl NostrDB {
         // Leak once to get static string, because of dynamically generated table names
         let last_offset_name: &'static str =
             Box::leak(format!("{wallet_id}_{}", Self::LAST_OFFSET_DB_NAME).into_boxed_str());
+        // Leak once to get static string, because of dynamically generated table names
+        let queued_message_name: &'static str =
+            Box::leak(format!("{wallet_id}_{}", Self::QUEUED_MESSAGE_DB_NAME).into_boxed_str());
 
         let offset_entry_table = TableDefinition::new(offset_entry_name);
         let last_offset_table = TableDefinition::new(last_offset_name);
+        let queued_message_table = TableDefinition::new(queued_message_name);
 
         Ok(Self {
             db,
             offset_entry_table,
             last_offset_table,
+            queued_message_table,
         })
     }
 
+    ///////////////////////////////////////////// Event Offset
     fn current_offset_sync(
         db: Arc<Database>,
         last_offset_table: TableDefinition<'static, &'static [u8], u64>,
@@ -137,10 +185,122 @@ impl NostrDB {
         Ok(())
     }
 
-    fn delete_repo(
+    ///////////////////////////////////////////// Event Offset
+    fn add_retry_message_sync(
+        db: Arc<Database>,
+        queued_message_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        entry: NostrQueuedMessageEntry,
+    ) -> Result<()> {
+        let id = entry.id.clone();
+        let write_txn = db.begin_write()?;
+
+        {
+            let mut table = write_txn.open_table(queued_message_table)?;
+
+            let mut serialized = Vec::new();
+            ciborium::into_writer(&entry, &mut serialized)?;
+            table.insert(id.as_bytes(), serialized)?;
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    fn get_retry_messages_sync(
+        db: Arc<Database>,
+        queued_message_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        limit: u64,
+    ) -> Result<Vec<NostrQueuedMessageEntry>> {
+        let now = Utc::now();
+        let retry_before =
+            now - chrono::Duration::seconds(Self::NOSTR_QUEUE_PROCESSING_TIMEOUT_SECS);
+
+        let write_txn = db.begin_write()?;
+
+        let res = {
+            let mut table = write_txn.open_table(queued_message_table)?;
+            let mut res = Vec::new();
+            for (_, v) in table.range::<&[u8]>(..)?.flatten() {
+                let entry: NostrQueuedMessageEntry = ciborium::from_reader(v.value().as_slice())?;
+                if entry.processing_started_at < retry_before {
+                    res.push(entry);
+                }
+            }
+
+            res.sort_by_key(|msg| msg.last_try);
+            res.truncate(limit as usize);
+
+            // set processing_started_at to avoid retrying before the backoff time
+            for to_update in res.iter_mut() {
+                to_update.processing_started_at = Utc::now();
+                let mut serialized = Vec::new();
+                ciborium::into_writer(&to_update, &mut serialized)?;
+                table.insert(to_update.id.as_bytes(), serialized)?;
+            }
+
+            res
+        };
+
+        write_txn.commit()?;
+
+        Ok(res)
+    }
+
+    fn fail_retry_sync(
+        db: Arc<Database>,
+        queued_message_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        id: String,
+    ) -> Result<()> {
+        let write_txn = db.begin_write()?;
+
+        {
+            let mut table = write_txn.open_table(queued_message_table)?;
+            let old_value = table.get(id.as_bytes())?.map(|v| v.value());
+
+            if let Some(old_value) = old_value {
+                let mut entry: NostrQueuedMessageEntry =
+                    ciborium::from_reader(old_value.as_slice())?;
+
+                entry.num_retries += 1;
+                if entry.num_retries >= entry.max_retries {
+                    table.remove(id.as_bytes())?;
+                } else {
+                    entry.last_try = Utc::now();
+                    entry.processing_started_at = DateTime::from_timestamp(0, 0).expect("valid");
+
+                    let mut serialized = Vec::new();
+                    ciborium::into_writer(&entry, &mut serialized)?;
+                    table.insert(id.as_bytes(), serialized)?;
+                }
+            }
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    fn succeed_retry_sync(
+        db: Arc<Database>,
+        queued_message_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        id: String,
+    ) -> Result<()> {
+        let write_txn = db.begin_write()?;
+
+        {
+            let mut table = write_txn.open_table(queued_message_table)?;
+            table.remove(id.as_bytes())?;
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    ///////////////////////////////////////////// Delete Repo
+    fn delete_repo_sync(
         db: Arc<Database>,
         offset_entry_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
         last_offset_table: TableDefinition<'static, &'static [u8], u64>,
+        queued_message_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
     ) -> Result<()> {
         let write_txn = db.begin_write()?;
 
@@ -152,6 +312,10 @@ impl NostrDB {
             if write_txn.open_table(last_offset_table).is_ok() {
                 write_txn.delete_table(last_offset_table)?;
             }
+
+            if write_txn.open_table(queued_message_table).is_ok() {
+                write_txn.delete_table(queued_message_table)?;
+            }
         }
 
         write_txn.commit()?;
@@ -160,7 +324,7 @@ impl NostrDB {
 }
 
 #[async_trait]
-impl NostrEventOffsetStoreApi for NostrDB {
+impl NostrRepository for NostrDB {
     async fn current_offset(&self) -> Result<Timestamp> {
         let db_clone = self.db.clone();
         let table = self.last_offset_table;
@@ -192,8 +356,56 @@ impl NostrEventOffsetStoreApi for NostrDB {
         let db_clone = self.db.clone();
         let last_offset_table = self.last_offset_table;
         let offset_entry_table = self.offset_entry_table;
-        spawn_blocking(move || Self::delete_repo(db_clone, offset_entry_table, last_offset_table))
-            .await?
+        let queued_message_table = self.queued_message_table;
+        spawn_blocking(move || {
+            Self::delete_repo_sync(
+                db_clone,
+                offset_entry_table,
+                last_offset_table,
+                queued_message_table,
+            )
+        })
+        .await?
+    }
+
+    async fn add_retry_message(&self, message: NostrQueuedMessage, max_retries: i32) -> Result<()> {
+        let db_clone = self.db.clone();
+        let table = self.queued_message_table;
+        let res = spawn_blocking(move || {
+            Self::add_retry_message_sync(
+                db_clone,
+                table,
+                NostrQueuedMessageEntry::from(message, max_retries),
+            )
+        })
+        .await??;
+        Ok(res)
+    }
+
+    async fn get_retry_messages(&self, limit: u64) -> Result<Vec<NostrQueuedMessage>> {
+        let db_clone = self.db.clone();
+        let table = self.queued_message_table;
+        let res =
+            spawn_blocking(move || Self::get_retry_messages_sync(db_clone, table, limit)).await??;
+        Ok(res.into_iter().map(|entry| entry.into()).collect())
+    }
+
+    async fn fail_retry(&self, id: &str) -> Result<()> {
+        let db_clone = self.db.clone();
+        let table = self.queued_message_table;
+        let id_clone = id.to_owned();
+        let res =
+            spawn_blocking(move || Self::fail_retry_sync(db_clone, table, id_clone)).await??;
+        Ok(res)
+    }
+
+    async fn succeed_retry(&self, id: &str) -> Result<()> {
+        let db_clone = self.db.clone();
+        let table = self.queued_message_table;
+        let id_clone = id.to_owned();
+        let res =
+            spawn_blocking(move || Self::succeed_retry_sync(db_clone, table, id_clone)).await??;
+        Ok(res)
     }
 }
 

--- a/crates/bcr-wallet-transport/Cargo.toml
+++ b/crates/bcr-wallet-transport/Cargo.toml
@@ -15,4 +15,4 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio = {workspace = true}
 tracing.workspace = true
-
+uuid = {workspace = true}

--- a/crates/bcr-wallet-transport/src/error.rs
+++ b/crates/bcr-wallet-transport/src/error.rs
@@ -11,6 +11,10 @@ pub enum Error {
     Nip06(#[from] nostr_sdk::nips::nip06::Error),
     #[error("nostr-sdk::client {0}")]
     NostrClient(#[from] nostr_sdk::client::Error),
+    #[error("nostr::event {0}")]
+    NostrEvent(#[from] ::nostr::event::builder::Error),
+    #[error("nostr::send_private_msg {0}")]
+    NostrSendPrivateMsg(nostr::event::EventId),
     #[error("serde_json: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("cashu::nut00: {0}")]
@@ -19,4 +23,6 @@ pub enum Error {
     Network(String),
     #[error("Crypto error: {0}")]
     Crypto(String),
+    #[error("Persistence error: {0}")]
+    Persistence(#[from] bcr_wallet_persistence::error::Error),
 }

--- a/crates/bcr-wallet-transport/src/lib.rs
+++ b/crates/bcr-wallet-transport/src/lib.rs
@@ -1,15 +1,8 @@
 use crate::error::Result;
-use ::nostr::{
-    PublicKey,
-    event::{Event, EventId},
-    filter::Filter,
-    signer::NostrSigner,
-    types::RelayUrl,
-};
+use ::nostr::{PublicKey, event::EventId, types::RelayUrl};
 use async_trait::async_trait;
 use bcr_common::cashu::nut18 as cdk18;
 use bcr_wallet_core::SendSync;
-use std::sync::Arc;
 use tokio::sync::broadcast;
 
 pub mod error;
@@ -22,25 +15,19 @@ pub enum SortOrder {
 }
 
 #[async_trait]
-pub trait TransportClientApi: SendSync {
-    async fn connect(&self) -> Result<()>;
-    async fn fetch_events(
-        &self,
-        filter: Filter,
-        order: Option<SortOrder>,
-        relays: Option<Vec<RelayUrl>>,
-    ) -> Result<Vec<Event>>;
-    async fn fetch_relay_list(
-        &self,
-        npub: PublicKey,
-        relays: Vec<RelayUrl>,
-    ) -> Result<Vec<RelayUrl>>;
-    async fn publish_relay_list(&self, relays: Vec<RelayUrl>) -> Result<()>;
+pub trait TransportApi: SendSync {
     async fn send_private_msg(&self, target: String, payload: String) -> Result<EventId>;
-    async fn subscribe(&self, subscription: Filter) -> Result<()>;
-    async fn signer(&self) -> Result<Arc<dyn NostrSigner>>;
     async fn cdk18_transport(&self) -> Result<cdk18::Transport>;
     async fn shutdown(&self);
+    fn relays(&self) -> &[RelayUrl];
+    async fn has_connected_relays(&self) -> bool;
+    async fn retry_messages(&self) -> Result<usize>;
+    async fn queue_retry_message(&self, recipient: Option<String>, payload: String) -> Result<()>;
+}
+
+#[async_trait]
+pub trait ClientApi: SendSync {
+    async fn connect(&self) -> Result<()>;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/bcr-wallet-transport/src/nostr.rs
+++ b/crates/bcr-wallet-transport/src/nostr.rs
@@ -1,10 +1,10 @@
 use crate::{
-    NostrEventChannel, NostrWalletEvent, SortOrder, TransportClientApi,
+    ClientApi, NostrEventChannel, NostrWalletEvent, SortOrder, TransportApi,
     error::{Error, Result},
 };
 use async_trait::async_trait;
 use bcr_common::cashu::nut18 as cdk18;
-use bcr_wallet_persistence::{NostrEventOffset, NostrEventOffsetStoreApi};
+use bcr_wallet_persistence::{NostrEventOffset, NostrQueuedMessage, NostrRepository};
 use nostr::{
     PublicKey,
     event::{Event, EventBuilder, EventId, Kind, TagKind, TagStandard},
@@ -18,8 +18,11 @@ use nostr::{
     signer::NostrSigner,
     types::{RelayUrl, Timestamp},
 };
-use nostr_sdk::{Client as NostrClient, ClientOptions, Keys, RelayPoolNotification, pool::Output};
+use nostr_sdk::{
+    Client as NostrClient, ClientOptions, Keys, RelayPoolNotification, RelayStatus, pool::Output,
+};
 use std::{
+    collections::HashSet,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -28,7 +31,7 @@ use std::{
 };
 use tokio::task::JoinSet;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Client {
     client: NostrClient,
     relays: Vec<RelayUrl>,
@@ -41,7 +44,7 @@ impl Client {
     pub async fn new(keypair: &Keypair, relays: Vec<RelayUrl>) -> Result<Self> {
         let signer = Keys::new(keypair.secret_key().into());
 
-        let default_timeout = Duration::from_secs(20);
+        let default_timeout = Duration::from_secs(1);
         let options = ClientOptions::new();
         let client = NostrClient::builder()
             .signer(signer.clone())
@@ -71,10 +74,7 @@ impl Client {
         }
         Ok(&self.client)
     }
-}
 
-#[async_trait]
-impl TransportClientApi for Client {
     async fn subscribe(&self, subscription: Filter) -> Result<()> {
         self.client()
             .await?
@@ -87,56 +87,9 @@ impl TransportClientApi for Client {
         Ok(())
     }
 
-    async fn send_private_msg(&self, target: String, payload: String) -> Result<EventId> {
-        let receiver = Nip19Profile::from_bech32(&target)?;
-
-        let output = self
-            .client
-            .send_private_msg_to(
-                receiver.relays,
-                receiver.public_key,
-                payload,
-                std::iter::empty(),
-            )
-            .await?;
-        Ok(output.id().to_owned())
-    }
-
-    async fn cdk18_transport(&self) -> Result<cdk18::Transport> {
-        Ok(cdk18::Transport {
-            _type: cdk18::TransportType::Nostr,
-            target: Nip19Profile::new(self.signer.public_key, self.relays.clone()).to_bech32()?,
-            tags: vec![vec![String::from("n"), String::from("17")]],
-        })
-    }
-
     async fn signer(&self) -> Result<Arc<dyn NostrSigner>> {
         let signer = self.client.signer().await?;
         Ok(signer)
-    }
-
-    async fn shutdown(&self) {
-        self.client.shutdown().await;
-    }
-
-    async fn connect(&self) -> Result<()> {
-        if self
-            .connected
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_ok()
-        {
-            self.client.connect().await;
-
-            if let Err(e) = self.publish_relay_list(self.relays.clone()).await {
-                tracing::error!(
-                    "Failed to publish relay list for {}: {}",
-                    self.signer.public_key,
-                    e
-                );
-            }
-        }
-
-        Ok(())
     }
 
     async fn fetch_events(
@@ -208,24 +161,201 @@ impl TransportClientApi for Client {
         })?;
         check_send_output(output, "publish_relay_list")
     }
+
+    async fn sync_relay_list(&self, relays: Vec<RelayUrl>) -> Result<()> {
+        let signer = self.signer.clone();
+        let fetched_relays = self
+            .fetch_relay_list(signer.public_key(), relays.clone())
+            .await?;
+        let mut merged: HashSet<RelayUrl> = relays.into_iter().collect();
+        merged.extend(fetched_relays);
+
+        self.publish_relay_list(merged.into_iter().collect())
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ClientApi for Client {
+    async fn connect(&self) -> Result<()> {
+        if self
+            .connected
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            self.client.connect().await;
+
+            let self_clone = self.clone();
+            tokio::spawn(async move {
+                if let Err(e) = self_clone.sync_relay_list(self_clone.relays.clone()).await {
+                    tracing::error!(
+                        "Failed to publish relay list for {}: {}",
+                        self_clone.signer.public_key,
+                        e
+                    );
+                }
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct Transport {
+    client: Arc<Client>,
+    nostr_store: Arc<dyn NostrRepository>,
+}
+
+impl Transport {
+    pub fn new(client: Arc<Client>, nostr_store: Arc<dyn NostrRepository>) -> Self {
+        Self {
+            client,
+            nostr_store,
+        }
+    }
+}
+
+#[async_trait]
+impl TransportApi for Transport {
+    async fn send_private_msg(&self, target: String, payload: String) -> Result<EventId> {
+        let receiver = Nip19Profile::from_bech32(&target)?;
+
+        let signer = self.client.client.signer().await?;
+        let event: Event =
+            EventBuilder::private_msg(&signer, receiver.public_key, payload, std::iter::empty())
+                .await?;
+        let _ = self
+            .client
+            .client
+            .send_event_to(receiver.relays, &event)
+            .await
+            .map_err(|e| {
+                tracing::error!("send_private_msg failed: {e}");
+                Error::NostrSendPrivateMsg(event.id)
+            })?;
+        Ok(event.id)
+    }
+
+    async fn cdk18_transport(&self) -> Result<cdk18::Transport> {
+        Ok(cdk18::Transport {
+            _type: cdk18::TransportType::Nostr,
+            target: Nip19Profile::new(self.client.signer.public_key, self.client.relays.clone())
+                .to_bech32()?,
+            tags: vec![vec![String::from("n"), String::from("17")]],
+        })
+    }
+
+    async fn shutdown(&self) {
+        self.client.client.shutdown().await;
+    }
+
+    fn relays(&self) -> &[RelayUrl] {
+        &self.client.relays
+    }
+
+    async fn has_connected_relays(&self) -> bool {
+        self.client
+            .client
+            .relays()
+            .await
+            .values()
+            .any(|relay| relay.status() == RelayStatus::Connected)
+    }
+
+    async fn queue_retry_message(&self, recipient: Option<String>, payload: String) -> Result<()> {
+        let receiver = match recipient {
+            Some(ref r) => Nip19Profile::from_bech32(r)?.public_key.to_string(),
+            None => "public broadcast".to_string(),
+        };
+        let queue_msg = NostrQueuedMessage {
+            id: uuid::Uuid::new_v4().to_string(),
+            recipient,
+            payload,
+        };
+        self.nostr_store.add_retry_message(queue_msg, 3).await?;
+        tracing::debug!("Queued Nostr retry message; triggering immediate retry for {receiver}");
+
+        let self_clone = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = self_clone.retry_messages().await {
+                tracing::error!("Failed to process Nostr retry queue after enqueue: {e}");
+            }
+        });
+        Ok(())
+    }
+
+    async fn retry_messages(&self) -> Result<usize> {
+        let mut failed_ids: Vec<String> = vec![];
+        let mut retried = 0;
+        while let Ok(Some(queued_message)) = self
+            .nostr_store
+            .get_retry_messages(1)
+            .await
+            .map(|r| r.first().cloned())
+        {
+            let result: Result<()> = match &queued_message.recipient {
+                Some(target) => {
+                    if let Err(e) = serde_json::from_str::<cdk18::PaymentRequestPayload>(
+                        &queued_message.payload,
+                    ) {
+                        tracing::error!("Failed to parse private retry payload: {e}");
+                        failed_ids.push(queued_message.id.clone());
+                        continue;
+                    };
+
+                    match self
+                        .send_private_msg(target.to_owned(), queued_message.payload)
+                        .await
+                    {
+                        Ok(_) => Ok(()),
+                        Err(e) => Err(e),
+                    }
+                }
+                None => Ok(()), // currently, we only send private events
+            };
+
+            match result {
+                Ok(()) => {
+                    tracing::info!("Successfully sent retry message {}", queued_message.id);
+                    if let Err(e) = self.nostr_store.succeed_retry(&queued_message.id).await {
+                        tracing::error!("Failed to mark retry message as sent: {e}");
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to send retry message: {e}");
+                    failed_ids.push(queued_message.id.clone());
+                }
+            }
+            retried += 1;
+        }
+
+        for failed in failed_ids {
+            if let Err(e) = self.nostr_store.fail_retry(&failed).await {
+                tracing::error!("Failed to store failed retry attempt: {e}");
+            }
+        }
+        Ok(retried)
+    }
 }
 
 #[derive(Clone)]
 pub struct Consumer {
     client: Arc<Client>,
-    offset_store: Arc<dyn NostrEventOffsetStoreApi>,
+    nostr_store: Arc<dyn NostrRepository>,
     event_channel: NostrEventChannel,
 }
 
 impl Consumer {
     pub fn new(
         client: Arc<Client>,
-        offset_store: Arc<dyn NostrEventOffsetStoreApi>,
+        nostr_store: Arc<dyn NostrRepository>,
         event_channel: NostrEventChannel,
     ) -> Self {
         Self {
             client,
-            offset_store,
+            nostr_store,
             event_channel,
         }
     }
@@ -241,7 +371,7 @@ impl Consumer {
         }
 
         let mut earliest_offset = Timestamp::now();
-        let offset = get_offset(&self.offset_store).await;
+        let offset = get_offset(&self.nostr_store).await;
         if offset != Timestamp::zero() && offset < earliest_offset {
             earliest_offset = offset;
         }
@@ -255,7 +385,7 @@ impl Consumer {
             Error::Network("Failed to subscribe to Nostr public events".to_string())
         })?;
 
-        let offset_store_clone = self.offset_store.clone();
+        let offset_store_clone = self.nostr_store.clone();
         let signer = self.client.signer().await?;
         let event_channel = self.event_channel.clone();
         tasks.spawn(async move {
@@ -288,7 +418,7 @@ impl Consumer {
 }
 
 async fn add_offset(
-    db: &Arc<dyn NostrEventOffsetStoreApi>,
+    db: &Arc<dyn NostrRepository>,
     event_id: EventId,
     time: Timestamp,
     success: bool,
@@ -303,7 +433,7 @@ async fn add_offset(
     .ok();
 }
 
-async fn get_offset(db: &Arc<dyn NostrEventOffsetStoreApi>) -> Timestamp {
+async fn get_offset(db: &Arc<dyn NostrRepository>) -> Timestamp {
     db.current_offset().await.unwrap_or_else(|e| {
         tracing::error!("Could not get event offset: {e}");
         Timestamp::zero()
@@ -364,7 +494,7 @@ async fn process_event(
 
 async fn should_process(
     event: Box<Event>,
-    offset_store: &Arc<dyn NostrEventOffsetStoreApi>,
+    offset_store: &Arc<dyn NostrRepository>,
     since: Timestamp,
 ) -> bool {
     valid_time(event.kind, event.created_at, since)

--- a/crates/bcr-wallet-transport/src/nostr.rs
+++ b/crates/bcr-wallet-transport/src/nostr.rs
@@ -209,6 +209,7 @@ pub struct Transport {
 }
 
 impl Transport {
+    const MAX_RETRIES: i32 = 5;
     pub fn new(client: Arc<Client>, nostr_store: Arc<dyn NostrRepository>) -> Self {
         Self {
             client,
@@ -274,7 +275,9 @@ impl TransportApi for Transport {
             recipient,
             payload,
         };
-        self.nostr_store.add_retry_message(queue_msg, 3).await?;
+        self.nostr_store
+            .add_retry_message(queue_msg, Self::MAX_RETRIES)
+            .await?;
         tracing::debug!("Queued Nostr retry message; triggering immediate retry for {receiver}");
 
         let self_clone = self.clone();

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -465,18 +465,23 @@ class RestoreWalletResponse {
 
 class StatusResponse {
   final String appVersion;
+  final Map<String, bool> nostrConnected;
 
-  const StatusResponse({required this.appVersion});
+  const StatusResponse({
+    required this.appVersion,
+    required this.nostrConnected,
+  });
 
   @override
-  int get hashCode => appVersion.hashCode;
+  int get hashCode => appVersion.hashCode ^ nostrConnected.hashCode;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is StatusResponse &&
           runtimeType == other.runtimeType &&
-          appVersion == other.appVersion;
+          appVersion == other.appVersion &&
+          nostrConnected == other.nostrConnected;
 }
 
 class TimeRange {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -2019,6 +2019,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  Map<String, bool> dco_decode_Map_String_bool_None(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return Map.fromEntries(
+      dco_decode_list_record_string_bool(raw).map((e) => MapEntry(e.$1, e.$2)),
+    );
+  }
+
+  @protected
   WalletPaymentCheckHandle
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
     dynamic raw,
@@ -2329,6 +2337,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<(String, bool)> dco_decode_list_record_string_bool(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_record_string_bool).toList();
+  }
+
+  @protected
   List<(String, String)> dco_decode_list_record_string_string(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_record_string_string).toList();
@@ -2484,6 +2498,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  (String, bool) dco_decode_record_string_bool(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (dco_decode_String(arr[0]), dco_decode_bool(arr[1]));
+  }
+
+  @protected
   (String, String) dco_decode_record_string_string(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -2506,9 +2530,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StatusResponse dco_decode_status_response(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 1)
-      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return StatusResponse(appVersion: dco_decode_String(arr[0]));
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return StatusResponse(
+      appVersion: dco_decode_String(arr[0]),
+      nostrConnected: dco_decode_Map_String_bool_None(arr[1]),
+    );
   }
 
   @protected
@@ -3287,6 +3314,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  Map<String, bool> sse_decode_Map_String_bool_None(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_list_record_string_bool(deserializer);
+    return Map.fromEntries(inner.map((e) => MapEntry(e.$1, e.$2)));
+  }
+
+  @protected
   WalletPaymentCheckHandle
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
     SseDeserializer deserializer,
@@ -3654,6 +3690,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<(String, bool)> sse_decode_list_record_string_bool(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <(String, bool)>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_record_string_bool(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<(String, String)> sse_decode_list_record_string_string(
     SseDeserializer deserializer,
   ) {
@@ -3859,6 +3909,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  (String, bool) sse_decode_record_string_bool(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 = sse_decode_String(deserializer);
+    var var_field1 = sse_decode_bool(deserializer);
+    return (var_field0, var_field1);
+  }
+
+  @protected
   (String, String) sse_decode_record_string_string(
     SseDeserializer deserializer,
   ) {
@@ -3881,7 +3939,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   StatusResponse sse_decode_status_response(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_appVersion = sse_decode_String(deserializer);
-    return StatusResponse(appVersion: var_appVersion);
+    var var_nostrConnected = sse_decode_Map_String_bool_None(deserializer);
+    return StatusResponse(
+      appVersion: var_appVersion,
+      nostrConnected: var_nostrConnected,
+    );
   }
 
   @protected
@@ -4671,6 +4733,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_Map_String_bool_None(
+    Map<String, bool> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_record_string_bool(
+      self.entries.map((e) => (e.key, e.value)).toList(),
+      serializer,
+    );
+  }
+
+  @protected
   void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
     WalletPaymentCheckHandle self,
@@ -5041,6 +5115,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_record_string_bool(
+    List<(String, bool)> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_record_string_bool(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_record_string_string(
     List<(String, String)> self,
     SseSerializer serializer,
@@ -5232,6 +5318,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_record_string_bool(
+    (String, bool) self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.$1, serializer);
+    sse_encode_bool(self.$2, serializer);
+  }
+
+  @protected
   void sse_encode_record_string_string(
     (String, String) self,
     SseSerializer serializer,
@@ -5257,6 +5353,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.appVersion, serializer);
+    sse_encode_Map_String_bool_None(self.nostrConnected, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -50,6 +50,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Map<String, String> dco_decode_Map_String_String_None(dynamic raw);
 
   @protected
+  Map<String, bool> dco_decode_Map_String_bool_None(dynamic raw);
+
+  @protected
   WalletPaymentCheckHandle
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
     dynamic raw,
@@ -204,6 +207,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
+  List<(String, bool)> dco_decode_list_record_string_bool(dynamic raw);
+
+  @protected
   List<(String, String)> dco_decode_list_record_string_string(dynamic raw);
 
   @protected
@@ -259,6 +265,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ProtestStatus dco_decode_protest_status(dynamic raw);
+
+  @protected
+  (String, bool) dco_decode_record_string_bool(dynamic raw);
 
   @protected
   (String, String) dco_decode_record_string_string(dynamic raw);
@@ -526,6 +535,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  Map<String, bool> sse_decode_Map_String_bool_None(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletPaymentCheckHandle
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
     SseDeserializer deserializer,
@@ -720,6 +734,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
   @protected
+  List<(String, bool)> sse_decode_list_record_string_bool(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<(String, String)> sse_decode_list_record_string_string(
     SseDeserializer deserializer,
   );
@@ -791,6 +810,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ProtestStatus sse_decode_protest_status(SseDeserializer deserializer);
+
+  @protected
+  (String, bool) sse_decode_record_string_bool(SseDeserializer deserializer);
 
   @protected
   (String, String) sse_decode_record_string_string(
@@ -1121,6 +1143,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_Map_String_bool_None(
+    Map<String, bool> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
     WalletPaymentCheckHandle self,
@@ -1347,6 +1375,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_record_string_bool(
+    List<(String, bool)> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_record_string_string(
     List<(String, String)> self,
     SseSerializer serializer,
@@ -1441,6 +1475,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_protest_status(ProtestStatus self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_record_string_bool(
+    (String, bool) self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_record_string_string(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -52,6 +52,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Map<String, String> dco_decode_Map_String_String_None(dynamic raw);
 
   @protected
+  Map<String, bool> dco_decode_Map_String_bool_None(dynamic raw);
+
+  @protected
   WalletPaymentCheckHandle
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
     dynamic raw,
@@ -206,6 +209,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
+  List<(String, bool)> dco_decode_list_record_string_bool(dynamic raw);
+
+  @protected
   List<(String, String)> dco_decode_list_record_string_string(dynamic raw);
 
   @protected
@@ -261,6 +267,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ProtestStatus dco_decode_protest_status(dynamic raw);
+
+  @protected
+  (String, bool) dco_decode_record_string_bool(dynamic raw);
 
   @protected
   (String, String) dco_decode_record_string_string(dynamic raw);
@@ -528,6 +537,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  Map<String, bool> sse_decode_Map_String_bool_None(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletPaymentCheckHandle
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
     SseDeserializer deserializer,
@@ -722,6 +736,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
   @protected
+  List<(String, bool)> sse_decode_list_record_string_bool(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<(String, String)> sse_decode_list_record_string_string(
     SseDeserializer deserializer,
   );
@@ -793,6 +812,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ProtestStatus sse_decode_protest_status(SseDeserializer deserializer);
+
+  @protected
+  (String, bool) sse_decode_record_string_bool(SseDeserializer deserializer);
 
   @protected
   (String, String) sse_decode_record_string_string(
@@ -1123,6 +1145,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_Map_String_bool_None(
+    Map<String, bool> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle(
     WalletPaymentCheckHandle self,
@@ -1349,6 +1377,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_record_string_bool(
+    List<(String, bool)> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_record_string_string(
     List<(String, String)> self,
     SseSerializer serializer,
@@ -1443,6 +1477,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_protest_status(ProtestStatus self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_record_string_bool(
+    (String, bool) self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_record_string_string(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wallet_ffi
 description: "Wallet FFI"
-version: 0.9.4
+version: 0.9.5
 homepage:
 
 environment:


### PR DESCRIPTION
* Structure Nostr as Consumer and Transport
* Add a retry-mechanism
* Expose nostr connection status to frontend
* Synchronize with published relay-list
* Add a background-receiver for incoming nostr payments 