### PR TITLE
Remote Payment Request via Nostr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
     * `wallet_pay_to_contact` - taking a payment request id
 * Add `node_id` to `WalletInfo`
 * Add endpoint to get `node_id`
+* Add API for remote payment requests via Nostr
+    * `wallet_request_payment_from_contact` - sends a payment request to a contact
+    * `wallet_list_pending_payment_requests` - returns a list of pending payment requests
+    * `wallet_subscribe_to_pending_payment_requests` - the caller can subscribe to incoming pending payment requests to react to them
+    * `wallet_get_pending_payment_request` - returns the details of a given pending payment request
+    * `wallet_pay_pending_payment_request` - pay a pending payment request
+    * `wallet_reject_pending_payment_request` - reject payment of a pending payment request
 
 # 0.9.4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -4003,6 +4004,8 @@ version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
+ "borsh",
+ "borsh-derive",
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,4 @@ tracing = {version = "0.1", features = ["log"]}
 tracing-log = {version = "0.2"}
 tracing-subscriber = {version = "0.3"}
 url = {version = "2.5"}
-uuid = {version = "1", features = ["v4", "serde"]}
+uuid = {version = "1", features = ["v4", "serde", "borsh"]}

--- a/crates/bcr-wallet-api/src/error.rs
+++ b/crates/bcr-wallet-api/src/error.rs
@@ -4,6 +4,7 @@ use bcr_common::{
     core::NodeId,
 };
 use thiserror::Error;
+use uuid::Uuid;
 
 pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
@@ -144,6 +145,8 @@ pub enum Error {
     External(#[from] crate::external::Error),
     #[error("Dev Mode is disabled")]
     NoDevMode,
+    #[error("No pending payment request found for {0}")]
+    PendingPaymentRequestNotFound(Uuid),
 }
 
 impl From<bcr_common::core::swap::wallet::Error> for Error {

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -14,8 +14,9 @@ use bcr_common::{
 use bcr_wallet_core::contact::Contact;
 use bcr_wallet_core::name::Name;
 use bcr_wallet_core::types::{
-    self, ListTransactionsResult, MintSummary, PaymentResultCallback, PaymentSummary, Seed,
-    TransactionCursor, TransactionFilters, TransactionSort, WalletConfig,
+    self, ListTransactionsResult, MintSummary, PaymentResultCallback, PaymentSummary,
+    PendingPaymentRequest, PendingPaymentSubscriptionCallback, Seed, TransactionCursor,
+    TransactionFilters, TransactionSort, WalletConfig,
 };
 use bcr_wallet_core::util::{
     build_wallet_id, keypair_from_mnemonic, keypair_from_seed, seed_from_mnemonic,
@@ -395,6 +396,125 @@ impl AppState {
         let (tx_id, _) = wallet.read().await.pay(p_id, &self.http_cl, tstamp).await?;
 
         Ok(tx_id)
+    }
+
+    pub async fn wallet_request_payment_from_contact(
+        &self,
+        wallet_id: String,
+        node_id: String,
+        amount: u64,
+        description: Option<String>,
+        deadline: Option<u64>,
+    ) -> Result<Uuid> {
+        tracing::debug!(
+            "wallet_request_payment_from_contact({wallet_id}, {node_id}, {amount}, {description:?}, {deadline:?})"
+        );
+        let node_id = NodeId::from_str(&node_id)?;
+        let amount = cashu::Amount::from(amount);
+        let wallet = self.get_wallet(&wallet_id).await?;
+        let unit = wallet.read().await.debit_unit();
+        let payment_req_id = wallet
+            .read()
+            .await
+            .request_payment_from_contact(node_id, amount, unit, description, deadline)
+            .await?;
+        Ok(payment_req_id)
+    }
+
+    pub async fn wallet_subscribe_to_pending_payment_requests(
+        &self,
+        wallet_id: String,
+        cancel_token: CancellationToken,
+        item_callback: PendingPaymentSubscriptionCallback,
+    ) -> Result<()> {
+        tracing::debug!("wallet_subscribe_to_pending_payment_requests({wallet_id})");
+        let wallet = self.get_wallet(&wallet_id).await?;
+        wallet
+            .read()
+            .await
+            .subscribe_to_pending_payment_requests(cancel_token, item_callback)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn wallet_list_pending_payment_requests(
+        &self,
+        wallet_id: String,
+    ) -> Result<Vec<PendingPaymentRequest>> {
+        tracing::debug!("wallet_list_pending_payment_requests({wallet_id})");
+        let wallet = self.get_wallet(&wallet_id).await?;
+        let res = wallet.read().await.list_pending_payment_requests().await?;
+        Ok(res)
+    }
+
+    pub async fn wallet_get_pending_payment_request(
+        &self,
+        wallet_id: String,
+        pending_payment_req_id: String,
+    ) -> Result<PendingPaymentRequest> {
+        tracing::debug!(
+            "wallet_get_pending_payment_request({wallet_id}, {pending_payment_req_id})"
+        );
+        let pending_payment_req_id = Uuid::from_str(&pending_payment_req_id)?;
+        let wallet = self.get_wallet(&wallet_id).await?;
+        match wallet
+            .read()
+            .await
+            .get_pending_payment_request(pending_payment_req_id)
+            .await?
+        {
+            Some(p) => Ok(p),
+            None => Err(Error::PendingPaymentRequestNotFound(pending_payment_req_id)),
+        }
+    }
+
+    pub async fn wallet_prepare_pay_pending_payment_request(
+        &self,
+        wallet_id: String,
+        pending_payment_req_id: String,
+    ) -> Result<PaymentSummary> {
+        tracing::debug!(
+            "wallet_prepare_pay_pending_payment_request({wallet_id}, {pending_payment_req_id})"
+        );
+        let pending_payment_req_id = Uuid::from_str(&pending_payment_req_id)?;
+        let wallet = self.get_wallet(&wallet_id).await?;
+        let tx_id = wallet
+            .read()
+            .await
+            .prepare_pay_pending_payment_request(pending_payment_req_id)
+            .await?;
+        Ok(tx_id)
+    }
+
+    pub async fn wallet_pay_pending_payment_request(
+        &self,
+        wallet_id: String,
+        rid: String,
+    ) -> Result<TransactionId> {
+        tracing::debug!("wallet_pay_pending_payment_request({wallet_id}, {rid})");
+        let tstamp = chrono::Utc::now().timestamp() as u64;
+        let p_id = Uuid::from_str(&rid)?;
+        let wallet = self.get_wallet(&wallet_id).await?;
+        let (tx_id, _) = wallet.read().await.pay(p_id, &self.http_cl, tstamp).await?;
+        Ok(tx_id)
+    }
+
+    pub async fn wallet_reject_pending_payment_request(
+        &self,
+        wallet_id: String,
+        pending_payment_req_id: String,
+    ) -> Result<()> {
+        tracing::debug!(
+            "wallet_reject_pending_payment_request({wallet_id}, {pending_payment_req_id})"
+        );
+        let pending_payment_req_id = Uuid::from_str(&pending_payment_req_id)?;
+        let wallet = self.get_wallet(&wallet_id).await?;
+        wallet
+            .read()
+            .await
+            .reject_pending_payment_request(pending_payment_req_id)
+            .await?;
+        Ok(())
     }
 
     pub async fn wallet_prepare_melt(
@@ -1008,7 +1128,7 @@ async fn build_wallet(
     nostr_cl: Arc<nostr::Client>,
 ) -> Result<Arc<RwLock<wallet::Wallet>>> {
     // building wallet dbs
-    let (tx_repo, debitdb, mintmeltdb, nostrdb, contactdb) =
+    let (tx_repo, debitdb, mintmeltdb, nostrdb, contactdb, pending_payment_request_db) =
         build_wallet_dbs(db_version, &w_cfg.wallet_id, &w_cfg.debit, db).await?;
 
     let nostr_repo = Arc::new(nostrdb);
@@ -1051,6 +1171,7 @@ async fn build_wallet(
         w_cfg.mint_keyset_infos,
         Box::new(tx_repo),
         Box::new(contactdb),
+        Box::new(pending_payment_request_db),
         debit_pocket,
         w_cfg.name,
         w_cfg.wallet_id,

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -22,15 +22,17 @@ use bcr_common::{
 use bcr_wallet_core::{
     SendSync,
     contact::Contact,
+    event::{ContactPaymentRequestPayload, EventEnvelope},
     name::Name,
     types::{
-        BTC_TX_ID_TYPE_METADATA_KEY, CONTACT_NODE_ID_METADATA_KEY, PaymentResultCallback,
-        PaymentType, TransactionStatus,
+        BTC_TX_ID_TYPE_METADATA_KEY, CONTACT_NODE_ID_METADATA_KEY, PAYMENT_REQUEST_ID_METADATA_KEY,
+        PaymentResultCallback, PaymentType, PendingPaymentRequest,
+        PendingPaymentSubscriptionCallback, TransactionStatus,
     },
     util::{from_mint_url, to_mint_url},
 };
 use bcr_wallet_transport::NostrWalletEvent;
-use bitcoin::secp256k1;
+use bitcoin::{base58, secp256k1};
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use nostr::RelayUrl;
@@ -134,6 +136,34 @@ pub trait WalletApi: SendSync {
     async fn delete_contact(&self, node_id: NodeId) -> Result<()>;
     async fn get_contact(&self, node_id: NodeId) -> Result<Option<Contact>>;
     async fn list_contacts(&self, search_term: Option<String>) -> Result<Vec<Contact>>;
+    // pending payment requests
+    async fn request_payment_from_contact(
+        &self,
+        node_id: NodeId,
+        amount: Amount,
+        unit: CurrencyUnit,
+        description: Option<String>,
+        deadline: Option<u64>,
+    ) -> Result<Uuid>;
+    async fn subscribe_to_pending_payment_requests(
+        &self,
+        cancel_token: CancellationToken,
+        item_callback: PendingPaymentSubscriptionCallback,
+    ) -> Result<()>;
+    async fn list_pending_payment_requests(&self) -> Result<Vec<PendingPaymentRequest>>;
+    async fn get_pending_payment_request(
+        &self,
+        pending_payment_request_id: Uuid,
+    ) -> Result<Option<PendingPaymentRequest>>;
+    async fn add_pending_payment_request(
+        &self,
+        pending_payment_request: PendingPaymentRequest,
+    ) -> Result<()>;
+    async fn prepare_pay_pending_payment_request(
+        &self,
+        pending_payment_request_id: Uuid,
+    ) -> Result<PaymentSummary>;
+    async fn reject_pending_payment_request(&self, pending_payment_request_id: Uuid) -> Result<()>;
 }
 
 #[async_trait]
@@ -558,7 +588,10 @@ impl WalletApi for super::Wallet {
                 let tx_id = self.tx_repo.store_tx(partial_tx).await?;
                 Ok((tx_id, None))
             }
-            WalletPaymentType::Contact { node_id } => {
+            WalletPaymentType::Contact {
+                node_id,
+                payment_request_id,
+            } => {
                 let Ok(Some(contact)) = self.contact_repo.get_contact(node_id.clone()).await else {
                     return Err(Error::ContactNotFound(node_id));
                 };
@@ -580,6 +613,13 @@ impl WalletApi for super::Wallet {
                     TransactionStatus::Pending.to_string(),
                 );
                 metadata.insert(CONTACT_NODE_ID_METADATA_KEY.to_owned(), node_id.to_string());
+                // if there is a payment request id, set it
+                if let Some(p_req_id) = payment_request_id {
+                    metadata.insert(
+                        PAYMENT_REQUEST_ID_METADATA_KEY.to_owned(),
+                        p_req_id.to_string(),
+                    );
+                }
 
                 let partial_tx = Transaction {
                     mint_url: to_mint_url(self.client.mint_url()),
@@ -599,8 +639,25 @@ impl WalletApi for super::Wallet {
                     saga_id: None,
                 };
                 let tx_id = self
-                    .pay_to_contact(proofs, &self.nostr_transport, contact, partial_tx)
+                    .pay_to_contact(
+                        proofs,
+                        &self.nostr_transport,
+                        contact,
+                        payment_request_id,
+                        partial_tx,
+                    )
                     .await?;
+                // if it was a payment request - delete the pending payment request afterwards
+                if let Some(p_req_id) = payment_request_id
+                    && let Err(e) = self
+                        .pending_payment_request_repo
+                        .delete_pending_payment_request(p_req_id)
+                        .await
+                {
+                    tracing::warn!(
+                        "Could not delete pending payment request {p_req_id} after successful payment: {e}"
+                    );
+                }
                 Ok((tx_id, None))
             }
         }
@@ -1069,7 +1126,10 @@ impl WalletApi for super::Wallet {
             request_id: summary.request_id,
             unit: summary.unit.clone(),
             fees: summary.fees,
-            ptype: WalletPaymentType::Contact { node_id },
+            ptype: WalletPaymentType::Contact {
+                node_id,
+                payment_request_id: None,
+            },
             memo: description,
         };
         *self.current_payment.lock().await = Some(pref);
@@ -1219,17 +1279,35 @@ impl WalletApi for super::Wallet {
             tracing::error!("Error deleting nostr DB for wallet {}: {e}", self.id())
         }
 
+        // delete contact tables
+        if let Err(e) = self.contact_repo.delete_repo().await {
+            tracing::error!("Error deleting contact DB for wallet {}: {e}", self.id())
+        }
+
+        // delete pending payment request tables
+        if let Err(e) = self.pending_payment_request_repo.delete_repo().await {
+            tracing::error!(
+                "Error deleting pending payment request DB for wallet {}: {e}",
+                self.id()
+            )
+        }
+
         Ok(())
     }
 
     async fn add_contact(&self, node_id: NodeId, name: Name) -> Result<()> {
         let my_relays = self.nostr_relays();
         // fetch relay list for the contact from nostr, falling back to our relays
-        let fetched_relay_list = self
+        let mut fetched_relay_list = self
             .nostr_transport
             .fetch_relay_list(node_id.npub(), my_relays.clone())
             .await
-            .unwrap_or(my_relays);
+            .unwrap_or(my_relays.clone());
+
+        if fetched_relay_list.is_empty() {
+            fetched_relay_list = my_relays;
+        }
+
         let contact = Contact {
             node_id: node_id.clone(),
             name,
@@ -1276,5 +1354,181 @@ impl WalletApi for super::Wallet {
     async fn list_contacts(&self, search_term: Option<String>) -> Result<Vec<Contact>> {
         let contacts = self.contact_repo.list_contacts(search_term).await?;
         Ok(contacts)
+    }
+
+    async fn request_payment_from_contact(
+        &self,
+        node_id: NodeId,
+        amount: Amount,
+        unit: CurrencyUnit,
+        description: Option<String>,
+        deadline: Option<u64>,
+    ) -> Result<Uuid> {
+        let Ok(Some(contact)) = self.contact_repo.get_contact(node_id.clone()).await else {
+            return Err(Error::ContactNotFound(node_id));
+        };
+        let payload = ContactPaymentRequestPayload::new(
+            self.node_id(),
+            amount,
+            unit,
+            description,
+            deadline,
+            to_mint_url(self.client.mint_url()),
+        );
+        let payment_req_id = payload.id;
+        let event: EventEnvelope =
+            bcr_wallet_core::event::Event::new_contact_payment_request(payload).try_into()?;
+        let payload = base58::encode(&borsh::to_vec(&event)?);
+        let target = self.nostr_transport.nip19_for_contact(&contact).await?;
+        match self
+            .nostr_transport
+            .send_private_msg(target.clone(), payload.clone())
+            .await
+        {
+            Ok(event_id) => {
+                tracing::info!(
+                    "Sent contact payment request {} with nostr event_id {event_id}",
+                    payment_req_id
+                );
+            }
+            Err(e) => {
+                tracing::error!("Failed to send contact payment request, queuing for retry: {e}");
+                match e {
+                    bcr_wallet_transport::error::Error::NostrSendPrivateMsg(_) => {
+                        self.nostr_transport
+                            .queue_retry_message(Some(target), payload)
+                            .await?;
+                    }
+                    e => return Err(e.into()),
+                }
+            }
+        };
+        Ok(payment_req_id)
+    }
+
+    async fn subscribe_to_pending_payment_requests(
+        &self,
+        cancel_token: CancellationToken,
+        item_callback: PendingPaymentSubscriptionCallback,
+    ) -> Result<()> {
+        tracing::debug!("Subscribing to payment requests from Nostr...");
+        let mut nostr_receiver = self.nostr_event_channel.subscribe();
+        loop {
+            tokio::select! {
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("subscribe_to_pending_payment_requests cancelled");
+                    return Ok(());
+                },
+                evt = nostr_receiver.recv() => {
+                    let received_evt = match evt {
+                        Ok(e) => e,
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                            tracing::warn!("subscribe_to_pending_payment_requests channel lagged behind");
+                            continue;
+                        },
+                        Err(broadcast::error::RecvError::Closed) => {
+                            tracing::warn!("subscribe_to_pending_payment_requests channel closed");
+                            return Ok(());
+                        },
+                    };
+
+                    let NostrWalletEvent::ContactPaymentRequest { event_id, payload, sender } = received_evt else {
+                        continue;
+                    };
+                    tracing::info!("Received contact payment request {} from {sender}, event_id: {event_id}", payload.id);
+                    let pending_payment_request: PendingPaymentRequest = payload.into();
+                    let payment_request_id = pending_payment_request.id;
+                    match self.pending_payment_request_repo.add_pending_payment_request(pending_payment_request).await {
+                        Ok(_) => {
+                            item_callback(payment_request_id);
+                        },
+                        Err(bcr_wallet_persistence::error::Error::PendingPaymentRequestAlreadyExists(_)) => {
+                            // already had it - either sent again, or already processed - sending it either way and the caller can choose to ignore it
+                            item_callback(payment_request_id);
+                        },
+                        Err(e) => {
+                            tracing::error!("Could not store payment request: {e}");
+                        }
+                    };
+                }
+            }
+        }
+    }
+
+    async fn list_pending_payment_requests(&self) -> Result<Vec<PendingPaymentRequest>> {
+        let res = self
+            .pending_payment_request_repo
+            .list_pending_payment_requests()
+            .await?;
+        Ok(res)
+    }
+
+    async fn get_pending_payment_request(
+        &self,
+        pending_payment_request_id: Uuid,
+    ) -> Result<Option<PendingPaymentRequest>> {
+        let res = self
+            .pending_payment_request_repo
+            .get_pending_payment_request(pending_payment_request_id)
+            .await?;
+        Ok(res)
+    }
+
+    async fn add_pending_payment_request(
+        &self,
+        pending_payment_request: PendingPaymentRequest,
+    ) -> Result<()> {
+        self.pending_payment_request_repo
+            .add_pending_payment_request(pending_payment_request)
+            .await?;
+        Ok(())
+    }
+
+    async fn prepare_pay_pending_payment_request(
+        &self,
+        pending_payment_request_id: Uuid,
+    ) -> Result<PaymentSummary> {
+        let Some(req) = self
+            .pending_payment_request_repo
+            .get_pending_payment_request(pending_payment_request_id)
+            .await?
+        else {
+            return Err(Error::PendingPaymentRequestNotFound(
+                pending_payment_request_id,
+            ));
+        };
+        // has to be added to contacts to pay the payment request
+        if self
+            .contact_repo
+            .get_contact(req.node_id.clone())
+            .await?
+            .is_none()
+        {
+            return Err(Error::ContactNotFound(req.node_id));
+        }
+        let infos = self.get_wallet_mint_keyset_infos().await?;
+
+        let s_summary = self.debit.prepare_send(req.amount, &infos).await?;
+        let mut summary = PaymentSummary::from(s_summary);
+        summary.ptype = PaymentType::Contact;
+        let pref = PayReference {
+            request_id: summary.request_id,
+            unit: summary.unit.clone(),
+            fees: summary.fees,
+            ptype: WalletPaymentType::Contact {
+                node_id: req.node_id,
+                payment_request_id: Some(req.id),
+            },
+            memo: req.description,
+        };
+        *self.current_payment.lock().await = Some(pref);
+        Ok(summary)
+    }
+
+    async fn reject_pending_payment_request(&self, pending_payment_request_id: Uuid) -> Result<()> {
+        self.pending_payment_request_repo
+            .delete_pending_payment_request(pending_payment_request_id)
+            .await?;
+        Ok(())
     }
 }

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -23,12 +23,15 @@ use bcr_wallet_core::{
     contact::Contact,
     event::{ContactPaymentPayload, EventEnvelope},
     types::{
-        CONTACT_NODE_ID_METADATA_KEY, ListTransactionsResult, PaymentType, TransactionCursor,
-        TransactionFilters, TransactionSort, TransactionStatus, extract_fees_per_month,
+        CONTACT_NODE_ID_METADATA_KEY, ListTransactionsResult, PaymentType, PendingPaymentRequest,
+        TransactionCursor, TransactionFilters, TransactionSort, TransactionStatus,
+        extract_fees_per_month,
     },
     util::{from_mint_url, to_mint_url},
 };
-use bcr_wallet_persistence::{ContactStoreApi, NostrRepository, TransactionRepository};
+use bcr_wallet_persistence::{
+    ContactStoreApi, NostrRepository, PendingPaymentRequestStoreApi, TransactionRepository,
+};
 use bcr_wallet_transport::{NostrEventChannel, TransportApi, nostr};
 use bitcoin::{
     base58,
@@ -39,6 +42,7 @@ use chrono::Utc;
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 use tokio::sync::{Mutex, RwLock, broadcast};
 use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
 
 pub struct Wallet {
     network: bitcoin::Network,
@@ -47,6 +51,7 @@ pub struct Wallet {
     beta_clients: HashMap<url::Url, Arc<dyn ClowderMintConnector>>,
     tx_repo: Box<dyn TransactionRepository>,
     contact_repo: Box<dyn ContactStoreApi>,
+    pending_payment_request_repo: Box<dyn PendingPaymentRequestStoreApi>,
     debit: Box<dyn DebitPocketApi>,
     name: String,
     id: String,
@@ -70,6 +75,7 @@ impl Wallet {
         mint_keyset_infos: HashMap<cashu::Id, KeySetInfo>,
         tx_repo: Box<dyn TransactionRepository>,
         contact_repo: Box<dyn ContactStoreApi>,
+        pending_payment_request_repo: Box<dyn PendingPaymentRequestStoreApi>,
         debit: Box<dyn DebitPocketApi>,
         name: String,
         id: String,
@@ -90,6 +96,7 @@ impl Wallet {
             mint_keyset_infos,
             tx_repo,
             contact_repo,
+            pending_payment_request_repo,
             debit,
             name,
             id,
@@ -208,6 +215,19 @@ impl Wallet {
                             },
                         };
                         match received_evt {
+                            bcr_wallet_transport::NostrWalletEvent::ContactPaymentRequest { sender, payload, event_id } => {
+                                let pending_payment_request: PendingPaymentRequest = payload.into();
+                                let payment_request_id = pending_payment_request.id;
+                                let wallet_guard = wallet.read().await;
+                                match <Self as api::WalletApi>::add_pending_payment_request(&*wallet_guard, pending_payment_request).await {
+                                    Ok(_) => {
+                                        tracing::info!("Received contact payment request {payment_request_id} from {sender}, event_id: {event_id}");
+                                    },
+                                    Err(e) => {
+                                        tracing::error!("Could not store payment request {payment_request_id}: {e}");
+                                    }
+                                };
+                            },
                             bcr_wallet_transport::NostrWalletEvent::Cdk18Payment { .. } => {
                                 // ignore - cdk18 payments are handled by explicitly awaiting them
                             },
@@ -915,9 +935,11 @@ impl Wallet {
         proofs: Vec<cashu::Proof>,
         nostr_cl: &Arc<dyn TransportApi>,
         contact: Contact,
+        payment_request_id: Option<Uuid>,
         mut partial_tx: Transaction,
     ) -> Result<TransactionId> {
         let payload = ContactPaymentPayload {
+            payment_request_id,
             sender: self.node_id(),
             proofs,
             memo: partial_tx.memo.clone(),
@@ -1039,7 +1061,8 @@ mod tests {
         MintSummary, PaymentResultCallback, TimeRange, get_payment_type, get_transaction_status,
     };
     use bcr_wallet_persistence::{
-        MockContactStoreApi, MockNostrRepository, MockTransactionRepository,
+        MockContactStoreApi, MockNostrRepository, MockPendingPaymentRequestStoreApi,
+        MockTransactionRepository,
         test_utils::tests::{test_pub_key, valid_payment_address_testnet},
     };
     use bcr_wallet_transport::{
@@ -1064,6 +1087,7 @@ mod tests {
         pub debit: MockDebitPocket,
         pub nostr_repo: MockNostrRepository,
         pub contact_repo: MockContactStoreApi,
+        pub pending_payment_request_repo: MockPendingPaymentRequestStoreApi,
     }
 
     fn wallet_ctx() -> MockWalletCtx {
@@ -1074,6 +1098,7 @@ mod tests {
             debit: MockDebitPocket::new(),
             nostr_repo: MockNostrRepository::new(),
             contact_repo: MockContactStoreApi::new(),
+            pending_payment_request_repo: MockPendingPaymentRequestStoreApi::new(),
         }
     }
 
@@ -1109,6 +1134,7 @@ mod tests {
             beta_clients,
             tx_repo: Box::new(ctx.tx_repo),
             contact_repo: Box::new(ctx.contact_repo),
+            pending_payment_request_repo: Box::new(ctx.pending_payment_request_repo),
             debit: Box::new(ctx.debit),
             name: "wallet-1".to_owned(),
             id: "w-1".to_owned(),

--- a/crates/bcr-wallet-api/src/wallet/types.rs
+++ b/crates/bcr-wallet-api/src/wallet/types.rs
@@ -22,6 +22,7 @@ pub enum WalletPaymentType {
     Token,
     Contact {
         node_id: NodeId,
+        payment_request_id: Option<Uuid>,
     },
 }
 

--- a/crates/bcr-wallet-cli/Cargo.toml
+++ b/crates/bcr-wallet-cli/Cargo.toml
@@ -23,3 +23,4 @@ tracing-log.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 url.workspace = true
+uuid.workspace = true

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -4,13 +4,15 @@ use anyhow::Result;
 use bcr_common::cdk_common::wallet::TransactionId;
 use bcr_wallet_api::{AppState, config::CreateWalletConfig};
 use bcr_wallet_core::types::{
-    PaymentResultCallback, TransactionFilters, TransactionSort, get_btc_tx_id, get_contact_node_id,
-    get_payment_type, get_transaction_status,
+    PaymentResultCallback, PendingPaymentSubscriptionCallback, TransactionFilters, TransactionSort,
+    get_btc_tx_id, get_contact_node_id, get_payment_request_id, get_payment_type,
+    get_transaction_status,
 };
 use chrono::{DateTime, Utc};
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
+use uuid::Uuid;
 
 use crate::WalletSettings;
 
@@ -91,14 +93,15 @@ pub async fn cmd_info(app_state: &AppState) -> Result<String> {
                 let ptype = get_payment_type(&tx.metadata);
                 let btc_tx_id = get_btc_tx_id(&tx.metadata);
                 let contact = get_contact_node_id(&tx.metadata);
+                let payment_req_id = get_payment_request_id(&tx.metadata);
                 let quote_or_btc_tx_id = match (btc_tx_id, &tx.quote_id) {
                     (Some(txid), _) => txid.to_string(),
                     (None, Some(quote_id)) => quote_id.to_string(),
                     (None, None) => String::default(),
                 };
                 res.push_str(&format!(
-                    "\t\tId: {} \t Amount: {:8} {} \t Fees: {}  \t Status: {:?} \t {} \tType: {:<10} \t {:?} \t Memo: {} \t BTC TxID/Quote ID: {} \t Contact: {}",
-                    tx.id(), tx.amount, tx.unit, tx.fee,  status, format_timestamp(tx.timestamp), &format!("{:?}", ptype), tx.direction, tx.memo.clone().unwrap_or_default(), quote_or_btc_tx_id, contact.map(|n| n.to_string()).unwrap_or_default()
+                    "\t\tId: {} \t Amount: {:8} {} \t Fees: {}  \t Status: {:?} \t {} \tType: {:<10} \t {:?} \t Memo: {} \t BTC TxID/Quote ID: {} \t Contact: {} \t Payment Request ID: {}",
+                    tx.id(), tx.amount, tx.unit, tx.fee,  status, format_timestamp(tx.timestamp), &format!("{:?}", ptype), tx.direction, tx.memo.clone().unwrap_or_default(), quote_or_btc_tx_id, contact.map(|n| n.to_string()).unwrap_or_default(), payment_req_id.map(|id| id.to_string()).unwrap_or_default()
                 ));
                 push_break(&mut res);
             }
@@ -686,6 +689,158 @@ pub async fn cmd_list_contacts(
         res.push_str(&format!("NodeId: {} Name: {}\n", c.node_id, c.name));
         push_break(&mut res);
     }
+    push_break(&mut res);
+    Ok(res)
+}
+
+pub async fn cmd_request_payment_from_contact(
+    app_state: &AppState,
+    name: &str,
+    id: &str,
+    node_id: &str,
+    amount: u64,
+) -> Result<String> {
+    let mut res = String::new();
+    app_state
+        .wallet_request_payment_from_contact(id.to_owned(), node_id.to_owned(), amount, None, None)
+        .await?;
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!(
+        "Request Payment over {amount} from Contact {node_id} for {name}:\n"
+    ));
+    push_break(&mut res);
+    Ok(res)
+}
+
+pub async fn cmd_subscribe_to_pprs(app_state: &AppState, _name: &str, id: &str) -> Result<String> {
+    let mut res = String::new();
+    let cancel_token = CancellationToken::new();
+    let cancel_token_clone = cancel_token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+        cancel_token_clone.cancel();
+    });
+
+    let (tx, rx) = oneshot::channel::<Uuid>();
+
+    let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
+
+    let res_cb: PendingPaymentSubscriptionCallback = Arc::new(move |id| {
+        if let Some(sender) = tx.lock().unwrap().take() {
+            let _ = sender.send(id);
+        }
+    });
+
+    app_state
+        .wallet_subscribe_to_pending_payment_requests(id.to_owned(), cancel_token, res_cb)
+        .await?;
+
+    let Ok(id) = rx.await else {
+        return Ok("Cancelled".to_string());
+    };
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!("ID: {id}"));
+    push_break(&mut res);
+    Ok(res)
+}
+
+pub async fn cmd_list_pprs(app_state: &AppState, name: &str, id: &str) -> Result<String> {
+    let mut res = String::new();
+    let pprs = app_state
+        .wallet_list_pending_payment_requests(id.to_owned())
+        .await?;
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!("Pending Payment Requests for {name}:\n"));
+    push_break(&mut res);
+    for ppr in pprs {
+        res.push_str(&format!(
+            "Id: {} NodeId: {} Amount: {}\n",
+            ppr.id, ppr.node_id, ppr.amount
+        ));
+        push_break(&mut res);
+    }
+    push_break(&mut res);
+    Ok(res)
+}
+
+pub async fn cmd_get_ppr(
+    app_state: &AppState,
+    name: &str,
+    id: &str,
+    pending_payment_req_id: &str,
+) -> Result<String> {
+    let mut res = String::new();
+    let ppr = app_state
+        .wallet_get_pending_payment_request(id.to_owned(), pending_payment_req_id.to_owned())
+        .await?;
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!(
+        "Pending Payment Request for {pending_payment_req_id} for {name}:\n"
+    ));
+    push_break(&mut res);
+    res.push_str(&format!(
+        "Id: {} NodeId: {} Amount: {}\n",
+        ppr.id, ppr.node_id, ppr.amount
+    ));
+    push_break(&mut res);
+    push_break(&mut res);
+    Ok(res)
+}
+
+pub async fn cmd_pay_ppr(
+    app_state: &AppState,
+    name: &str,
+    id: &str,
+    pending_payment_req_id: &str,
+) -> Result<String> {
+    let mut res = String::new();
+    let payment_summary = app_state
+        .wallet_prepare_pay_pending_payment_request(
+            id.to_owned(),
+            pending_payment_req_id.to_owned(),
+        )
+        .await?;
+    info!(
+        "Payment Summary: Amount: {}, Unit: {}, Fees: {}",
+        &payment_summary.amount, &payment_summary.unit, &payment_summary.fees,
+    );
+    let result = app_state
+        .wallet_pay_pending_payment_request(id.to_owned(), payment_summary.request_id.to_string())
+        .await?;
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!(
+        "Pay Payment Request {pending_payment_req_id} for {name}, Wallet ID: {id}.\n"
+    ));
+    res.push_str(&format!(
+        "Unit: {}, Amount: {}, Fees: {}",
+        &payment_summary.unit, &payment_summary.amount, &payment_summary.fees
+    ));
+    push_break(&mut res);
+    res.push_str(&format!("Transaction ID: {}", result));
+    push_break(&mut res);
+    Ok(res)
+}
+
+pub async fn cmd_reject_ppr(
+    app_state: &AppState,
+    name: &str,
+    id: &str,
+    pending_payment_req_id: &str,
+) -> Result<String> {
+    let mut res = String::new();
+    app_state
+        .wallet_reject_pending_payment_request(id.to_owned(), pending_payment_req_id.to_owned())
+        .await?;
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!(
+        "Reject Pending Payment Request for {pending_payment_req_id} for {name}:\n"
+    ));
     push_break(&mut res);
     Ok(res)
 }

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -139,6 +139,31 @@ enum Commands {
         id: String,
         search_term: Option<String>,
     },
+    #[command(name = "req_payment_from_contact")]
+    RequestPaymentFromContact {
+        id: String,
+        node_id: String,
+        amount: u64,
+    },
+    #[command(name = "subscribe_to_pprs")]
+    SubscribeToPendingPaymentRequests { id: String },
+    #[command(name = "list_pprs")]
+    ListPendingPaymentRequests { id: String },
+    #[command(name = "get_ppr")]
+    GetPendingPaymentRequest {
+        id: String,
+        pending_payment_req_id: String,
+    },
+    #[command(name = "pay_ppr")]
+    PayPendingPaymentRequest {
+        id: String,
+        pending_payment_req_id: String,
+    },
+    #[command(name = "reject_ppr")]
+    RejectPendingPaymentRequest {
+        id: String,
+        pending_payment_req_id: String,
+    },
 }
 
 #[tokio::main]
@@ -428,6 +453,69 @@ async fn main() -> Result<()> {
                 "List Contacts for {}: {}",
                 cli.wallet,
                 command::cmd_list_contacts(&app_state, &cli.wallet, &id, &search_term).await?
+            );
+        }
+        Commands::RequestPaymentFromContact {
+            id,
+            node_id,
+            amount,
+        } => {
+            info!(
+                "Request Payment Requests for {}: {}",
+                cli.wallet,
+                command::cmd_request_payment_from_contact(
+                    &app_state,
+                    &cli.wallet,
+                    &id,
+                    &node_id,
+                    amount
+                )
+                .await?
+            );
+        }
+        Commands::SubscribeToPendingPaymentRequests { id } => {
+            info!(
+                "Subscribe to Payment Requests for {}: {}",
+                cli.wallet,
+                command::cmd_subscribe_to_pprs(&app_state, &cli.wallet, &id).await?
+            );
+        }
+        Commands::ListPendingPaymentRequests { id } => {
+            info!(
+                "List Pending Payment Requests for {}: {}",
+                cli.wallet,
+                command::cmd_list_pprs(&app_state, &cli.wallet, &id).await?
+            );
+        }
+        Commands::GetPendingPaymentRequest {
+            id,
+            pending_payment_req_id,
+        } => {
+            info!(
+                "Get Pending Payment Request for {}: {}",
+                cli.wallet,
+                command::cmd_get_ppr(&app_state, &cli.wallet, &id, &pending_payment_req_id).await?
+            );
+        }
+        Commands::PayPendingPaymentRequest {
+            id,
+            pending_payment_req_id,
+        } => {
+            info!(
+                "Pay Pending Payment Request for {}: {}",
+                cli.wallet,
+                command::cmd_pay_ppr(&app_state, &cli.wallet, &id, &pending_payment_req_id).await?
+            );
+        }
+        Commands::RejectPendingPaymentRequest {
+            id,
+            pending_payment_req_id,
+        } => {
+            info!(
+                "Reject Pending Payment Request for {}: {}",
+                cli.wallet,
+                command::cmd_reject_ppr(&app_state, &cli.wallet, &id, &pending_payment_req_id)
+                    .await?
             );
         }
     }

--- a/crates/bcr-wallet-core/src/event.rs
+++ b/crates/bcr-wallet-core/src/event.rs
@@ -1,13 +1,15 @@
 use bcr_common::{
-    cashu::{CurrencyUnit, MintUrl, Proof},
+    cashu::{self, Amount, CurrencyUnit, MintUrl, Proof},
     core::NodeId,
     wire::borsh::{
-        deserialize_from_str, deserialize_vecof_cdkproof, serialize_as_str,
-        serialize_vecof_cdkproof,
+        deserialize_from_str, deserialize_from_u64, deserialize_vecof_cdkproof, serialize_as_str,
+        serialize_as_u64, serialize_vecof_cdkproof,
     },
 };
 use borsh::{BorshDeserialize, BorshSerialize};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 const DEFAULT_EVENT_VERSION: &str = "1.0";
 
@@ -28,6 +30,7 @@ fn get_version(_event_type: &EventType) -> String {
 )]
 pub enum EventType {
     ContactPayment,
+    ContactPaymentRequest,
 }
 
 #[derive(Debug, Clone, BorshSerialize)]
@@ -48,6 +51,10 @@ impl<T: BorshSerialize> Event<T> {
 
     pub fn new_contact_payment(data: T) -> Self {
         Self::new(EventType::ContactPayment, data)
+    }
+
+    pub fn new_contact_payment_request(data: T) -> Self {
+        Self::new(EventType::ContactPaymentRequest, data)
     }
 }
 
@@ -85,6 +92,7 @@ pub struct EventEnvelope {
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct ContactPaymentPayload {
+    pub payment_request_id: Option<Uuid>,
     pub sender: NodeId,
     #[borsh(
         serialize_with = "serialize_vecof_cdkproof",
@@ -103,4 +111,50 @@ pub struct ContactPaymentPayload {
     )]
     pub unit: CurrencyUnit,
     pub created_at: u64,
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct ContactPaymentRequestPayload {
+    pub id: Uuid,
+    pub sender: NodeId,
+    pub memo: Option<String>,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub mint: MintUrl,
+    #[borsh(
+        serialize_with = "serialize_as_u64",
+        deserialize_with = "deserialize_from_u64"
+    )]
+    pub amount: cashu::Amount,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub unit: CurrencyUnit,
+    pub deadline: Option<u64>,
+    pub created_at: u64,
+}
+
+impl ContactPaymentRequestPayload {
+    pub fn new(
+        node_id: NodeId,
+        amount: Amount,
+        unit: CurrencyUnit,
+        memo: Option<String>,
+        deadline: Option<u64>,
+        mint: MintUrl,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            sender: node_id,
+            memo,
+            mint,
+            amount,
+            unit,
+            deadline,
+            created_at: Utc::now().timestamp() as u64,
+        }
+    }
 }

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -13,9 +13,12 @@ use std::{
 };
 use uuid::Uuid;
 
+use crate::event::ContactPaymentRequestPayload;
+
 pub type Seed = [u8; 64];
 
 pub type PaymentResultCallback = Arc<dyn Fn(Option<TransactionId>) + Send + Sync + 'static>;
+pub type PendingPaymentSubscriptionCallback = Arc<dyn Fn(Uuid) + Send + Sync + 'static>;
 
 #[derive(Default, Debug, Clone)]
 pub struct SendSummary {
@@ -76,6 +79,51 @@ pub struct MintSummary {
     pub expiry: u64,
 }
 
+#[derive(Debug, Clone)]
+pub struct PendingPaymentRequest {
+    pub id: Uuid,
+    pub node_id: NodeId,
+    pub amount: Amount,
+    pub unit: CurrencyUnit,
+    pub description: Option<String>,
+    pub deadline: Option<u64>,
+    pub created_at: u64,
+}
+
+impl PendingPaymentRequest {
+    pub fn new(
+        node_id: NodeId,
+        amount: Amount,
+        unit: CurrencyUnit,
+        description: Option<String>,
+        deadline: Option<u64>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            node_id,
+            amount,
+            unit,
+            description,
+            deadline,
+            created_at: Utc::now().timestamp() as u64,
+        }
+    }
+}
+
+impl From<ContactPaymentRequestPayload> for PendingPaymentRequest {
+    fn from(value: ContactPaymentRequestPayload) -> Self {
+        Self {
+            id: value.id,
+            node_id: value.sender,
+            amount: value.amount,
+            unit: value.unit,
+            description: value.memo,
+            deadline: value.deadline,
+            created_at: value.created_at,
+        }
+    }
+}
+
 #[derive(strum::EnumString, strum::Display, Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum PaymentType {
     #[default]
@@ -133,6 +181,12 @@ pub const CONTACT_NODE_ID_METADATA_KEY: &str = "contact_node_id";
 pub fn get_contact_node_id(metas: &HashMap<String, String>) -> Option<NodeId> {
     let node_id = metas.get(CONTACT_NODE_ID_METADATA_KEY)?;
     NodeId::from_str(node_id).ok()
+}
+
+pub const PAYMENT_REQUEST_ID_METADATA_KEY: &str = "payment_request_id";
+pub fn get_payment_request_id(metas: &HashMap<String, String>) -> Option<Uuid> {
+    let id = metas.get(PAYMENT_REQUEST_ID_METADATA_KEY)?;
+    Uuid::from_str(id).ok()
 }
 
 impl std::convert::From<SendSummary> for PaymentSummary {

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -1,6 +1,6 @@
 use bcr_wallet_core::types::{
-    ListTransactionsResult, PaymentResultCallback, get_btc_tx_id, get_contact_node_id,
-    get_payment_type, get_transaction_status,
+    ListTransactionsResult, PaymentResultCallback, PendingPaymentSubscriptionCallback,
+    get_btc_tx_id, get_contact_node_id, get_payment_type, get_transaction_status,
 };
 use nostr::RelayUrl;
 use once_cell::sync::Lazy;
@@ -761,6 +761,140 @@ pub async fn wallet_list_contacts(
 }
 
 #[frb]
+pub async fn wallet_request_payment_from_contact(
+    req: WalletRequestPaymentFromContactRequest,
+) -> Result<WalletRequestPaymentFromContactResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let res = app_state
+        .wallet_request_payment_from_contact(
+            req.wallet_id,
+            req.node_id,
+            req.amount,
+            req.description,
+            req.deadline,
+        )
+        .await?;
+    Ok(WalletRequestPaymentFromContactResponse {
+        payment_request_id: res.to_string(),
+    })
+}
+
+#[frb]
+pub async fn wallet_list_pending_payment_requests(
+    req: WalletListPendingPaymentRequestsRequest,
+) -> Result<WalletListPendingPaymentRequestsResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let res = app_state
+        .wallet_list_pending_payment_requests(req.wallet_id)
+        .await?;
+    Ok(WalletListPendingPaymentRequestsResponse {
+        pending_payment_requests: res.into_iter().map(|p| p.into()).collect(),
+    })
+}
+
+#[frb]
+pub async fn wallet_get_pending_payment_request(
+    req: WalletGetPendingPaymentRequestRequest,
+) -> Result<WalletGetPendingPaymentRequestResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let res = app_state
+        .wallet_get_pending_payment_request(req.wallet_id, req.pending_payment_request_id)
+        .await?;
+    Ok(WalletGetPendingPaymentRequestResponse {
+        pending_payment_request: res.into(),
+    })
+}
+
+#[frb]
+pub async fn wallet_prepare_pay_pending_payment_request(
+    req: WalletPreparePayPendingPaymentRequestRequest,
+) -> Result<WalletPreparePaymentResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let payment_summary = app_state
+        .wallet_prepare_pay_pending_payment_request(req.wallet_id, req.pending_payment_request_id)
+        .await?;
+    Ok(WalletPreparePaymentResponse {
+        payment_summary: PaymentSummary {
+            request_id: payment_summary.request_id.to_string(),
+            unit: payment_summary.unit.to_string(),
+            amount: u64::from(payment_summary.amount),
+            fees: u64::from(payment_summary.fees),
+            reserved_fees: u64::from(payment_summary.reserved_fees),
+            expiry: payment_summary.expiry,
+            ptype: PaymentType::from(bcr_wallet_core::types::PaymentType::from(
+                payment_summary.ptype,
+            )),
+        },
+    })
+}
+
+#[frb]
+pub async fn wallet_pay_pending_payment_request(
+    req: WalletPayRequest,
+) -> Result<WalletTransactionIdResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let res = app_state
+        .wallet_pay_pending_payment_request(req.wallet_id, req.rid)
+        .await?;
+    Ok(WalletTransactionIdResponse {
+        tx_id: res.to_string(),
+    })
+}
+
+#[frb]
+pub async fn wallet_reject_pending_payment_request(
+    req: WalletRejectPendingPaymentRequestRequest,
+) -> Result<WalletRejectPendingPaymentRequestResponse, WalletError> {
+    let app_state = get_app_state().await;
+    app_state
+        .wallet_reject_pending_payment_request(
+            req.wallet_id,
+            req.pending_payment_request_id.clone(),
+        )
+        .await?;
+    Ok(WalletRejectPendingPaymentRequestResponse {
+        pending_payment_request_id: req.pending_payment_request_id.clone(),
+    })
+}
+
+#[frb]
+pub async fn wallet_subscribe_to_pending_payment_requests(
+    req: WalletSubscribeToPendingPaymentRequestsRequest,
+    result_callback: impl Fn(WalletPendingPaymentRequestResponse) -> DartFnFuture<()>
+    + Send
+    + Sync
+    + 'static,
+) -> Result<WalletPaymentCheckHandle, WalletError> {
+    let app_state = get_app_state().await;
+
+    let dart_callback = Arc::new(result_callback);
+    let callback: PendingPaymentSubscriptionCallback = Arc::new(move |id| {
+        let dart_callback = dart_callback.clone();
+        flutter_rust_bridge::spawn(async move {
+            let _ = dart_callback(WalletPendingPaymentRequestResponse { id: id.to_string() }).await;
+        });
+    });
+
+    let cancel_token = CancellationToken::new();
+    let handle = WalletPaymentCheckHandle {
+        cancel_token: cancel_token.clone(),
+    };
+    flutter_rust_bridge::spawn(async move {
+        if let Err(e) = app_state
+            .wallet_subscribe_to_pending_payment_requests(
+                req.wallet_id,
+                cancel_token,
+                callback.clone(),
+            )
+            .await
+        {
+            error!("Error during wallet_subscribe_to_pending_payment_requests: {e}");
+        }
+    });
+    Ok(handle)
+}
+
+#[frb]
 pub async fn wallet_dev_mode_get_detailed_balance(
     req: WalletRequest,
 ) -> Result<WalletDevModeDetailedBalanceResponse, WalletError> {
@@ -999,6 +1133,11 @@ pub struct WalletMaybeTransactionIdResponse {
     pub tx_id: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct WalletPendingPaymentRequestResponse {
+    pub id: String,
+}
+
 #[derive(Clone)]
 pub struct WalletPaymentCheckHandle {
     cancel_token: CancellationToken,
@@ -1120,6 +1259,31 @@ impl From<bcr_common::wire::common::ProtestStatus> for ProtestStatus {
         match s {
             bcr_common::wire::common::ProtestStatus::Resolved => ProtestStatus::Resolved,
             bcr_common::wire::common::ProtestStatus::Rabid => ProtestStatus::Rabid,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingPaymentRequest {
+    pub id: String,
+    pub node_id: String,
+    pub amount: u64,
+    pub unit: String,
+    pub description: Option<String>,
+    pub deadline: Option<u64>,
+    pub created_at: u64,
+}
+
+impl From<bcr_wallet_core::types::PendingPaymentRequest> for PendingPaymentRequest {
+    fn from(value: bcr_wallet_core::types::PendingPaymentRequest) -> Self {
+        Self {
+            id: value.id.to_string(),
+            node_id: value.node_id.to_string(),
+            amount: value.amount.to_u64(),
+            unit: value.unit.to_string(),
+            description: value.description,
+            deadline: value.deadline,
+            created_at: value.created_at,
         }
     }
 }
@@ -1630,6 +1794,63 @@ pub struct WalletListContactsResponse {
     pub contacts: Vec<Contact>,
 }
 
+#[derive(Debug, Clone)]
+pub struct WalletRequestPaymentFromContactRequest {
+    pub wallet_id: String,
+    pub node_id: String,
+    pub amount: u64,
+    pub description: Option<String>,
+    pub deadline: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletRequestPaymentFromContactResponse {
+    pub payment_request_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletListPendingPaymentRequestsRequest {
+    pub wallet_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletSubscribeToPendingPaymentRequestsRequest {
+    pub wallet_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletListPendingPaymentRequestsResponse {
+    pub pending_payment_requests: Vec<PendingPaymentRequest>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletGetPendingPaymentRequestRequest {
+    pub wallet_id: String,
+    pub pending_payment_request_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletGetPendingPaymentRequestResponse {
+    pub pending_payment_request: PendingPaymentRequest,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletPreparePayPendingPaymentRequestRequest {
+    pub wallet_id: String,
+    pub pending_payment_request_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletRejectPendingPaymentRequestRequest {
+    pub wallet_id: String,
+    pub pending_payment_request_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletRejectPendingPaymentRequestResponse {
+    pub pending_payment_request_id: String,
+}
+
 // -------------------------------------------------------------- Errors
 #[derive(Debug, Clone)]
 pub struct WalletError {
@@ -1688,6 +1909,7 @@ pub enum WalletErrorCode {
     Network,
     WalletNotFound,
     ContactNotFound,
+    PendingPaymentRequestNotFound,
     ContactAlreadyExists,
     EmptyToken,
     InvalidToken,
@@ -1759,8 +1981,12 @@ impl From<BcrWalletError> for WalletError {
             BcrWalletError::ContactNotFound(id) => {
                 WalletError::not_found(id.to_string(), WalletErrorCode::ContactNotFound)
             }
+            BcrWalletError::PendingPaymentRequestNotFound(id) => WalletError::not_found(
+                id.to_string(),
+                WalletErrorCode::PendingPaymentRequestNotFound,
+            ),
             BcrWalletError::ContactAlreadyExists(_) => {
-                WalletError::bad_request(value.to_string(), WalletErrorCode::ContactNotFound)
+                WalletError::bad_request(value.to_string(), WalletErrorCode::ContactAlreadyExists)
             }
             BcrWalletError::WalletUniqueId(_) => {
                 WalletError::bad_request(value.to_string(), WalletErrorCode::WalletUniqueId)

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1861160958;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1755304891;
 
 // Section: executor
 
@@ -1166,6 +1166,44 @@ fn wire__crate__api__wallet_get_node_id_impl(
         },
     )
 }
+fn wire__crate__api__wallet_get_pending_payment_request_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_get_pending_payment_request",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req =
+                <crate::api::WalletGetPendingPaymentRequestRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::wallet_get_pending_payment_request(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet_get_status_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1340,6 +1378,45 @@ fn wire__crate__api__wallet_list_contacts_impl(
                 transform_result_sse::<_, crate::api::WalletError>(
                     (move || async move {
                         let output_ok = crate::api::wallet_list_contacts(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet_list_pending_payment_requests_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_list_pending_payment_requests",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::WalletListPendingPaymentRequestsRequest>::sse_decode(
+                &mut deserializer,
+            );
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::wallet_list_pending_payment_requests(api_req).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -1635,6 +1712,43 @@ fn wire__crate__api__wallet_pay_by_token_impl(
         },
     )
 }
+fn wire__crate__api__wallet_pay_pending_payment_request_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_pay_pending_payment_request",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::WalletPayRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::wallet_pay_pending_payment_request(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet_prepare_melt_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1700,6 +1814,45 @@ fn wire__crate__api__wallet_prepare_pay_by_token_impl(
                 transform_result_sse::<_, crate::api::WalletError>(
                     (move || async move {
                         let output_ok = crate::api::wallet_prepare_pay_by_token(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet_prepare_pay_pending_payment_request_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_prepare_pay_pending_payment_request",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::WalletPreparePayPendingPaymentRequestRequest>::sse_decode(
+                &mut deserializer,
+            );
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::wallet_prepare_pay_pending_payment_request(api_req).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -2072,6 +2225,83 @@ fn wire__crate__api__wallet_refresh_transactions_impl(
         },
     )
 }
+fn wire__crate__api__wallet_reject_pending_payment_request_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_reject_pending_payment_request",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::WalletRejectPendingPaymentRequestRequest>::sse_decode(
+                &mut deserializer,
+            );
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::wallet_reject_pending_payment_request(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet_request_payment_from_contact_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_request_payment_from_contact",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req =
+                <crate::api::WalletRequestPaymentFromContactRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::wallet_request_payment_from_contact(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet_restore_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2108,6 +2338,22 @@ fn wire__crate__api__wallet_restore_impl(
         },
     )
 }
+fn wire__crate__api__wallet_subscribe_to_pending_payment_requests_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "wallet_subscribe_to_pending_payment_requests", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { 
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::WalletSubscribeToPendingPaymentRequestsRequest>::sse_decode(&mut deserializer);
+let api_result_callback = decode_DartFn_Inputs_wallet_pending_payment_request_response_Output_unit_AnyhowException(<flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer));deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, crate::api::WalletError>((move || async move {
+                         let output_ok = crate::api::wallet_subscribe_to_pending_payment_requests(api_req, api_result_callback).await?;   Ok(output_ok)
+                    })().await)
+                } })
+}
 
 // Section: related_funcs
 
@@ -2141,6 +2387,42 @@ fn decode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowE
     }
 
     move |arg0: crate::api::WalletMaybeTransactionIdResponse| {
+        flutter_rust_bridge::for_generated::convert_into_dart_fn_future(body(
+            dart_opaque.clone(),
+            arg0,
+        ))
+    }
+}
+fn decode_DartFn_Inputs_wallet_pending_payment_request_response_Output_unit_AnyhowException(
+    dart_opaque: flutter_rust_bridge::DartOpaque,
+) -> impl Fn(crate::api::WalletPendingPaymentRequestResponse) -> flutter_rust_bridge::DartFnFuture<()>
+{
+    use flutter_rust_bridge::IntoDart;
+
+    async fn body(
+        dart_opaque: flutter_rust_bridge::DartOpaque,
+        arg0: crate::api::WalletPendingPaymentRequestResponse,
+    ) -> () {
+        let args = vec![arg0.into_into_dart().into_dart()];
+        let message = FLUTTER_RUST_BRIDGE_HANDLER
+            .dart_fn_invoke(dart_opaque, args)
+            .await;
+
+        let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+        let action = deserializer.cursor.read_u8().unwrap();
+        let ans = match action {
+            0 => std::result::Result::Ok(<()>::sse_decode(&mut deserializer)),
+            1 => std::result::Result::Err(
+                <flutter_rust_bridge::for_generated::anyhow::Error>::sse_decode(&mut deserializer),
+            ),
+            _ => unreachable!(),
+        };
+        deserializer.end();
+        let ans = ans.expect("Dart throws exception but Rust side assume it is not failable");
+        ans
+    }
+
+    move |arg0: crate::api::WalletPendingPaymentRequestResponse| {
         flutter_rust_bridge::for_generated::convert_into_dart_fn_future(body(
             dart_opaque.clone(),
             arg0,
@@ -2355,6 +2637,20 @@ impl SseDecode for Vec<crate::api::PaymentType> {
         let mut ans_ = Vec::with_capacity(len_ as usize);
         for idx_ in 0..len_ {
             ans_.push(<crate::api::PaymentType>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<crate::api::PendingPaymentRequest> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::PendingPaymentRequest>::sse_decode(
+                deserializer,
+            ));
         }
         return ans_;
     }
@@ -2587,6 +2883,28 @@ impl SseDecode for crate::api::PaymentType {
             4 => crate::api::PaymentType::Swap,
             5 => crate::api::PaymentType::Contact,
             _ => unreachable!("Invalid variant for PaymentType: {}", inner),
+        };
+    }
+}
+
+impl SseDecode for crate::api::PendingPaymentRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_id = <String>::sse_decode(deserializer);
+        let mut var_nodeId = <String>::sse_decode(deserializer);
+        let mut var_amount = <u64>::sse_decode(deserializer);
+        let mut var_unit = <String>::sse_decode(deserializer);
+        let mut var_description = <Option<String>>::sse_decode(deserializer);
+        let mut var_deadline = <Option<u64>>::sse_decode(deserializer);
+        let mut var_createdAt = <u64>::sse_decode(deserializer);
+        return crate::api::PendingPaymentRequest {
+            id: var_id,
+            node_id: var_nodeId,
+            amount: var_amount,
+            unit: var_unit,
+            description: var_description,
+            deadline: var_deadline,
+            created_at: var_createdAt,
         };
     }
 }
@@ -2980,38 +3298,39 @@ impl SseDecode for crate::api::WalletErrorCode {
             1 => crate::api::WalletErrorCode::Network,
             2 => crate::api::WalletErrorCode::WalletNotFound,
             3 => crate::api::WalletErrorCode::ContactNotFound,
-            4 => crate::api::WalletErrorCode::ContactAlreadyExists,
-            5 => crate::api::WalletErrorCode::EmptyToken,
-            6 => crate::api::WalletErrorCode::InvalidToken,
-            7 => crate::api::WalletErrorCode::CashuMintUrl,
-            8 => crate::api::WalletErrorCode::Url,
-            9 => crate::api::WalletErrorCode::InsufficientBalance,
-            10 => crate::api::WalletErrorCode::NoActiveKeyset,
-            11 => crate::api::WalletErrorCode::UnknownKeysetId,
-            12 => crate::api::WalletErrorCode::InvalidCurrencyUnit,
-            13 => crate::api::WalletErrorCode::NoPrepareRef,
-            14 => crate::api::WalletErrorCode::InactiveKeyset,
-            15 => crate::api::WalletErrorCode::NoDebitCurrencyInMint,
-            16 => crate::api::WalletErrorCode::InvalidNetwork,
-            17 => crate::api::WalletErrorCode::MissingAmount,
-            18 => crate::api::WalletErrorCode::UnknownPaymentRequest,
-            19 => crate::api::WalletErrorCode::Unsupported,
-            20 => crate::api::WalletErrorCode::TransactionCantBeReclaimed,
-            21 => crate::api::WalletErrorCode::InsufficientOnChainMeltAmount,
-            22 => crate::api::WalletErrorCode::InsufficientOnChainMintAmount,
-            23 => crate::api::WalletErrorCode::NoDevMode,
-            24 => crate::api::WalletErrorCode::InvalidBitcoinAddress,
-            25 => crate::api::WalletErrorCode::InvalidMnemonic,
-            26 => crate::api::WalletErrorCode::InvalidTransactionId,
-            27 => crate::api::WalletErrorCode::InvalidCursor,
-            28 => crate::api::WalletErrorCode::SortMismatch,
-            29 => crate::api::WalletErrorCode::MnemonicNotFound,
-            30 => crate::api::WalletErrorCode::WalletUniqueName,
-            31 => crate::api::WalletErrorCode::WalletUniqueId,
-            32 => crate::api::WalletErrorCode::InvalidNodeId,
-            33 => crate::api::WalletErrorCode::InvalidBillId,
-            34 => crate::api::WalletErrorCode::InvalidName,
-            35 => crate::api::WalletErrorCode::EmptyName,
+            4 => crate::api::WalletErrorCode::PendingPaymentRequestNotFound,
+            5 => crate::api::WalletErrorCode::ContactAlreadyExists,
+            6 => crate::api::WalletErrorCode::EmptyToken,
+            7 => crate::api::WalletErrorCode::InvalidToken,
+            8 => crate::api::WalletErrorCode::CashuMintUrl,
+            9 => crate::api::WalletErrorCode::Url,
+            10 => crate::api::WalletErrorCode::InsufficientBalance,
+            11 => crate::api::WalletErrorCode::NoActiveKeyset,
+            12 => crate::api::WalletErrorCode::UnknownKeysetId,
+            13 => crate::api::WalletErrorCode::InvalidCurrencyUnit,
+            14 => crate::api::WalletErrorCode::NoPrepareRef,
+            15 => crate::api::WalletErrorCode::InactiveKeyset,
+            16 => crate::api::WalletErrorCode::NoDebitCurrencyInMint,
+            17 => crate::api::WalletErrorCode::InvalidNetwork,
+            18 => crate::api::WalletErrorCode::MissingAmount,
+            19 => crate::api::WalletErrorCode::UnknownPaymentRequest,
+            20 => crate::api::WalletErrorCode::Unsupported,
+            21 => crate::api::WalletErrorCode::TransactionCantBeReclaimed,
+            22 => crate::api::WalletErrorCode::InsufficientOnChainMeltAmount,
+            23 => crate::api::WalletErrorCode::InsufficientOnChainMintAmount,
+            24 => crate::api::WalletErrorCode::NoDevMode,
+            25 => crate::api::WalletErrorCode::InvalidBitcoinAddress,
+            26 => crate::api::WalletErrorCode::InvalidMnemonic,
+            27 => crate::api::WalletErrorCode::InvalidTransactionId,
+            28 => crate::api::WalletErrorCode::InvalidCursor,
+            29 => crate::api::WalletErrorCode::SortMismatch,
+            30 => crate::api::WalletErrorCode::MnemonicNotFound,
+            31 => crate::api::WalletErrorCode::WalletUniqueName,
+            32 => crate::api::WalletErrorCode::WalletUniqueId,
+            33 => crate::api::WalletErrorCode::InvalidNodeId,
+            34 => crate::api::WalletErrorCode::InvalidBillId,
+            35 => crate::api::WalletErrorCode::InvalidName,
+            36 => crate::api::WalletErrorCode::EmptyName,
             _ => unreachable!("Invalid variant for WalletErrorCode: {}", inner),
         };
     }
@@ -3078,6 +3397,29 @@ impl SseDecode for crate::api::WalletGetContactResponse {
     }
 }
 
+impl SseDecode for crate::api::WalletGetPendingPaymentRequestRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_walletId = <String>::sse_decode(deserializer);
+        let mut var_pendingPaymentRequestId = <String>::sse_decode(deserializer);
+        return crate::api::WalletGetPendingPaymentRequestRequest {
+            wallet_id: var_walletId,
+            pending_payment_request_id: var_pendingPaymentRequestId,
+        };
+    }
+}
+
+impl SseDecode for crate::api::WalletGetPendingPaymentRequestResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_pendingPaymentRequest =
+            <crate::api::PendingPaymentRequest>::sse_decode(deserializer);
+        return crate::api::WalletGetPendingPaymentRequestResponse {
+            pending_payment_request: var_pendingPaymentRequest,
+        };
+    }
+}
+
 impl SseDecode for crate::api::WalletIdForMnemonicAndNetworkRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3136,6 +3478,27 @@ impl SseDecode for crate::api::WalletListContactsResponse {
         let mut var_contacts = <Vec<crate::api::Contact>>::sse_decode(deserializer);
         return crate::api::WalletListContactsResponse {
             contacts: var_contacts,
+        };
+    }
+}
+
+impl SseDecode for crate::api::WalletListPendingPaymentRequestsRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_walletId = <String>::sse_decode(deserializer);
+        return crate::api::WalletListPendingPaymentRequestsRequest {
+            wallet_id: var_walletId,
+        };
+    }
+}
+
+impl SseDecode for crate::api::WalletListPendingPaymentRequestsResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_pendingPaymentRequests =
+            <Vec<crate::api::PendingPaymentRequest>>::sse_decode(deserializer);
+        return crate::api::WalletListPendingPaymentRequestsResponse {
+            pending_payment_requests: var_pendingPaymentRequests,
         };
     }
 }
@@ -3272,6 +3635,14 @@ impl SseDecode for crate::api::WalletPaymentByTokenResponse {
     }
 }
 
+impl SseDecode for crate::api::WalletPendingPaymentRequestResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_id = <String>::sse_decode(deserializer);
+        return crate::api::WalletPendingPaymentRequestResponse { id: var_id };
+    }
+}
+
 impl SseDecode for crate::api::WalletPrepareMeltRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3284,6 +3655,18 @@ impl SseDecode for crate::api::WalletPrepareMeltRequest {
             amount: var_amount,
             address: var_address,
             description: var_description,
+        };
+    }
+}
+
+impl SseDecode for crate::api::WalletPreparePayPendingPaymentRequestRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_walletId = <String>::sse_decode(deserializer);
+        let mut var_pendingPaymentRequestId = <String>::sse_decode(deserializer);
+        return crate::api::WalletPreparePayPendingPaymentRequestRequest {
+            wallet_id: var_walletId,
+            pending_payment_request_id: var_pendingPaymentRequestId,
         };
     }
 }
@@ -3494,11 +3877,71 @@ impl SseDecode for crate::api::WalletRefreshTransactionsResponse {
     }
 }
 
+impl SseDecode for crate::api::WalletRejectPendingPaymentRequestRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_walletId = <String>::sse_decode(deserializer);
+        let mut var_pendingPaymentRequestId = <String>::sse_decode(deserializer);
+        return crate::api::WalletRejectPendingPaymentRequestRequest {
+            wallet_id: var_walletId,
+            pending_payment_request_id: var_pendingPaymentRequestId,
+        };
+    }
+}
+
+impl SseDecode for crate::api::WalletRejectPendingPaymentRequestResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_pendingPaymentRequestId = <String>::sse_decode(deserializer);
+        return crate::api::WalletRejectPendingPaymentRequestResponse {
+            pending_payment_request_id: var_pendingPaymentRequestId,
+        };
+    }
+}
+
 impl SseDecode for crate::api::WalletRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_walletId = <String>::sse_decode(deserializer);
         return crate::api::WalletRequest {
+            wallet_id: var_walletId,
+        };
+    }
+}
+
+impl SseDecode for crate::api::WalletRequestPaymentFromContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_walletId = <String>::sse_decode(deserializer);
+        let mut var_nodeId = <String>::sse_decode(deserializer);
+        let mut var_amount = <u64>::sse_decode(deserializer);
+        let mut var_description = <Option<String>>::sse_decode(deserializer);
+        let mut var_deadline = <Option<u64>>::sse_decode(deserializer);
+        return crate::api::WalletRequestPaymentFromContactRequest {
+            wallet_id: var_walletId,
+            node_id: var_nodeId,
+            amount: var_amount,
+            description: var_description,
+            deadline: var_deadline,
+        };
+    }
+}
+
+impl SseDecode for crate::api::WalletRequestPaymentFromContactResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_paymentRequestId = <String>::sse_decode(deserializer);
+        return crate::api::WalletRequestPaymentFromContactResponse {
+            payment_request_id: var_paymentRequestId,
+        };
+    }
+}
+
+impl SseDecode for crate::api::WalletSubscribeToPendingPaymentRequestsRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_walletId = <String>::sse_decode(deserializer);
+        return crate::api::WalletSubscribeToPendingPaymentRequestsRequest {
             wallet_id: var_walletId,
         };
     }
@@ -3607,44 +4050,86 @@ fn pde_ffi_dispatcher_primary_impl(
         30 => wire__crate__api__wallet_get_mint_url_impl(port, ptr, rust_vec_len, data_len),
         31 => wire__crate__api__wallet_get_name_impl(port, ptr, rust_vec_len, data_len),
         32 => wire__crate__api__wallet_get_node_id_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__wallet_get_status_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__wallet_get_transaction_ids_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__wallet_get_transactions_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__wallet_id_for_mnemonic_and_network_impl(
+        33 => wire__crate__api__wallet_get_pending_payment_request_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        37 => wire__crate__api__wallet_list_contacts_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__wallet_load_transaction_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__wallet_melt_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__wallet_migrate_rabid_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__wallet_mint_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__wallet_mint_is_offline_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__wallet_mint_is_rabid_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__wallet_pay_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__wallet_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__wallet_prepare_melt_impl(port, ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__wallet_prepare_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__wallet_prepare_payment_impl(port, ptr, rust_vec_len, data_len),
-        49 => {
+        34 => wire__crate__api__wallet_get_status_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__wallet_get_transaction_ids_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__wallet_get_transactions_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__wallet_id_for_mnemonic_and_network_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        38 => wire__crate__api__wallet_list_contacts_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__wallet_list_pending_payment_requests_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        40 => wire__crate__api__wallet_load_transaction_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__wallet_melt_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__wallet_migrate_rabid_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__wallet_mint_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__wallet_mint_is_offline_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__wallet_mint_is_rabid_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__wallet_pay_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__wallet_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__wallet_pay_pending_payment_request_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        49 => wire__crate__api__wallet_prepare_melt_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__wallet_prepare_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
+        51 => wire__crate__api__wallet_prepare_pay_pending_payment_request_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        52 => wire__crate__api__wallet_prepare_payment_impl(port, ptr, rust_vec_len, data_len),
+        53 => {
             wire__crate__api__wallet_prepare_payment_request_impl(port, ptr, rust_vec_len, data_len)
         }
-        50 => wire__crate__api__wallet_protest_melt_impl(port, ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__wallet_protest_mint_impl(port, ptr, rust_vec_len, data_len),
-        52 => wire__crate__api__wallet_protest_swap_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__wallet_receive_impl(port, ptr, rust_vec_len, data_len),
-        54 => wire__crate__api__wallet_reclaim_transaction_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__wallet_recover_pending_stale_proofs_impl(
+        54 => wire__crate__api__wallet_protest_melt_impl(port, ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__wallet_protest_mint_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__wallet_protest_swap_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__wallet_receive_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__wallet_reclaim_transaction_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__wallet_recover_pending_stale_proofs_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        56 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__wallet_reject_pending_payment_request_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        63 => wire__crate__api__wallet_request_payment_from_contact_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        64 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__wallet_subscribe_to_pending_payment_requests_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
         _ => unreachable!(),
     }
 }
@@ -3934,6 +4419,32 @@ impl flutter_rust_bridge::IntoDart for crate::api::PaymentType {
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::PaymentType {}
 impl flutter_rust_bridge::IntoIntoDart<crate::api::PaymentType> for crate::api::PaymentType {
     fn into_into_dart(self) -> crate::api::PaymentType {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::PendingPaymentRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.id.into_into_dart().into_dart(),
+            self.node_id.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
+            self.unit.into_into_dart().into_dart(),
+            self.description.into_into_dart().into_dart(),
+            self.deadline.into_into_dart().into_dart(),
+            self.created_at.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::PendingPaymentRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::PendingPaymentRequest>
+    for crate::api::PendingPaymentRequest
+{
+    fn into_into_dart(self) -> crate::api::PendingPaymentRequest {
         self
     }
 }
@@ -4429,38 +4940,39 @@ impl flutter_rust_bridge::IntoDart for crate::api::WalletErrorCode {
             Self::Network => 1.into_dart(),
             Self::WalletNotFound => 2.into_dart(),
             Self::ContactNotFound => 3.into_dart(),
-            Self::ContactAlreadyExists => 4.into_dart(),
-            Self::EmptyToken => 5.into_dart(),
-            Self::InvalidToken => 6.into_dart(),
-            Self::CashuMintUrl => 7.into_dart(),
-            Self::Url => 8.into_dart(),
-            Self::InsufficientBalance => 9.into_dart(),
-            Self::NoActiveKeyset => 10.into_dart(),
-            Self::UnknownKeysetId => 11.into_dart(),
-            Self::InvalidCurrencyUnit => 12.into_dart(),
-            Self::NoPrepareRef => 13.into_dart(),
-            Self::InactiveKeyset => 14.into_dart(),
-            Self::NoDebitCurrencyInMint => 15.into_dart(),
-            Self::InvalidNetwork => 16.into_dart(),
-            Self::MissingAmount => 17.into_dart(),
-            Self::UnknownPaymentRequest => 18.into_dart(),
-            Self::Unsupported => 19.into_dart(),
-            Self::TransactionCantBeReclaimed => 20.into_dart(),
-            Self::InsufficientOnChainMeltAmount => 21.into_dart(),
-            Self::InsufficientOnChainMintAmount => 22.into_dart(),
-            Self::NoDevMode => 23.into_dart(),
-            Self::InvalidBitcoinAddress => 24.into_dart(),
-            Self::InvalidMnemonic => 25.into_dart(),
-            Self::InvalidTransactionId => 26.into_dart(),
-            Self::InvalidCursor => 27.into_dart(),
-            Self::SortMismatch => 28.into_dart(),
-            Self::MnemonicNotFound => 29.into_dart(),
-            Self::WalletUniqueName => 30.into_dart(),
-            Self::WalletUniqueId => 31.into_dart(),
-            Self::InvalidNodeId => 32.into_dart(),
-            Self::InvalidBillId => 33.into_dart(),
-            Self::InvalidName => 34.into_dart(),
-            Self::EmptyName => 35.into_dart(),
+            Self::PendingPaymentRequestNotFound => 4.into_dart(),
+            Self::ContactAlreadyExists => 5.into_dart(),
+            Self::EmptyToken => 6.into_dart(),
+            Self::InvalidToken => 7.into_dart(),
+            Self::CashuMintUrl => 8.into_dart(),
+            Self::Url => 9.into_dart(),
+            Self::InsufficientBalance => 10.into_dart(),
+            Self::NoActiveKeyset => 11.into_dart(),
+            Self::UnknownKeysetId => 12.into_dart(),
+            Self::InvalidCurrencyUnit => 13.into_dart(),
+            Self::NoPrepareRef => 14.into_dart(),
+            Self::InactiveKeyset => 15.into_dart(),
+            Self::NoDebitCurrencyInMint => 16.into_dart(),
+            Self::InvalidNetwork => 17.into_dart(),
+            Self::MissingAmount => 18.into_dart(),
+            Self::UnknownPaymentRequest => 19.into_dart(),
+            Self::Unsupported => 20.into_dart(),
+            Self::TransactionCantBeReclaimed => 21.into_dart(),
+            Self::InsufficientOnChainMeltAmount => 22.into_dart(),
+            Self::InsufficientOnChainMintAmount => 23.into_dart(),
+            Self::NoDevMode => 24.into_dart(),
+            Self::InvalidBitcoinAddress => 25.into_dart(),
+            Self::InvalidMnemonic => 26.into_dart(),
+            Self::InvalidTransactionId => 27.into_dart(),
+            Self::InvalidCursor => 28.into_dart(),
+            Self::SortMismatch => 29.into_dart(),
+            Self::MnemonicNotFound => 30.into_dart(),
+            Self::WalletUniqueName => 31.into_dart(),
+            Self::WalletUniqueId => 32.into_dart(),
+            Self::InvalidNodeId => 33.into_dart(),
+            Self::InvalidBillId => 34.into_dart(),
+            Self::InvalidName => 35.into_dart(),
+            Self::EmptyName => 36.into_dart(),
             _ => unreachable!(),
         }
     }
@@ -4553,6 +5065,44 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletGetContactResponse>
     for crate::api::WalletGetContactResponse
 {
     fn into_into_dart(self) -> crate::api::WalletGetContactResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletGetPendingPaymentRequestRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.wallet_id.into_into_dart().into_dart(),
+            self.pending_payment_request_id.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletGetPendingPaymentRequestRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletGetPendingPaymentRequestRequest>
+    for crate::api::WalletGetPendingPaymentRequestRequest
+{
+    fn into_into_dart(self) -> crate::api::WalletGetPendingPaymentRequestRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletGetPendingPaymentRequestResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.pending_payment_request.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletGetPendingPaymentRequestResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletGetPendingPaymentRequestResponse>
+    for crate::api::WalletGetPendingPaymentRequestResponse
+{
+    fn into_into_dart(self) -> crate::api::WalletGetPendingPaymentRequestResponse {
         self
     }
 }
@@ -4653,6 +5203,40 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletListContactsResponse>
     for crate::api::WalletListContactsResponse
 {
     fn into_into_dart(self) -> crate::api::WalletListContactsResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletListPendingPaymentRequestsRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.wallet_id.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletListPendingPaymentRequestsRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletListPendingPaymentRequestsRequest>
+    for crate::api::WalletListPendingPaymentRequestsRequest
+{
+    fn into_into_dart(self) -> crate::api::WalletListPendingPaymentRequestsRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletListPendingPaymentRequestsResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.pending_payment_requests.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletListPendingPaymentRequestsResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletListPendingPaymentRequestsResponse>
+    for crate::api::WalletListPendingPaymentRequestsResponse
+{
+    fn into_into_dart(self) -> crate::api::WalletListPendingPaymentRequestsResponse {
         self
     }
 }
@@ -4872,6 +5456,23 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletPaymentByTokenResponse>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletPendingPaymentRequestResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.id.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletPendingPaymentRequestResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletPendingPaymentRequestResponse>
+    for crate::api::WalletPendingPaymentRequestResponse
+{
+    fn into_into_dart(self) -> crate::api::WalletPendingPaymentRequestResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::WalletPrepareMeltRequest {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -4891,6 +5492,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletPrepareMeltRequest>
     for crate::api::WalletPrepareMeltRequest
 {
     fn into_into_dart(self) -> crate::api::WalletPrepareMeltRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletPreparePayPendingPaymentRequestRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.wallet_id.into_into_dart().into_dart(),
+            self.pending_payment_request_id.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletPreparePayPendingPaymentRequestRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletPreparePayPendingPaymentRequestRequest>
+    for crate::api::WalletPreparePayPendingPaymentRequestRequest
+{
+    fn into_into_dart(self) -> crate::api::WalletPreparePayPendingPaymentRequestRequest {
         self
     }
 }
@@ -5252,6 +5874,44 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletRefreshTransactionsResp
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletRejectPendingPaymentRequestRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.wallet_id.into_into_dart().into_dart(),
+            self.pending_payment_request_id.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletRejectPendingPaymentRequestRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletRejectPendingPaymentRequestRequest>
+    for crate::api::WalletRejectPendingPaymentRequestRequest
+{
+    fn into_into_dart(self) -> crate::api::WalletRejectPendingPaymentRequestRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletRejectPendingPaymentRequestResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.pending_payment_request_id.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletRejectPendingPaymentRequestResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletRejectPendingPaymentRequestResponse>
+    for crate::api::WalletRejectPendingPaymentRequestResponse
+{
+    fn into_into_dart(self) -> crate::api::WalletRejectPendingPaymentRequestResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::WalletRequest {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [self.wallet_id.into_into_dart().into_dart()].into_dart()
@@ -5260,6 +5920,64 @@ impl flutter_rust_bridge::IntoDart for crate::api::WalletRequest {
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::WalletRequest {}
 impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletRequest> for crate::api::WalletRequest {
     fn into_into_dart(self) -> crate::api::WalletRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletRequestPaymentFromContactRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.wallet_id.into_into_dart().into_dart(),
+            self.node_id.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
+            self.description.into_into_dart().into_dart(),
+            self.deadline.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletRequestPaymentFromContactRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletRequestPaymentFromContactRequest>
+    for crate::api::WalletRequestPaymentFromContactRequest
+{
+    fn into_into_dart(self) -> crate::api::WalletRequestPaymentFromContactRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletRequestPaymentFromContactResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.payment_request_id.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletRequestPaymentFromContactResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletRequestPaymentFromContactResponse>
+    for crate::api::WalletRequestPaymentFromContactResponse
+{
+    fn into_into_dart(self) -> crate::api::WalletRequestPaymentFromContactResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletSubscribeToPendingPaymentRequestsRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.wallet_id.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletSubscribeToPendingPaymentRequestsRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletSubscribeToPendingPaymentRequestsRequest>
+    for crate::api::WalletSubscribeToPendingPaymentRequestsRequest
+{
+    fn into_into_dart(self) -> crate::api::WalletSubscribeToPendingPaymentRequestsRequest {
         self
     }
 }
@@ -5528,6 +6246,16 @@ impl SseEncode for Vec<crate::api::PaymentType> {
     }
 }
 
+impl SseEncode for Vec<crate::api::PendingPaymentRequest> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::PendingPaymentRequest>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<u8> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5713,6 +6441,19 @@ impl SseEncode for crate::api::PaymentType {
             },
             serializer,
         );
+    }
+}
+
+impl SseEncode for crate::api::PendingPaymentRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.id, serializer);
+        <String>::sse_encode(self.node_id, serializer);
+        <u64>::sse_encode(self.amount, serializer);
+        <String>::sse_encode(self.unit, serializer);
+        <Option<String>>::sse_encode(self.description, serializer);
+        <Option<u64>>::sse_encode(self.deadline, serializer);
+        <u64>::sse_encode(self.created_at, serializer);
     }
 }
 
@@ -6026,38 +6767,39 @@ impl SseEncode for crate::api::WalletErrorCode {
                 crate::api::WalletErrorCode::Network => 1,
                 crate::api::WalletErrorCode::WalletNotFound => 2,
                 crate::api::WalletErrorCode::ContactNotFound => 3,
-                crate::api::WalletErrorCode::ContactAlreadyExists => 4,
-                crate::api::WalletErrorCode::EmptyToken => 5,
-                crate::api::WalletErrorCode::InvalidToken => 6,
-                crate::api::WalletErrorCode::CashuMintUrl => 7,
-                crate::api::WalletErrorCode::Url => 8,
-                crate::api::WalletErrorCode::InsufficientBalance => 9,
-                crate::api::WalletErrorCode::NoActiveKeyset => 10,
-                crate::api::WalletErrorCode::UnknownKeysetId => 11,
-                crate::api::WalletErrorCode::InvalidCurrencyUnit => 12,
-                crate::api::WalletErrorCode::NoPrepareRef => 13,
-                crate::api::WalletErrorCode::InactiveKeyset => 14,
-                crate::api::WalletErrorCode::NoDebitCurrencyInMint => 15,
-                crate::api::WalletErrorCode::InvalidNetwork => 16,
-                crate::api::WalletErrorCode::MissingAmount => 17,
-                crate::api::WalletErrorCode::UnknownPaymentRequest => 18,
-                crate::api::WalletErrorCode::Unsupported => 19,
-                crate::api::WalletErrorCode::TransactionCantBeReclaimed => 20,
-                crate::api::WalletErrorCode::InsufficientOnChainMeltAmount => 21,
-                crate::api::WalletErrorCode::InsufficientOnChainMintAmount => 22,
-                crate::api::WalletErrorCode::NoDevMode => 23,
-                crate::api::WalletErrorCode::InvalidBitcoinAddress => 24,
-                crate::api::WalletErrorCode::InvalidMnemonic => 25,
-                crate::api::WalletErrorCode::InvalidTransactionId => 26,
-                crate::api::WalletErrorCode::InvalidCursor => 27,
-                crate::api::WalletErrorCode::SortMismatch => 28,
-                crate::api::WalletErrorCode::MnemonicNotFound => 29,
-                crate::api::WalletErrorCode::WalletUniqueName => 30,
-                crate::api::WalletErrorCode::WalletUniqueId => 31,
-                crate::api::WalletErrorCode::InvalidNodeId => 32,
-                crate::api::WalletErrorCode::InvalidBillId => 33,
-                crate::api::WalletErrorCode::InvalidName => 34,
-                crate::api::WalletErrorCode::EmptyName => 35,
+                crate::api::WalletErrorCode::PendingPaymentRequestNotFound => 4,
+                crate::api::WalletErrorCode::ContactAlreadyExists => 5,
+                crate::api::WalletErrorCode::EmptyToken => 6,
+                crate::api::WalletErrorCode::InvalidToken => 7,
+                crate::api::WalletErrorCode::CashuMintUrl => 8,
+                crate::api::WalletErrorCode::Url => 9,
+                crate::api::WalletErrorCode::InsufficientBalance => 10,
+                crate::api::WalletErrorCode::NoActiveKeyset => 11,
+                crate::api::WalletErrorCode::UnknownKeysetId => 12,
+                crate::api::WalletErrorCode::InvalidCurrencyUnit => 13,
+                crate::api::WalletErrorCode::NoPrepareRef => 14,
+                crate::api::WalletErrorCode::InactiveKeyset => 15,
+                crate::api::WalletErrorCode::NoDebitCurrencyInMint => 16,
+                crate::api::WalletErrorCode::InvalidNetwork => 17,
+                crate::api::WalletErrorCode::MissingAmount => 18,
+                crate::api::WalletErrorCode::UnknownPaymentRequest => 19,
+                crate::api::WalletErrorCode::Unsupported => 20,
+                crate::api::WalletErrorCode::TransactionCantBeReclaimed => 21,
+                crate::api::WalletErrorCode::InsufficientOnChainMeltAmount => 22,
+                crate::api::WalletErrorCode::InsufficientOnChainMintAmount => 23,
+                crate::api::WalletErrorCode::NoDevMode => 24,
+                crate::api::WalletErrorCode::InvalidBitcoinAddress => 25,
+                crate::api::WalletErrorCode::InvalidMnemonic => 26,
+                crate::api::WalletErrorCode::InvalidTransactionId => 27,
+                crate::api::WalletErrorCode::InvalidCursor => 28,
+                crate::api::WalletErrorCode::SortMismatch => 29,
+                crate::api::WalletErrorCode::MnemonicNotFound => 30,
+                crate::api::WalletErrorCode::WalletUniqueName => 31,
+                crate::api::WalletErrorCode::WalletUniqueId => 32,
+                crate::api::WalletErrorCode::InvalidNodeId => 33,
+                crate::api::WalletErrorCode::InvalidBillId => 34,
+                crate::api::WalletErrorCode::InvalidName => 35,
+                crate::api::WalletErrorCode::EmptyName => 36,
                 _ => {
                     unimplemented!("");
                 }
@@ -6115,6 +6857,21 @@ impl SseEncode for crate::api::WalletGetContactResponse {
     }
 }
 
+impl SseEncode for crate::api::WalletGetPendingPaymentRequestRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.wallet_id, serializer);
+        <String>::sse_encode(self.pending_payment_request_id, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletGetPendingPaymentRequestResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::PendingPaymentRequest>::sse_encode(self.pending_payment_request, serializer);
+    }
+}
+
 impl SseEncode for crate::api::WalletIdForMnemonicAndNetworkRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -6153,6 +6910,23 @@ impl SseEncode for crate::api::WalletListContactsResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <Vec<crate::api::Contact>>::sse_encode(self.contacts, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletListPendingPaymentRequestsRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.wallet_id, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletListPendingPaymentRequestsResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<crate::api::PendingPaymentRequest>>::sse_encode(
+            self.pending_payment_requests,
+            serializer,
+        );
     }
 }
 
@@ -6246,6 +7020,13 @@ impl SseEncode for crate::api::WalletPaymentByTokenResponse {
     }
 }
 
+impl SseEncode for crate::api::WalletPendingPaymentRequestResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.id, serializer);
+    }
+}
+
 impl SseEncode for crate::api::WalletPrepareMeltRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -6253,6 +7034,14 @@ impl SseEncode for crate::api::WalletPrepareMeltRequest {
         <u64>::sse_encode(self.amount, serializer);
         <String>::sse_encode(self.address, serializer);
         <Option<String>>::sse_encode(self.description, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletPreparePayPendingPaymentRequestRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.wallet_id, serializer);
+        <String>::sse_encode(self.pending_payment_request_id, serializer);
     }
 }
 
@@ -6397,7 +7186,47 @@ impl SseEncode for crate::api::WalletRefreshTransactionsResponse {
     }
 }
 
+impl SseEncode for crate::api::WalletRejectPendingPaymentRequestRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.wallet_id, serializer);
+        <String>::sse_encode(self.pending_payment_request_id, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletRejectPendingPaymentRequestResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.pending_payment_request_id, serializer);
+    }
+}
+
 impl SseEncode for crate::api::WalletRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.wallet_id, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletRequestPaymentFromContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.wallet_id, serializer);
+        <String>::sse_encode(self.node_id, serializer);
+        <u64>::sse_encode(self.amount, serializer);
+        <Option<String>>::sse_encode(self.description, serializer);
+        <Option<u64>>::sse_encode(self.deadline, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletRequestPaymentFromContactResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.payment_request_id, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletSubscribeToPendingPaymentRequestsRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.wallet_id, serializer);

--- a/crates/bcr-wallet-persistence/src/error.rs
+++ b/crates/bcr-wallet-persistence/src/error.rs
@@ -52,4 +52,6 @@ pub enum Error {
     ContactAlreadyExists(String),
     #[error("Contact not found {0}")]
     ContactNotFound(String),
+    #[error("Pending Payment Request already exists {0}")]
+    PendingPaymentRequestAlreadyExists(String),
 }

--- a/crates/bcr-wallet-persistence/src/lib.rs
+++ b/crates/bcr-wallet-persistence/src/lib.rs
@@ -11,7 +11,10 @@ use bcr_common::cdk_common::wallet::{Transaction, TransactionId};
 use bcr_common::core::NodeId;
 use bcr_wallet_core::contact::Contact;
 use bcr_wallet_core::name::Name;
-use bcr_wallet_core::{SendSync, types::WalletConfig};
+use bcr_wallet_core::{
+    SendSync,
+    types::{PendingPaymentRequest, WalletConfig},
+};
 use bitcoin::secp256k1;
 use nostr::types::Timestamp;
 use std::collections::HashMap;
@@ -185,7 +188,6 @@ pub trait NostrRepository: SendSync {
 }
 
 //////////////////////////////////////////// Contact
-
 #[cfg_attr(any(test, feature = "test-utils"), mockall::automock)]
 #[async_trait]
 pub trait ContactStoreApi: SendSync {
@@ -194,4 +196,19 @@ pub trait ContactStoreApi: SendSync {
     async fn delete_contact(&self, node_id: NodeId) -> Result<()>;
     async fn get_contact(&self, node_id: NodeId) -> Result<Option<Contact>>;
     async fn list_contacts(&self, search_term: Option<String>) -> Result<Vec<Contact>>;
+    async fn delete_repo(&self) -> Result<()>;
+}
+
+//////////////////////////////////////////// Pending Payment Requests
+#[cfg_attr(any(test, feature = "test-utils"), mockall::automock)]
+#[async_trait]
+pub trait PendingPaymentRequestStoreApi: SendSync {
+    async fn add_pending_payment_request(
+        &self,
+        pending_payment_request: PendingPaymentRequest,
+    ) -> Result<()>;
+    async fn get_pending_payment_request(&self, id: Uuid) -> Result<Option<PendingPaymentRequest>>;
+    async fn list_pending_payment_requests(&self) -> Result<Vec<PendingPaymentRequest>>;
+    async fn delete_pending_payment_request(&self, id: Uuid) -> Result<()>;
+    async fn delete_repo(&self) -> Result<()>;
 }

--- a/crates/bcr-wallet-persistence/src/redb/contact.rs
+++ b/crates/bcr-wallet-persistence/src/redb/contact.rs
@@ -172,6 +172,22 @@ impl ContactDB {
             Err(e) => Err(e.into()),
         }
     }
+
+    fn delete_repo_sync(
+        db: Arc<Database>,
+        contact_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+    ) -> Result<()> {
+        let write_txn = db.begin_write()?;
+
+        {
+            if write_txn.open_table(contact_table).is_ok() {
+                write_txn.delete_table(contact_table)?;
+            }
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -209,6 +225,12 @@ impl ContactStoreApi for ContactDB {
         let res = spawn_blocking(move || Self::list_contacts_sync(db_clone, table, search_term))
             .await??;
         Ok(res.into_iter().map(|entry| entry.into()).collect())
+    }
+
+    async fn delete_repo(&self) -> Result<()> {
+        let db_clone = self.db.clone();
+        let table = self.contact_table;
+        spawn_blocking(move || Self::delete_repo_sync(db_clone, table)).await?
     }
 }
 

--- a/crates/bcr-wallet-persistence/src/redb/mod.rs
+++ b/crates/bcr-wallet-persistence/src/redb/mod.rs
@@ -1,6 +1,7 @@
 pub mod contact;
 pub mod mintmelt;
 pub mod nostr;
+pub mod pending_payment_requests;
 pub mod pocket;
 pub mod purse;
 pub mod transaction;
@@ -31,11 +32,21 @@ pub async fn build_wallet_dbs(
     mintmelt::MintMeltDB,
     nostr::NostrDB,
     contact::ContactDB,
+    pending_payment_requests::PendingPaymentRequestDB,
 )> {
     let txdb = transaction::TransactionDB::new(db.clone(), wallet_id)?;
     let debitdb = pocket::PocketDB::new(db.clone(), wallet_id, debit)?;
     let mintmeltdb = mintmelt::MintMeltDB::new(db.clone(), wallet_id, debit)?;
     let nostrdb = nostr::NostrDB::new(db.clone(), wallet_id)?;
     let contactdb = contact::ContactDB::new(db.clone(), wallet_id)?;
-    Ok((txdb, debitdb, mintmeltdb, nostrdb, contactdb))
+    let pending_payment_requests_db =
+        pending_payment_requests::PendingPaymentRequestDB::new(db.clone(), wallet_id)?;
+    Ok((
+        txdb,
+        debitdb,
+        mintmeltdb,
+        nostrdb,
+        contactdb,
+        pending_payment_requests_db,
+    ))
 }

--- a/crates/bcr-wallet-persistence/src/redb/pending_payment_requests.rs
+++ b/crates/bcr-wallet-persistence/src/redb/pending_payment_requests.rs
@@ -1,0 +1,607 @@
+use crate::{
+    PendingPaymentRequestStoreApi,
+    error::{Error, Result},
+};
+use async_trait::async_trait;
+use bcr_common::{
+    cashu::{Amount, CurrencyUnit},
+    core::NodeId,
+};
+use bcr_wallet_core::types::PendingPaymentRequest;
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, TableError};
+use std::sync::Arc;
+use tokio::task::spawn_blocking;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PendingPaymentRequestEntry {
+    pub id: Uuid,
+    pub node_id: NodeId,
+    pub amount: Amount,
+    pub unit: CurrencyUnit,
+    pub description: Option<String>,
+    pub deadline: Option<u64>,
+    pub created_at: u64,
+}
+
+impl From<PendingPaymentRequest> for PendingPaymentRequestEntry {
+    fn from(value: PendingPaymentRequest) -> Self {
+        Self {
+            id: value.id,
+            node_id: value.node_id,
+            amount: value.amount,
+            unit: value.unit,
+            description: value.description,
+            deadline: value.deadline,
+            created_at: value.created_at,
+        }
+    }
+}
+
+impl From<PendingPaymentRequestEntry> for PendingPaymentRequest {
+    fn from(value: PendingPaymentRequestEntry) -> Self {
+        Self {
+            id: value.id,
+            node_id: value.node_id,
+            amount: value.amount,
+            unit: value.unit,
+            description: value.description,
+            deadline: value.deadline,
+            created_at: value.created_at,
+        }
+    }
+}
+
+///////////////////////////////////////////// PendingPaymentRequestDB
+pub struct PendingPaymentRequestDB {
+    db: Arc<Database>,
+    pending_payment_requests_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+}
+
+impl PendingPaymentRequestDB {
+    const PENDING_PAYMENT_REQUESTS_DB_NAME: &'static str = "pending_payment_requests";
+
+    pub fn new(db: Arc<Database>, wallet_id: &str) -> Result<Self> {
+        // Leak once to get static string, because of dynamically generated table names
+        let pending_payment_requests_name: &'static str = Box::leak(
+            format!("{wallet_id}_{}", Self::PENDING_PAYMENT_REQUESTS_DB_NAME).into_boxed_str(),
+        );
+
+        let pending_payment_requests_table = TableDefinition::new(pending_payment_requests_name);
+
+        Ok(Self {
+            db,
+            pending_payment_requests_table,
+        })
+    }
+
+    fn add_pending_payment_request_sync(
+        db: Arc<Database>,
+        pending_payment_requests_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        entry: PendingPaymentRequestEntry,
+    ) -> Result<()> {
+        let id = entry.id;
+        let write_txn = db.begin_write()?;
+
+        {
+            let mut table = write_txn.open_table(pending_payment_requests_table)?;
+            let old_value = table.get(id.as_bytes().as_slice())?.map(|v| v.value());
+
+            if old_value.is_some() {
+                return Err(Error::PendingPaymentRequestAlreadyExists(id.to_string()));
+            }
+            let mut serialized = Vec::new();
+            ciborium::into_writer(&entry, &mut serialized)?;
+            table.insert(id.as_bytes().as_slice(), serialized)?;
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    fn get_pending_payment_request_sync(
+        db: Arc<Database>,
+        pending_payment_requests_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        id: Uuid,
+    ) -> Result<Option<PendingPaymentRequestEntry>> {
+        let read_txn = db.begin_read()?;
+
+        match read_txn.open_table(pending_payment_requests_table) {
+            Ok(table) => {
+                let entry = table.get(id.as_bytes().as_slice())?;
+                match entry {
+                    Some(e) => {
+                        let pending_payment_request: PendingPaymentRequestEntry =
+                            ciborium::from_reader(e.value().as_slice())?;
+                        Ok(Some(pending_payment_request))
+                    }
+                    None => Ok(None),
+                }
+            }
+            Err(TableError::TableDoesNotExist(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn list_pending_payment_requests_sync(
+        db: Arc<Database>,
+        pending_payment_requests_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+    ) -> Result<Vec<PendingPaymentRequestEntry>> {
+        let read_txn = db.begin_read()?;
+
+        match read_txn.open_table(pending_payment_requests_table) {
+            Ok(table) => {
+                let mut res = Vec::new();
+                for (_, v) in table.range::<&[u8]>(..)?.flatten() {
+                    let entry: PendingPaymentRequestEntry =
+                        ciborium::from_reader(v.value().as_slice())?;
+                    res.push(entry);
+                }
+                Ok(res)
+            }
+            Err(TableError::TableDoesNotExist(_)) => Ok(vec![]),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn delete_pending_payment_request_sync(
+        db: Arc<Database>,
+        pending_payment_requests_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        id: Uuid,
+    ) -> Result<()> {
+        let write_txn = db.begin_write()?;
+
+        {
+            let mut table = write_txn.open_table(pending_payment_requests_table)?;
+            table.remove(id.as_bytes().as_slice())?;
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
+
+    fn delete_repo_sync(
+        db: Arc<Database>,
+        pending_payment_requests_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+    ) -> Result<()> {
+        let write_txn = db.begin_write()?;
+
+        {
+            if write_txn.open_table(pending_payment_requests_table).is_ok() {
+                write_txn.delete_table(pending_payment_requests_table)?;
+            }
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl PendingPaymentRequestStoreApi for PendingPaymentRequestDB {
+    async fn add_pending_payment_request(
+        &self,
+        pending_payment_request: PendingPaymentRequest,
+    ) -> Result<()> {
+        let db_clone = self.db.clone();
+        let table = self.pending_payment_requests_table;
+        let res = spawn_blocking(move || {
+            Self::add_pending_payment_request_sync(db_clone, table, pending_payment_request.into())
+        })
+        .await??;
+        Ok(res)
+    }
+
+    async fn get_pending_payment_request(&self, id: Uuid) -> Result<Option<PendingPaymentRequest>> {
+        let db_clone = self.db.clone();
+        let table = self.pending_payment_requests_table;
+        let res =
+            spawn_blocking(move || Self::get_pending_payment_request_sync(db_clone, table, id))
+                .await??;
+        Ok(res.map(|c| c.into()))
+    }
+
+    async fn list_pending_payment_requests(&self) -> Result<Vec<PendingPaymentRequest>> {
+        let db_clone = self.db.clone();
+        let table = self.pending_payment_requests_table;
+        let res = spawn_blocking(move || Self::list_pending_payment_requests_sync(db_clone, table))
+            .await??;
+        Ok(res.into_iter().map(|entry| entry.into()).collect())
+    }
+
+    async fn delete_pending_payment_request(&self, id: Uuid) -> Result<()> {
+        let db_clone = self.db.clone();
+        let table = self.pending_payment_requests_table;
+        spawn_blocking(move || Self::delete_pending_payment_request_sync(db_clone, table, id))
+            .await??;
+        Ok(())
+    }
+
+    async fn delete_repo(&self) -> Result<()> {
+        let db_clone = self.db.clone();
+        let pending_payment_requests_table = self.pending_payment_requests_table;
+        spawn_blocking(move || Self::delete_repo_sync(db_clone, pending_payment_requests_table))
+            .await?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use redb::{Builder, backends::InMemoryBackend};
+    use uuid::Uuid;
+
+    const NODE_ID_1: &str =
+        "bitcrt03205b8dec12bc9e879f5b517aa32192a2550e88adcee3e54ec2c7294802568fef";
+
+    const NODE_ID_2: &str =
+        "bitcrt0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    fn get_db(wallet_id: &str) -> PendingPaymentRequestDB {
+        let in_mem = InMemoryBackend::new();
+        let db = Arc::new(
+            Builder::new()
+                .create_with_backend(in_mem)
+                .expect("can create in-memory redb"),
+        );
+
+        PendingPaymentRequestDB::new(db, wallet_id).expect("can create PendingPaymentRequestDB")
+    }
+
+    fn pending_payment_request(
+        id: Uuid,
+        node_id: &str,
+        amount: u64,
+        description: Option<&str>,
+        deadline: Option<u64>,
+        created_at: u64,
+    ) -> PendingPaymentRequest {
+        PendingPaymentRequest {
+            id,
+            node_id: NodeId::from_str(node_id).unwrap(),
+            amount: Amount::from(amount),
+            unit: CurrencyUnit::Sat,
+            description: description.map(ToString::to_string),
+            deadline,
+            created_at,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_pending_payment_request_empty_returns_none() {
+        let repo = get_db("wallet-empty-pending-payment-request");
+
+        let result = repo
+            .get_pending_payment_request(Uuid::new_v4())
+            .await
+            .expect("get_pending_payment_request works");
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_pending_payment_requests_empty_returns_empty_vec() {
+        let repo = get_db("wallet-empty-pending-payment-request-list");
+
+        let result = repo
+            .list_pending_payment_requests()
+            .await
+            .expect("list_pending_payment_requests works");
+
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_add_pending_payment_request_can_be_retrieved() {
+        let repo = get_db("wallet-store-pending-payment-request");
+        let id = Uuid::new_v4();
+
+        let request = pending_payment_request(id, NODE_ID_1, 100, Some("Coffee"), None, 999);
+
+        repo.add_pending_payment_request(request.clone())
+            .await
+            .expect("add_pending_payment_request works");
+
+        let result = repo
+            .get_pending_payment_request(id)
+            .await
+            .expect("get_pending_payment_request works")
+            .expect("pending payment request exists");
+
+        assert_eq!(result.id, request.id);
+        assert_eq!(result.node_id, request.node_id);
+        assert_eq!(result.amount, request.amount);
+        assert_eq!(result.description, request.description);
+        assert_eq!(result.deadline, request.deadline);
+        assert_eq!(result.created_at, request.created_at);
+    }
+
+    #[tokio::test]
+    async fn test_get_pending_payment_request_returns_none_for_unknown_id() {
+        let repo = get_db("wallet-missing-pending-payment-request");
+
+        repo.add_pending_payment_request(pending_payment_request(
+            Uuid::new_v4(),
+            NODE_ID_1,
+            100,
+            Some("Coffee"),
+            None,
+            999,
+        ))
+        .await
+        .expect("add_pending_payment_request works");
+
+        let result = repo
+            .get_pending_payment_request(Uuid::new_v4())
+            .await
+            .expect("get_pending_payment_request works");
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_add_pending_payment_request_rejects_duplicate_id() {
+        let repo = get_db("wallet-duplicate-pending-payment-request");
+        let id = Uuid::new_v4();
+
+        let first = pending_payment_request(id, NODE_ID_1, 100, Some("Coffee"), None, 999);
+
+        let duplicate = pending_payment_request(id, NODE_ID_2, 200, Some("Tea"), None, 1000);
+
+        repo.add_pending_payment_request(first.clone())
+            .await
+            .expect("add first pending payment request works");
+
+        let result = repo.add_pending_payment_request(duplicate).await;
+
+        assert!(matches!(
+            result,
+            Err(Error::PendingPaymentRequestAlreadyExists(_))
+        ));
+
+        let stored = repo
+            .get_pending_payment_request(id)
+            .await
+            .expect("get_pending_payment_request works")
+            .expect("original pending payment request still exists");
+
+        assert_eq!(stored.id, first.id);
+        assert_eq!(stored.node_id, first.node_id);
+        assert_eq!(stored.amount, first.amount);
+        assert_eq!(stored.description, first.description);
+        assert_eq!(stored.deadline, first.deadline);
+        assert_eq!(stored.created_at, first.created_at);
+    }
+
+    #[tokio::test]
+    async fn test_list_pending_payment_requests_returns_all_requests() {
+        let repo = get_db("wallet-list-pending-payment-requests");
+
+        let id_1 = Uuid::new_v4();
+        let id_2 = Uuid::new_v4();
+
+        repo.add_pending_payment_request(pending_payment_request(
+            id_1,
+            NODE_ID_1,
+            100,
+            Some("Coffee"),
+            Some(2000),
+            999,
+        ))
+        .await
+        .expect("store first pending payment request works");
+
+        repo.add_pending_payment_request(pending_payment_request(
+            id_2,
+            NODE_ID_2,
+            200,
+            Some("Tea"),
+            None,
+            1000,
+        ))
+        .await
+        .expect("store second pending payment request works");
+
+        let mut result = repo
+            .list_pending_payment_requests()
+            .await
+            .expect("list_pending_payment_requests works");
+
+        result.sort_by_key(|request| request.amount);
+
+        assert_eq!(result.len(), 2);
+
+        assert_eq!(result[0].id, id_1);
+        assert_eq!(result[0].node_id, NodeId::from_str(NODE_ID_1).unwrap());
+        assert_eq!(result[0].amount, Amount::from(100));
+        assert_eq!(result[0].description, Some("Coffee".to_string()));
+        assert_eq!(result[0].deadline, Some(2000));
+        assert_eq!(result[0].created_at, 999);
+
+        assert_eq!(result[1].id, id_2);
+        assert_eq!(result[1].node_id, NodeId::from_str(NODE_ID_2).unwrap());
+        assert_eq!(result[1].amount, Amount::from(200));
+        assert_eq!(result[1].description, Some("Tea".to_string()));
+        assert_eq!(result[1].deadline, None);
+        assert_eq!(result[1].created_at, 1000);
+    }
+
+    #[tokio::test]
+    async fn test_delete_pending_payment_request_removes_existing_request() {
+        let repo = get_db("wallet-delete-pending-payment-request");
+        let id = Uuid::new_v4();
+
+        repo.add_pending_payment_request(pending_payment_request(
+            id,
+            NODE_ID_1,
+            100,
+            Some("Coffee"),
+            None,
+            999,
+        ))
+        .await
+        .expect("add_pending_payment_request works");
+
+        repo.delete_pending_payment_request(id)
+            .await
+            .expect("delete_pending_payment_request works");
+
+        let result = repo
+            .get_pending_payment_request(id)
+            .await
+            .expect("get_pending_payment_request works");
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_pending_payment_request_ignores_missing_request() {
+        let repo = get_db("wallet-delete-missing-pending-payment-request");
+
+        repo.delete_pending_payment_request(Uuid::new_v4())
+            .await
+            .expect("delete_pending_payment_request ignores missing requests");
+    }
+
+    #[tokio::test]
+    async fn test_list_pending_payment_requests_after_delete_excludes_deleted_request() {
+        let repo = get_db("wallet-list-after-delete-pending-payment-request");
+
+        let id_1 = Uuid::new_v4();
+        let id_2 = Uuid::new_v4();
+
+        repo.add_pending_payment_request(pending_payment_request(
+            id_1,
+            NODE_ID_1,
+            100,
+            Some("Coffee"),
+            None,
+            999,
+        ))
+        .await
+        .expect("store first pending payment request works");
+
+        repo.add_pending_payment_request(pending_payment_request(
+            id_2,
+            NODE_ID_2,
+            200,
+            Some("Tea"),
+            None,
+            1000,
+        ))
+        .await
+        .expect("store second pending payment request works");
+
+        repo.delete_pending_payment_request(id_1)
+            .await
+            .expect("delete_pending_payment_request works");
+
+        let result = repo
+            .list_pending_payment_requests()
+            .await
+            .expect("list_pending_payment_requests works");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, id_2);
+    }
+
+    #[tokio::test]
+    async fn test_delete_repo_removes_all_pending_payment_requests() {
+        let repo = get_db("wallet-delete-pending-payment-request-repo");
+
+        repo.add_pending_payment_request(pending_payment_request(
+            Uuid::new_v4(),
+            NODE_ID_1,
+            100,
+            Some("Coffee"),
+            None,
+            999,
+        ))
+        .await
+        .expect("store first pending payment request works");
+
+        repo.add_pending_payment_request(pending_payment_request(
+            Uuid::new_v4(),
+            NODE_ID_2,
+            200,
+            Some("Tea"),
+            None,
+            1_600_000_001,
+        ))
+        .await
+        .expect("store second pending payment request works");
+
+        repo.delete_repo().await.expect("delete_repo works");
+
+        let result = repo
+            .list_pending_payment_requests()
+            .await
+            .expect("list_pending_payment_requests works");
+
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_wallets_are_isolated() {
+        let in_mem = InMemoryBackend::new();
+        let db = Arc::new(
+            Builder::new()
+                .create_with_backend(in_mem)
+                .expect("can create in-memory redb"),
+        );
+
+        let repo_a =
+            PendingPaymentRequestDB::new(db.clone(), "wallet-a").expect("can create repo a");
+        let repo_b =
+            PendingPaymentRequestDB::new(db.clone(), "wallet-b").expect("can create repo b");
+
+        let id = Uuid::new_v4();
+
+        repo_a
+            .add_pending_payment_request(pending_payment_request(
+                id,
+                NODE_ID_1,
+                100,
+                Some("Coffee"),
+                None,
+                999,
+            ))
+            .await
+            .expect("store pending payment request in repo a works");
+
+        assert!(
+            repo_a
+                .get_pending_payment_request(id)
+                .await
+                .expect("get_pending_payment_request repo a works")
+                .is_some()
+        );
+
+        assert!(
+            repo_b
+                .get_pending_payment_request(id)
+                .await
+                .expect("get_pending_payment_request repo b works")
+                .is_none()
+        );
+
+        assert_eq!(
+            repo_a
+                .list_pending_payment_requests()
+                .await
+                .expect("list_pending_payment_requests repo a works")
+                .len(),
+            1
+        );
+
+        assert!(
+            repo_b
+                .list_pending_payment_requests()
+                .await
+                .expect("list_pending_payment_requests repo b works")
+                .is_empty()
+        );
+    }
+}

--- a/crates/bcr-wallet-transport/src/lib.rs
+++ b/crates/bcr-wallet-transport/src/lib.rs
@@ -2,7 +2,11 @@ use crate::error::Result;
 use ::nostr::{PublicKey, event::EventId, types::RelayUrl};
 use async_trait::async_trait;
 use bcr_common::cashu::nut18 as cdk18;
-use bcr_wallet_core::{SendSync, contact::Contact, event::ContactPaymentPayload};
+use bcr_wallet_core::{
+    SendSync,
+    contact::Contact,
+    event::{ContactPaymentPayload, ContactPaymentRequestPayload},
+};
 use tokio::sync::broadcast;
 
 pub mod error;
@@ -46,6 +50,11 @@ pub enum NostrWalletEvent {
     ContactPayment {
         event_id: EventId,
         payload: ContactPaymentPayload,
+        sender: PublicKey,
+    },
+    ContactPaymentRequest {
+        event_id: EventId,
+        payload: ContactPaymentRequestPayload,
         sender: PublicKey,
     },
 }

--- a/crates/bcr-wallet-transport/src/nostr.rs
+++ b/crates/bcr-wallet-transport/src/nostr.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use bcr_common::{cashu::nut18 as cdk18, cdk_common::bitcoin::base58};
 use bcr_wallet_core::{
     contact::Contact,
-    event::{ContactPaymentPayload, EventEnvelope},
+    event::{ContactPaymentPayload, ContactPaymentRequestPayload, EventEnvelope},
 };
 use bcr_wallet_persistence::{NostrEventOffset, NostrQueuedMessage, NostrRepository};
 use nostr::{
@@ -520,6 +520,17 @@ async fn handle_nip17_direct_message<T: NostrSigner>(
                     if let Ok(payload) = borsh::from_slice::<ContactPaymentPayload>(&envelope.data)
                     {
                         event_channel.publish(NostrWalletEvent::ContactPayment {
+                            event_id: event.id,
+                            payload,
+                            sender: event.pubkey,
+                        });
+                    }
+                }
+                bcr_wallet_core::event::EventType::ContactPaymentRequest => {
+                    if let Ok(payload) =
+                        borsh::from_slice::<ContactPaymentRequestPayload>(&envelope.data)
+                    {
+                        event_channel.publish(NostrWalletEvent::ContactPaymentRequest {
                             event_id: event.id,
                             payload,
                             sender: event.pubkey,

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `get_app_state`, `init_logging`, `init_panic_hook`, `new`, `reset_runtime`, `start_jobs`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `WalletCleanLocalDbResponse`, `WalletRuntime`, `WalletsNamesResponse`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
 
 Future<void> initWalletFfi({required WalletFfiConfig conf}) =>
     RustLib.instance.api.crateApiInitWalletFfi(conf: conf);
@@ -157,6 +157,44 @@ Future<WalletGetContactResponse> walletGetContact({
 Future<WalletListContactsResponse> walletListContacts({
   required WalletListContactsRequest req,
 }) => RustLib.instance.api.crateApiWalletListContacts(req: req);
+
+Future<WalletRequestPaymentFromContactResponse>
+walletRequestPaymentFromContact({
+  required WalletRequestPaymentFromContactRequest req,
+}) => RustLib.instance.api.crateApiWalletRequestPaymentFromContact(req: req);
+
+Future<WalletListPendingPaymentRequestsResponse>
+walletListPendingPaymentRequests({
+  required WalletListPendingPaymentRequestsRequest req,
+}) => RustLib.instance.api.crateApiWalletListPendingPaymentRequests(req: req);
+
+Future<WalletGetPendingPaymentRequestResponse> walletGetPendingPaymentRequest({
+  required WalletGetPendingPaymentRequestRequest req,
+}) => RustLib.instance.api.crateApiWalletGetPendingPaymentRequest(req: req);
+
+Future<WalletPreparePaymentResponse> walletPreparePayPendingPaymentRequest({
+  required WalletPreparePayPendingPaymentRequestRequest req,
+}) => RustLib.instance.api.crateApiWalletPreparePayPendingPaymentRequest(
+  req: req,
+);
+
+Future<WalletTransactionIdResponse> walletPayPendingPaymentRequest({
+  required WalletPayRequest req,
+}) => RustLib.instance.api.crateApiWalletPayPendingPaymentRequest(req: req);
+
+Future<WalletRejectPendingPaymentRequestResponse>
+walletRejectPendingPaymentRequest({
+  required WalletRejectPendingPaymentRequestRequest req,
+}) => RustLib.instance.api.crateApiWalletRejectPendingPaymentRequest(req: req);
+
+Future<WalletPaymentCheckHandle> walletSubscribeToPendingPaymentRequests({
+  required WalletSubscribeToPendingPaymentRequestsRequest req,
+  required FutureOr<void> Function(WalletPendingPaymentRequestResponse)
+  resultCallback,
+}) => RustLib.instance.api.crateApiWalletSubscribeToPendingPaymentRequests(
+  req: req,
+  resultCallback: resultCallback,
+);
 
 Future<WalletDevModeDetailedBalanceResponse> walletDevModeGetDetailedBalance({
   required WalletRequest req,
@@ -479,6 +517,49 @@ enum PaymentType {
 
   static Future<PaymentType> default_() =>
       RustLib.instance.api.crateApiPaymentTypeDefault();
+}
+
+class PendingPaymentRequest {
+  final String id;
+  final String nodeId;
+  final BigInt amount;
+  final String unit;
+  final String? description;
+  final BigInt? deadline;
+  final BigInt createdAt;
+
+  const PendingPaymentRequest({
+    required this.id,
+    required this.nodeId,
+    required this.amount,
+    required this.unit,
+    this.description,
+    this.deadline,
+    required this.createdAt,
+  });
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      nodeId.hashCode ^
+      amount.hashCode ^
+      unit.hashCode ^
+      description.hashCode ^
+      deadline.hashCode ^
+      createdAt.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PendingPaymentRequest &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          nodeId == other.nodeId &&
+          amount == other.amount &&
+          unit == other.unit &&
+          description == other.description &&
+          deadline == other.deadline &&
+          createdAt == other.createdAt;
 }
 
 enum ProtestStatus {
@@ -1030,6 +1111,7 @@ enum WalletErrorCode {
   network,
   walletNotFound,
   contactNotFound,
+  pendingPaymentRequestNotFound,
   contactAlreadyExists,
   emptyToken,
   invalidToken,
@@ -1150,6 +1232,45 @@ class WalletGetContactResponse {
           contact == other.contact;
 }
 
+class WalletGetPendingPaymentRequestRequest {
+  final String walletId;
+  final String pendingPaymentRequestId;
+
+  const WalletGetPendingPaymentRequestRequest({
+    required this.walletId,
+    required this.pendingPaymentRequestId,
+  });
+
+  @override
+  int get hashCode => walletId.hashCode ^ pendingPaymentRequestId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletGetPendingPaymentRequestRequest &&
+          runtimeType == other.runtimeType &&
+          walletId == other.walletId &&
+          pendingPaymentRequestId == other.pendingPaymentRequestId;
+}
+
+class WalletGetPendingPaymentRequestResponse {
+  final PendingPaymentRequest pendingPaymentRequest;
+
+  const WalletGetPendingPaymentRequestResponse({
+    required this.pendingPaymentRequest,
+  });
+
+  @override
+  int get hashCode => pendingPaymentRequest.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletGetPendingPaymentRequestResponse &&
+          runtimeType == other.runtimeType &&
+          pendingPaymentRequest == other.pendingPaymentRequest;
+}
+
 class WalletIdForMnemonicAndNetworkRequest {
   final String bitcoinNetwork;
   final String mnemonic;
@@ -1254,6 +1375,40 @@ class WalletListContactsResponse {
       other is WalletListContactsResponse &&
           runtimeType == other.runtimeType &&
           contacts == other.contacts;
+}
+
+class WalletListPendingPaymentRequestsRequest {
+  final String walletId;
+
+  const WalletListPendingPaymentRequestsRequest({required this.walletId});
+
+  @override
+  int get hashCode => walletId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletListPendingPaymentRequestsRequest &&
+          runtimeType == other.runtimeType &&
+          walletId == other.walletId;
+}
+
+class WalletListPendingPaymentRequestsResponse {
+  final List<PendingPaymentRequest> pendingPaymentRequests;
+
+  const WalletListPendingPaymentRequestsResponse({
+    required this.pendingPaymentRequests,
+  });
+
+  @override
+  int get hashCode => pendingPaymentRequests.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletListPendingPaymentRequestsResponse &&
+          runtimeType == other.runtimeType &&
+          pendingPaymentRequests == other.pendingPaymentRequests;
 }
 
 class WalletListTransactionsRequest {
@@ -1482,6 +1637,22 @@ class WalletPaymentByTokenResponse {
           token == other.token;
 }
 
+class WalletPendingPaymentRequestResponse {
+  final String id;
+
+  const WalletPendingPaymentRequestResponse({required this.id});
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletPendingPaymentRequestResponse &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+}
+
 class WalletPrepareMeltRequest {
   final String walletId;
   final BigInt amount;
@@ -1511,6 +1682,27 @@ class WalletPrepareMeltRequest {
           amount == other.amount &&
           address == other.address &&
           description == other.description;
+}
+
+class WalletPreparePayPendingPaymentRequestRequest {
+  final String walletId;
+  final String pendingPaymentRequestId;
+
+  const WalletPreparePayPendingPaymentRequestRequest({
+    required this.walletId,
+    required this.pendingPaymentRequestId,
+  });
+
+  @override
+  int get hashCode => walletId.hashCode ^ pendingPaymentRequestId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletPreparePayPendingPaymentRequestRequest &&
+          runtimeType == other.runtimeType &&
+          walletId == other.walletId &&
+          pendingPaymentRequestId == other.pendingPaymentRequestId;
 }
 
 class WalletPreparePaymentByTokenRequest {
@@ -1863,6 +2055,45 @@ class WalletRefreshTransactionsResponse {
           updated == other.updated;
 }
 
+class WalletRejectPendingPaymentRequestRequest {
+  final String walletId;
+  final String pendingPaymentRequestId;
+
+  const WalletRejectPendingPaymentRequestRequest({
+    required this.walletId,
+    required this.pendingPaymentRequestId,
+  });
+
+  @override
+  int get hashCode => walletId.hashCode ^ pendingPaymentRequestId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletRejectPendingPaymentRequestRequest &&
+          runtimeType == other.runtimeType &&
+          walletId == other.walletId &&
+          pendingPaymentRequestId == other.pendingPaymentRequestId;
+}
+
+class WalletRejectPendingPaymentRequestResponse {
+  final String pendingPaymentRequestId;
+
+  const WalletRejectPendingPaymentRequestResponse({
+    required this.pendingPaymentRequestId,
+  });
+
+  @override
+  int get hashCode => pendingPaymentRequestId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletRejectPendingPaymentRequestResponse &&
+          runtimeType == other.runtimeType &&
+          pendingPaymentRequestId == other.pendingPaymentRequestId;
+}
+
 class WalletRequest {
   final String walletId;
 
@@ -1875,6 +2106,77 @@ class WalletRequest {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is WalletRequest &&
+          runtimeType == other.runtimeType &&
+          walletId == other.walletId;
+}
+
+class WalletRequestPaymentFromContactRequest {
+  final String walletId;
+  final String nodeId;
+  final BigInt amount;
+  final String? description;
+  final BigInt? deadline;
+
+  const WalletRequestPaymentFromContactRequest({
+    required this.walletId,
+    required this.nodeId,
+    required this.amount,
+    this.description,
+    this.deadline,
+  });
+
+  @override
+  int get hashCode =>
+      walletId.hashCode ^
+      nodeId.hashCode ^
+      amount.hashCode ^
+      description.hashCode ^
+      deadline.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletRequestPaymentFromContactRequest &&
+          runtimeType == other.runtimeType &&
+          walletId == other.walletId &&
+          nodeId == other.nodeId &&
+          amount == other.amount &&
+          description == other.description &&
+          deadline == other.deadline;
+}
+
+class WalletRequestPaymentFromContactResponse {
+  final String paymentRequestId;
+
+  const WalletRequestPaymentFromContactResponse({
+    required this.paymentRequestId,
+  });
+
+  @override
+  int get hashCode => paymentRequestId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletRequestPaymentFromContactResponse &&
+          runtimeType == other.runtimeType &&
+          paymentRequestId == other.paymentRequestId;
+}
+
+class WalletSubscribeToPendingPaymentRequestsRequest {
+  final String walletId;
+
+  const WalletSubscribeToPendingPaymentRequestsRequest({
+    required this.walletId,
+  });
+
+  @override
+  int get hashCode => walletId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletSubscribeToPendingPaymentRequestsRequest &&
           runtimeType == other.runtimeType &&
           walletId == other.walletId;
 }

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -66,7 +66,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 1861160958;
+  int get rustContentHash => -1755304891;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -185,6 +185,11 @@ abstract class RustLibApi extends BaseApi {
     required WalletRequest req,
   });
 
+  Future<WalletGetPendingPaymentRequestResponse>
+  crateApiWalletGetPendingPaymentRequest({
+    required WalletGetPendingPaymentRequestRequest req,
+  });
+
   Future<StatusResponse> crateApiWalletGetStatus();
 
   Future<WalletTransactionIdsResponse> crateApiWalletGetTransactionIds({
@@ -202,6 +207,11 @@ abstract class RustLibApi extends BaseApi {
 
   Future<WalletListContactsResponse> crateApiWalletListContacts({
     required WalletListContactsRequest req,
+  });
+
+  Future<WalletListPendingPaymentRequestsResponse>
+  crateApiWalletListPendingPaymentRequests({
+    required WalletListPendingPaymentRequestsRequest req,
   });
 
   Future<WalletTransactionResponse> crateApiWalletLoadTransaction({
@@ -234,12 +244,21 @@ abstract class RustLibApi extends BaseApi {
     required WalletPaymentByTokenRequest req,
   });
 
+  Future<WalletTransactionIdResponse> crateApiWalletPayPendingPaymentRequest({
+    required WalletPayRequest req,
+  });
+
   Future<WalletPreparePaymentResponse> crateApiWalletPrepareMelt({
     required WalletPrepareMeltRequest req,
   });
 
   Future<WalletPreparePaymentResponse> crateApiWalletPreparePayByToken({
     required WalletPreparePaymentByTokenRequest req,
+  });
+
+  Future<WalletPreparePaymentResponse>
+  crateApiWalletPreparePayPendingPaymentRequest({
+    required WalletPreparePayPendingPaymentRequestRequest req,
   });
 
   Future<WalletPreparePaymentResponse> crateApiWalletPreparePayment({
@@ -281,8 +300,25 @@ abstract class RustLibApi extends BaseApi {
     required WalletRequest req,
   });
 
+  Future<WalletRejectPendingPaymentRequestResponse>
+  crateApiWalletRejectPendingPaymentRequest({
+    required WalletRejectPendingPaymentRequestRequest req,
+  });
+
+  Future<WalletRequestPaymentFromContactResponse>
+  crateApiWalletRequestPaymentFromContact({
+    required WalletRequestPaymentFromContactRequest req,
+  });
+
   Future<RestoreWalletResponse> crateApiWalletRestore({
     required CreateWalletRequest req,
+  });
+
+  Future<WalletPaymentCheckHandle>
+  crateApiWalletSubscribeToPendingPaymentRequests({
+    required WalletSubscribeToPendingPaymentRequestsRequest req,
+    required FutureOr<void> Function(WalletPendingPaymentRequestResponse)
+    resultCallback,
   });
 
   RustArcIncrementStrongCountFnType
@@ -1294,6 +1330,44 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "wallet_get_node_id", argNames: ["req"]);
 
   @override
+  Future<WalletGetPendingPaymentRequestResponse>
+  crateApiWalletGetPendingPaymentRequest({
+    required WalletGetPendingPaymentRequestRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_get_pending_payment_request_request(
+            req,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 33,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_wallet_get_pending_payment_request_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletGetPendingPaymentRequestConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletGetPendingPaymentRequestConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_get_pending_payment_request",
+        argNames: ["req"],
+      );
+
+  @override
   Future<StatusResponse> crateApiWalletGetStatus() {
     return handler.executeNormal(
       NormalTask(
@@ -1302,7 +1376,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1332,7 +1406,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1368,7 +1442,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1405,7 +1479,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1439,7 +1513,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -1458,6 +1532,44 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "wallet_list_contacts", argNames: ["req"]);
 
   @override
+  Future<WalletListPendingPaymentRequestsResponse>
+  crateApiWalletListPendingPaymentRequests({
+    required WalletListPendingPaymentRequestsRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_list_pending_payment_requests_request(
+            req,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 39,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_wallet_list_pending_payment_requests_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletListPendingPaymentRequestsConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletListPendingPaymentRequestsConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_list_pending_payment_requests",
+        argNames: ["req"],
+      );
+
+  @override
   Future<WalletTransactionResponse> crateApiWalletLoadTransaction({
     required WalletTransactionRequest req,
   }) {
@@ -1469,7 +1581,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1502,7 +1614,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1529,7 +1641,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1559,7 +1671,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1589,7 +1701,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1622,7 +1734,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 45,
             port: port_,
           );
         },
@@ -1652,7 +1764,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 46,
             port: port_,
           );
         },
@@ -1685,7 +1797,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 47,
             port: port_,
           );
         },
@@ -1704,6 +1816,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "wallet_pay_by_token", argNames: ["req"]);
 
   @override
+  Future<WalletTransactionIdResponse> crateApiWalletPayPendingPaymentRequest({
+    required WalletPayRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_pay_request(req, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 48,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_wallet_transaction_id_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletPayPendingPaymentRequestConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletPayPendingPaymentRequestConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_pay_pending_payment_request",
+        argNames: ["req"],
+      );
+
+  @override
   Future<WalletPreparePaymentResponse> crateApiWalletPrepareMelt({
     required WalletPrepareMeltRequest req,
   }) {
@@ -1715,7 +1860,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 49,
             port: port_,
           );
         },
@@ -1748,7 +1893,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 50,
             port: port_,
           );
         },
@@ -1770,6 +1915,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<WalletPreparePaymentResponse>
+  crateApiWalletPreparePayPendingPaymentRequest({
+    required WalletPreparePayPendingPaymentRequestRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_prepare_pay_pending_payment_request_request(
+            req,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 51,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_wallet_prepare_payment_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletPreparePayPendingPaymentRequestConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletPreparePayPendingPaymentRequestConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_prepare_pay_pending_payment_request",
+        argNames: ["req"],
+      );
+
+  @override
   Future<WalletPreparePaymentResponse> crateApiWalletPreparePayment({
     required WalletPreparePaymentRequest req,
   }) {
@@ -1784,7 +1966,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 52,
             port: port_,
           );
         },
@@ -1820,7 +2002,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 53,
             port: port_,
           );
         },
@@ -1853,7 +2035,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 54,
             port: port_,
           );
         },
@@ -1883,7 +2065,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 55,
             port: port_,
           );
         },
@@ -1913,7 +2095,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 56,
             port: port_,
           );
         },
@@ -1943,7 +2125,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 57,
             port: port_,
           );
         },
@@ -1976,7 +2158,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2008,7 +2190,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2045,7 +2227,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2078,7 +2260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2100,6 +2282,82 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<WalletRejectPendingPaymentRequestResponse>
+  crateApiWalletRejectPendingPaymentRequest({
+    required WalletRejectPendingPaymentRequestRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_reject_pending_payment_request_request(
+            req,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 62,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_wallet_reject_pending_payment_request_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletRejectPendingPaymentRequestConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletRejectPendingPaymentRequestConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_reject_pending_payment_request",
+        argNames: ["req"],
+      );
+
+  @override
+  Future<WalletRequestPaymentFromContactResponse>
+  crateApiWalletRequestPaymentFromContact({
+    required WalletRequestPaymentFromContactRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_request_payment_from_contact_request(
+            req,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 63,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_wallet_request_payment_from_contact_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletRequestPaymentFromContactConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletRequestPaymentFromContactConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_request_payment_from_contact",
+        argNames: ["req"],
+      );
+
+  @override
   Future<RestoreWalletResponse> crateApiWalletRestore({
     required CreateWalletRequest req,
   }) {
@@ -2111,7 +2369,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 64,
             port: port_,
           );
         },
@@ -2129,12 +2387,91 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiWalletRestoreConstMeta =>
       const TaskConstMeta(debugName: "wallet_restore", argNames: ["req"]);
 
+  @override
+  Future<WalletPaymentCheckHandle>
+  crateApiWalletSubscribeToPendingPaymentRequests({
+    required WalletSubscribeToPendingPaymentRequestsRequest req,
+    required FutureOr<void> Function(WalletPendingPaymentRequestResponse)
+    resultCallback,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_subscribe_to_pending_payment_requests_request(
+            req,
+            serializer,
+          );
+          sse_encode_DartFn_Inputs_wallet_pending_payment_request_response_Output_unit_AnyhowException(
+            resultCallback,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 65,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerWalletPaymentCheckHandle,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletSubscribeToPendingPaymentRequestsConstMeta,
+        argValues: [req, resultCallback],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletSubscribeToPendingPaymentRequestsConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_subscribe_to_pending_payment_requests",
+        argNames: ["req", "resultCallback"],
+      );
+
   Future<void> Function(int, dynamic)
   encode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
     FutureOr<void> Function(WalletMaybeTransactionIdResponse) raw,
   ) {
     return (callId, rawArg0) async {
       final arg0 = dco_decode_wallet_maybe_transaction_id_response(rawArg0);
+
+      Box<void>? rawOutput;
+      Box<AnyhowException>? rawError;
+      try {
+        rawOutput = Box(await raw(arg0));
+      } catch (e, s) {
+        rawError = Box(AnyhowException("$e\n\n$s"));
+      }
+
+      final serializer = SseSerializer(generalizedFrbRustBinding);
+      assert((rawOutput != null) ^ (rawError != null));
+      if (rawOutput != null) {
+        serializer.buffer.putUint8(0);
+        sse_encode_unit(rawOutput.value, serializer);
+      } else {
+        serializer.buffer.putUint8(1);
+        sse_encode_AnyhowException(rawError!.value, serializer);
+      }
+      final output = serializer.intoRaw();
+
+      generalizedFrbRustBinding.dartFnDeliverOutput(
+        callId: callId,
+        ptr: output.ptr,
+        rustVecLen: output.rustVecLen,
+        dataLen: output.dataLen,
+      );
+    };
+  }
+
+  Future<void> Function(int, dynamic)
+  encode_DartFn_Inputs_wallet_pending_payment_request_response_Output_unit_AnyhowException(
+    FutureOr<void> Function(WalletPendingPaymentRequestResponse) raw,
+  ) {
+    return (callId, rawArg0) async {
+      final arg0 = dco_decode_wallet_pending_payment_request_response(rawArg0);
 
       Box<void>? rawOutput;
       Box<AnyhowException>? rawError;
@@ -2203,6 +2540,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   FutureOr<void> Function(WalletMaybeTransactionIdResponse)
   dco_decode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError('');
+  }
+
+  @protected
+  FutureOr<void> Function(WalletPendingPaymentRequestResponse)
+  dco_decode_DartFn_Inputs_wallet_pending_payment_request_response_Output_unit_AnyhowException(
     dynamic raw,
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -2365,6 +2711,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_get_pending_payment_request_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_wallet_get_pending_payment_request_request(raw);
+  }
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   dco_decode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
     dynamic raw,
@@ -2379,6 +2734,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_wallet_list_contacts_request(raw);
+  }
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  dco_decode_box_autoadd_wallet_list_pending_payment_requests_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_wallet_list_pending_payment_requests_request(raw);
   }
 
   @protected
@@ -2413,6 +2777,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_wallet_prepare_melt_request(raw);
+  }
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_prepare_pay_pending_payment_request_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_wallet_prepare_pay_pending_payment_request_request(raw);
   }
 
   @protected
@@ -2483,9 +2856,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_reject_pending_payment_request_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_wallet_reject_pending_payment_request_request(raw);
+  }
+
+  @protected
   WalletRequest dco_decode_box_autoadd_wallet_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_wallet_request(raw);
+  }
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  dco_decode_box_autoadd_wallet_request_payment_from_contact_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_wallet_request_payment_from_contact_request(raw);
+  }
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  dco_decode_box_autoadd_wallet_subscribe_to_pending_payment_requests_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_wallet_subscribe_to_pending_payment_requests_request(raw);
   }
 
   @protected
@@ -2592,6 +2992,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<PaymentType> dco_decode_list_payment_type(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_payment_type).toList();
+  }
+
+  @protected
+  List<PendingPaymentRequest> dco_decode_list_pending_payment_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_pending_payment_request)
+        .toList();
   }
 
   @protected
@@ -2753,6 +3163,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PaymentType dco_decode_payment_type(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PaymentType.values[raw as int];
+  }
+
+  @protected
+  PendingPaymentRequest dco_decode_pending_payment_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    return PendingPaymentRequest(
+      id: dco_decode_String(arr[0]),
+      nodeId: dco_decode_String(arr[1]),
+      amount: dco_decode_u_64(arr[2]),
+      unit: dco_decode_String(arr[3]),
+      description: dco_decode_opt_String(arr[4]),
+      deadline: dco_decode_opt_box_autoadd_u_64(arr[5]),
+      createdAt: dco_decode_u_64(arr[6]),
+    );
   }
 
   @protected
@@ -3147,6 +3574,31 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  dco_decode_wallet_get_pending_payment_request_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return WalletGetPendingPaymentRequestRequest(
+      walletId: dco_decode_String(arr[0]),
+      pendingPaymentRequestId: dco_decode_String(arr[1]),
+    );
+  }
+
+  @protected
+  WalletGetPendingPaymentRequestResponse
+  dco_decode_wallet_get_pending_payment_request_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return WalletGetPendingPaymentRequestResponse(
+      pendingPaymentRequest: dco_decode_pending_payment_request(arr[0]),
+    );
+  }
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   dco_decode_wallet_id_for_mnemonic_and_network_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -3210,6 +3662,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return WalletListContactsResponse(
       contacts: dco_decode_list_contact(arr[0]),
+    );
+  }
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  dco_decode_wallet_list_pending_payment_requests_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return WalletListPendingPaymentRequestsRequest(
+      walletId: dco_decode_String(arr[0]),
+    );
+  }
+
+  @protected
+  WalletListPendingPaymentRequestsResponse
+  dco_decode_wallet_list_pending_payment_requests_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return WalletListPendingPaymentRequestsResponse(
+      pendingPaymentRequests: dco_decode_list_pending_payment_request(arr[0]),
     );
   }
 
@@ -3353,6 +3829,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletPendingPaymentRequestResponse
+  dco_decode_wallet_pending_payment_request_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return WalletPendingPaymentRequestResponse(id: dco_decode_String(arr[0]));
+  }
+
+  @protected
   WalletPrepareMeltRequest dco_decode_wallet_prepare_melt_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -3363,6 +3849,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       amount: dco_decode_u_64(arr[1]),
       address: dco_decode_String(arr[2]),
       description: dco_decode_opt_String(arr[3]),
+    );
+  }
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  dco_decode_wallet_prepare_pay_pending_payment_request_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return WalletPreparePayPendingPaymentRequestRequest(
+      walletId: dco_decode_String(arr[0]),
+      pendingPaymentRequestId: dco_decode_String(arr[1]),
     );
   }
 
@@ -3596,12 +4095,77 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  dco_decode_wallet_reject_pending_payment_request_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return WalletRejectPendingPaymentRequestRequest(
+      walletId: dco_decode_String(arr[0]),
+      pendingPaymentRequestId: dco_decode_String(arr[1]),
+    );
+  }
+
+  @protected
+  WalletRejectPendingPaymentRequestResponse
+  dco_decode_wallet_reject_pending_payment_request_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return WalletRejectPendingPaymentRequestResponse(
+      pendingPaymentRequestId: dco_decode_String(arr[0]),
+    );
+  }
+
+  @protected
   WalletRequest dco_decode_wallet_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return WalletRequest(walletId: dco_decode_String(arr[0]));
+  }
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  dco_decode_wallet_request_payment_from_contact_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    return WalletRequestPaymentFromContactRequest(
+      walletId: dco_decode_String(arr[0]),
+      nodeId: dco_decode_String(arr[1]),
+      amount: dco_decode_u_64(arr[2]),
+      description: dco_decode_opt_String(arr[3]),
+      deadline: dco_decode_opt_box_autoadd_u_64(arr[4]),
+    );
+  }
+
+  @protected
+  WalletRequestPaymentFromContactResponse
+  dco_decode_wallet_request_payment_from_contact_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return WalletRequestPaymentFromContactResponse(
+      paymentRequestId: dco_decode_String(arr[0]),
+    );
+  }
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  dco_decode_wallet_subscribe_to_pending_payment_requests_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return WalletSubscribeToPendingPaymentRequestsRequest(
+      walletId: dco_decode_String(arr[0]),
+    );
   }
 
   @protected
@@ -3862,6 +4426,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_get_pending_payment_request_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_wallet_get_pending_payment_request_request(
+      deserializer,
+    ));
+  }
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   sse_decode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
     SseDeserializer deserializer,
@@ -3878,6 +4453,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_wallet_list_contacts_request(deserializer));
+  }
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  sse_decode_box_autoadd_wallet_list_pending_payment_requests_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_wallet_list_pending_payment_requests_request(
+      deserializer,
+    ));
   }
 
   @protected
@@ -3920,6 +4506,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_wallet_prepare_melt_request(deserializer));
+  }
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_prepare_pay_pending_payment_request_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_wallet_prepare_pay_pending_payment_request_request(
+      deserializer,
+    ));
   }
 
   @protected
@@ -4000,11 +4597,44 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_reject_pending_payment_request_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_wallet_reject_pending_payment_request_request(
+      deserializer,
+    ));
+  }
+
+  @protected
   WalletRequest sse_decode_box_autoadd_wallet_request(
     SseDeserializer deserializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_wallet_request(deserializer));
+  }
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  sse_decode_box_autoadd_wallet_request_payment_from_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_wallet_request_payment_from_contact_request(
+      deserializer,
+    ));
+  }
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  sse_decode_box_autoadd_wallet_subscribe_to_pending_payment_requests_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_wallet_subscribe_to_pending_payment_requests_request(
+      deserializer,
+    ));
   }
 
   @protected
@@ -4133,6 +4763,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var ans_ = <PaymentType>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_payment_type(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<PendingPaymentRequest> sse_decode_list_pending_payment_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <PendingPaymentRequest>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_pending_payment_request(deserializer));
     }
     return ans_;
   }
@@ -4354,6 +4998,29 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_32(deserializer);
     return PaymentType.values[inner];
+  }
+
+  @protected
+  PendingPaymentRequest sse_decode_pending_payment_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_id = sse_decode_String(deserializer);
+    var var_nodeId = sse_decode_String(deserializer);
+    var var_amount = sse_decode_u_64(deserializer);
+    var var_unit = sse_decode_String(deserializer);
+    var var_description = sse_decode_opt_String(deserializer);
+    var var_deadline = sse_decode_opt_box_autoadd_u_64(deserializer);
+    var var_createdAt = sse_decode_u_64(deserializer);
+    return PendingPaymentRequest(
+      id: var_id,
+      nodeId: var_nodeId,
+      amount: var_amount,
+      unit: var_unit,
+      description: var_description,
+      deadline: var_deadline,
+      createdAt: var_createdAt,
+    );
   }
 
   @protected
@@ -4766,6 +5433,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  sse_decode_wallet_get_pending_payment_request_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_walletId = sse_decode_String(deserializer);
+    var var_pendingPaymentRequestId = sse_decode_String(deserializer);
+    return WalletGetPendingPaymentRequestRequest(
+      walletId: var_walletId,
+      pendingPaymentRequestId: var_pendingPaymentRequestId,
+    );
+  }
+
+  @protected
+  WalletGetPendingPaymentRequestResponse
+  sse_decode_wallet_get_pending_payment_request_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_pendingPaymentRequest = sse_decode_pending_payment_request(
+      deserializer,
+    );
+    return WalletGetPendingPaymentRequestResponse(
+      pendingPaymentRequest: var_pendingPaymentRequest,
+    );
+  }
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   sse_decode_wallet_id_for_mnemonic_and_network_request(
     SseDeserializer deserializer,
@@ -4828,6 +5523,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_contacts = sse_decode_list_contact(deserializer);
     return WalletListContactsResponse(contacts: var_contacts);
+  }
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  sse_decode_wallet_list_pending_payment_requests_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_walletId = sse_decode_String(deserializer);
+    return WalletListPendingPaymentRequestsRequest(walletId: var_walletId);
+  }
+
+  @protected
+  WalletListPendingPaymentRequestsResponse
+  sse_decode_wallet_list_pending_payment_requests_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_pendingPaymentRequests = sse_decode_list_pending_payment_request(
+      deserializer,
+    );
+    return WalletListPendingPaymentRequestsResponse(
+      pendingPaymentRequests: var_pendingPaymentRequests,
+    );
   }
 
   @protected
@@ -4961,6 +5680,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletPendingPaymentRequestResponse
+  sse_decode_wallet_pending_payment_request_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_id = sse_decode_String(deserializer);
+    return WalletPendingPaymentRequestResponse(id: var_id);
+  }
+
+  @protected
   WalletPrepareMeltRequest sse_decode_wallet_prepare_melt_request(
     SseDeserializer deserializer,
   ) {
@@ -4974,6 +5703,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       amount: var_amount,
       address: var_address,
       description: var_description,
+    );
+  }
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  sse_decode_wallet_prepare_pay_pending_payment_request_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_walletId = sse_decode_String(deserializer);
+    var var_pendingPaymentRequestId = sse_decode_String(deserializer);
+    return WalletPreparePayPendingPaymentRequestRequest(
+      walletId: var_walletId,
+      pendingPaymentRequestId: var_pendingPaymentRequestId,
     );
   }
 
@@ -5182,10 +5925,80 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  sse_decode_wallet_reject_pending_payment_request_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_walletId = sse_decode_String(deserializer);
+    var var_pendingPaymentRequestId = sse_decode_String(deserializer);
+    return WalletRejectPendingPaymentRequestRequest(
+      walletId: var_walletId,
+      pendingPaymentRequestId: var_pendingPaymentRequestId,
+    );
+  }
+
+  @protected
+  WalletRejectPendingPaymentRequestResponse
+  sse_decode_wallet_reject_pending_payment_request_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_pendingPaymentRequestId = sse_decode_String(deserializer);
+    return WalletRejectPendingPaymentRequestResponse(
+      pendingPaymentRequestId: var_pendingPaymentRequestId,
+    );
+  }
+
+  @protected
   WalletRequest sse_decode_wallet_request(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_walletId = sse_decode_String(deserializer);
     return WalletRequest(walletId: var_walletId);
+  }
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  sse_decode_wallet_request_payment_from_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_walletId = sse_decode_String(deserializer);
+    var var_nodeId = sse_decode_String(deserializer);
+    var var_amount = sse_decode_u_64(deserializer);
+    var var_description = sse_decode_opt_String(deserializer);
+    var var_deadline = sse_decode_opt_box_autoadd_u_64(deserializer);
+    return WalletRequestPaymentFromContactRequest(
+      walletId: var_walletId,
+      nodeId: var_nodeId,
+      amount: var_amount,
+      description: var_description,
+      deadline: var_deadline,
+    );
+  }
+
+  @protected
+  WalletRequestPaymentFromContactResponse
+  sse_decode_wallet_request_payment_from_contact_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_paymentRequestId = sse_decode_String(deserializer);
+    return WalletRequestPaymentFromContactResponse(
+      paymentRequestId: var_paymentRequestId,
+    );
+  }
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  sse_decode_wallet_subscribe_to_pending_payment_requests_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_walletId = sse_decode_String(deserializer);
+    return WalletSubscribeToPendingPaymentRequestsRequest(
+      walletId: var_walletId,
+    );
   }
 
   @protected
@@ -5278,6 +6091,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_DartOpaque(
       encode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
+        self,
+      ),
+      serializer,
+    );
+  }
+
+  @protected
+  void
+  sse_encode_DartFn_Inputs_wallet_pending_payment_request_response_Output_unit_AnyhowException(
+    FutureOr<void> Function(WalletPendingPaymentRequestResponse) self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_DartOpaque(
+      encode_DartFn_Inputs_wallet_pending_payment_request_response_Output_unit_AnyhowException(
         self,
       ),
       serializer,
@@ -5481,6 +6309,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_wallet_get_pending_payment_request_request(
+    WalletGetPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_wallet_get_pending_payment_request_request(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
     WalletIdForMnemonicAndNetworkRequest self,
     SseSerializer serializer,
@@ -5496,6 +6333,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_wallet_list_contacts_request(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_wallet_list_pending_payment_requests_request(
+    WalletListPendingPaymentRequestsRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_wallet_list_pending_payment_requests_request(self, serializer);
   }
 
   @protected
@@ -5541,6 +6387,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_wallet_prepare_melt_request(self, serializer);
+  }
+
+  @protected
+  void
+  sse_encode_box_autoadd_wallet_prepare_pay_pending_payment_request_request(
+    WalletPreparePayPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_wallet_prepare_pay_pending_payment_request_request(
+      self,
+      serializer,
+    );
   }
 
   @protected
@@ -5625,12 +6484,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_wallet_reject_pending_payment_request_request(
+    WalletRejectPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_wallet_reject_pending_payment_request_request(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_wallet_request(
     WalletRequest self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_wallet_request(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_wallet_request_payment_from_contact_request(
+    WalletRequestPaymentFromContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_wallet_request_payment_from_contact_request(self, serializer);
+  }
+
+  @protected
+  void
+  sse_encode_box_autoadd_wallet_subscribe_to_pending_payment_requests_request(
+    WalletSubscribeToPendingPaymentRequestsRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_wallet_subscribe_to_pending_payment_requests_request(
+      self,
+      serializer,
+    );
   }
 
   @protected
@@ -5741,6 +6631,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
       sse_encode_payment_type(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_pending_payment_request(
+    List<PendingPaymentRequest> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_pending_payment_request(item, serializer);
     }
   }
 
@@ -5949,6 +6851,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_payment_type(PaymentType self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_pending_payment_request(
+    PendingPaymentRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.id, serializer);
+    sse_encode_String(self.nodeId, serializer);
+    sse_encode_u_64(self.amount, serializer);
+    sse_encode_String(self.unit, serializer);
+    sse_encode_opt_String(self.description, serializer);
+    sse_encode_opt_box_autoadd_u_64(self.deadline, serializer);
+    sse_encode_u_64(self.createdAt, serializer);
   }
 
   @protected
@@ -6306,6 +7223,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_wallet_get_pending_payment_request_request(
+    WalletGetPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.walletId, serializer);
+    sse_encode_String(self.pendingPaymentRequestId, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_get_pending_payment_request_response(
+    WalletGetPendingPaymentRequestResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_pending_payment_request(self.pendingPaymentRequest, serializer);
+  }
+
+  @protected
   void sse_encode_wallet_id_for_mnemonic_and_network_request(
     WalletIdForMnemonicAndNetworkRequest self,
     SseSerializer serializer,
@@ -6354,6 +7290,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_list_contact(self.contacts, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_list_pending_payment_requests_request(
+    WalletListPendingPaymentRequestsRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.walletId, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_list_pending_payment_requests_response(
+    WalletListPendingPaymentRequestsResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_pending_payment_request(
+      self.pendingPaymentRequests,
+      serializer,
+    );
   }
 
   @protected
@@ -6469,6 +7426,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_wallet_pending_payment_request_response(
+    WalletPendingPaymentRequestResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.id, serializer);
+  }
+
+  @protected
   void sse_encode_wallet_prepare_melt_request(
     WalletPrepareMeltRequest self,
     SseSerializer serializer,
@@ -6478,6 +7444,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_u_64(self.amount, serializer);
     sse_encode_String(self.address, serializer);
     sse_encode_opt_String(self.description, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_prepare_pay_pending_payment_request_request(
+    WalletPreparePayPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.walletId, serializer);
+    sse_encode_String(self.pendingPaymentRequestId, serializer);
   }
 
   @protected
@@ -6658,7 +7634,57 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_wallet_reject_pending_payment_request_request(
+    WalletRejectPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.walletId, serializer);
+    sse_encode_String(self.pendingPaymentRequestId, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_reject_pending_payment_request_response(
+    WalletRejectPendingPaymentRequestResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.pendingPaymentRequestId, serializer);
+  }
+
+  @protected
   void sse_encode_wallet_request(WalletRequest self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.walletId, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_request_payment_from_contact_request(
+    WalletRequestPaymentFromContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.walletId, serializer);
+    sse_encode_String(self.nodeId, serializer);
+    sse_encode_u_64(self.amount, serializer);
+    sse_encode_opt_String(self.description, serializer);
+    sse_encode_opt_box_autoadd_u_64(self.deadline, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_request_payment_from_contact_response(
+    WalletRequestPaymentFromContactResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.paymentRequestId, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_subscribe_to_pending_payment_requests_request(
+    WalletSubscribeToPendingPaymentRequestsRequest self,
+    SseSerializer serializer,
+  ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.walletId, serializer);
   }

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -44,6 +44,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  FutureOr<void> Function(WalletPendingPaymentRequestResponse)
+  dco_decode_DartFn_Inputs_wallet_pending_payment_request_response_Output_unit_AnyhowException(
+    dynamic raw,
+  );
+
+  @protected
   Object dco_decode_DartOpaque(dynamic raw);
 
   @protected
@@ -123,6 +129,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_get_pending_payment_request_request(
+    dynamic raw,
+  );
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   dco_decode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
     dynamic raw,
@@ -130,6 +142,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletListContactsRequest dco_decode_box_autoadd_wallet_list_contacts_request(
+    dynamic raw,
+  );
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  dco_decode_box_autoadd_wallet_list_pending_payment_requests_request(
     dynamic raw,
   );
 
@@ -149,6 +167,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletPrepareMeltRequest dco_decode_box_autoadd_wallet_prepare_melt_request(
+    dynamic raw,
+  );
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_prepare_pay_pending_payment_request_request(
     dynamic raw,
   );
 
@@ -193,7 +217,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_box_autoadd_wallet_refresh_transaction_request(dynamic raw);
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_reject_pending_payment_request_request(
+    dynamic raw,
+  );
+
+  @protected
   WalletRequest dco_decode_box_autoadd_wallet_request(dynamic raw);
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  dco_decode_box_autoadd_wallet_request_payment_from_contact_request(
+    dynamic raw,
+  );
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  dco_decode_box_autoadd_wallet_subscribe_to_pending_payment_requests_request(
+    dynamic raw,
+  );
 
   @protected
   WalletTransactionRequest dco_decode_box_autoadd_wallet_transaction_request(
@@ -232,6 +274,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<PaymentType> dco_decode_list_payment_type(dynamic raw);
+
+  @protected
+  List<PendingPaymentRequest> dco_decode_list_pending_payment_request(
+    dynamic raw,
+  );
 
   @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
@@ -292,6 +339,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PaymentType dco_decode_payment_type(dynamic raw);
+
+  @protected
+  PendingPaymentRequest dco_decode_pending_payment_request(dynamic raw);
 
   @protected
   ProtestStatus dco_decode_protest_status(dynamic raw);
@@ -419,6 +469,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletGetContactResponse dco_decode_wallet_get_contact_response(dynamic raw);
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  dco_decode_wallet_get_pending_payment_request_request(dynamic raw);
+
+  @protected
+  WalletGetPendingPaymentRequestResponse
+  dco_decode_wallet_get_pending_payment_request_response(dynamic raw);
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   dco_decode_wallet_id_for_mnemonic_and_network_request(dynamic raw);
 
@@ -438,6 +496,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletListContactsResponse dco_decode_wallet_list_contacts_response(
     dynamic raw,
   );
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  dco_decode_wallet_list_pending_payment_requests_request(dynamic raw);
+
+  @protected
+  WalletListPendingPaymentRequestsResponse
+  dco_decode_wallet_list_pending_payment_requests_response(dynamic raw);
 
   @protected
   WalletListTransactionsRequest dco_decode_wallet_list_transactions_request(
@@ -484,7 +550,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletPendingPaymentRequestResponse
+  dco_decode_wallet_pending_payment_request_response(dynamic raw);
+
+  @protected
   WalletPrepareMeltRequest dco_decode_wallet_prepare_melt_request(dynamic raw);
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  dco_decode_wallet_prepare_pay_pending_payment_request_request(dynamic raw);
 
   @protected
   WalletPreparePaymentByTokenRequest
@@ -563,7 +637,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_wallet_refresh_transactions_response(dynamic raw);
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  dco_decode_wallet_reject_pending_payment_request_request(dynamic raw);
+
+  @protected
+  WalletRejectPendingPaymentRequestResponse
+  dco_decode_wallet_reject_pending_payment_request_response(dynamic raw);
+
+  @protected
   WalletRequest dco_decode_wallet_request(dynamic raw);
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  dco_decode_wallet_request_payment_from_contact_request(dynamic raw);
+
+  @protected
+  WalletRequestPaymentFromContactResponse
+  dco_decode_wallet_request_payment_from_contact_response(dynamic raw);
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  dco_decode_wallet_subscribe_to_pending_payment_requests_request(dynamic raw);
 
   @protected
   WalletTransactionIdResponse dco_decode_wallet_transaction_id_response(
@@ -699,6 +793,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_get_pending_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   sse_decode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
     SseDeserializer deserializer,
@@ -706,6 +806,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletListContactsRequest sse_decode_box_autoadd_wallet_list_contacts_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  sse_decode_box_autoadd_wallet_list_pending_payment_requests_request(
     SseDeserializer deserializer,
   );
 
@@ -733,6 +839,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletPrepareMeltRequest sse_decode_box_autoadd_wallet_prepare_melt_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_prepare_pay_pending_payment_request_request(
     SseDeserializer deserializer,
   );
 
@@ -787,7 +899,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_reject_pending_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletRequest sse_decode_box_autoadd_wallet_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  sse_decode_box_autoadd_wallet_request_payment_from_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  sse_decode_box_autoadd_wallet_subscribe_to_pending_payment_requests_request(
     SseDeserializer deserializer,
   );
 
@@ -834,6 +964,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<PaymentType> sse_decode_list_payment_type(SseDeserializer deserializer);
+
+  @protected
+  List<PendingPaymentRequest> sse_decode_list_pending_payment_request(
+    SseDeserializer deserializer,
+  );
 
   @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
@@ -912,6 +1047,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PaymentType sse_decode_payment_type(SseDeserializer deserializer);
+
+  @protected
+  PendingPaymentRequest sse_decode_pending_payment_request(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ProtestStatus sse_decode_protest_status(SseDeserializer deserializer);
@@ -1067,6 +1207,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  sse_decode_wallet_get_pending_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletGetPendingPaymentRequestResponse
+  sse_decode_wallet_get_pending_payment_request_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   sse_decode_wallet_id_for_mnemonic_and_network_request(
     SseDeserializer deserializer,
@@ -1090,6 +1242,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletListContactsResponse sse_decode_wallet_list_contacts_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  sse_decode_wallet_list_pending_payment_requests_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletListPendingPaymentRequestsResponse
+  sse_decode_wallet_list_pending_payment_requests_response(
     SseDeserializer deserializer,
   );
 
@@ -1146,7 +1310,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletPendingPaymentRequestResponse
+  sse_decode_wallet_pending_payment_request_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletPrepareMeltRequest sse_decode_wallet_prepare_melt_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  sse_decode_wallet_prepare_pay_pending_payment_request_request(
     SseDeserializer deserializer,
   );
 
@@ -1239,7 +1415,37 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   sse_decode_wallet_refresh_transactions_response(SseDeserializer deserializer);
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  sse_decode_wallet_reject_pending_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletRejectPendingPaymentRequestResponse
+  sse_decode_wallet_reject_pending_payment_request_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletRequest sse_decode_wallet_request(SseDeserializer deserializer);
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  sse_decode_wallet_request_payment_from_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletRequestPaymentFromContactResponse
+  sse_decode_wallet_request_payment_from_contact_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  sse_decode_wallet_subscribe_to_pending_payment_requests_request(
+    SseDeserializer deserializer,
+  );
 
   @protected
   WalletTransactionIdResponse sse_decode_wallet_transaction_id_response(
@@ -1290,6 +1496,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
     FutureOr<void> Function(WalletMaybeTransactionIdResponse) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_DartFn_Inputs_wallet_pending_payment_request_response_Output_unit_AnyhowException(
+    FutureOr<void> Function(WalletPendingPaymentRequestResponse) self,
     SseSerializer serializer,
   );
 
@@ -1409,6 +1622,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_wallet_get_pending_payment_request_request(
+    WalletGetPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
     WalletIdForMnemonicAndNetworkRequest self,
     SseSerializer serializer,
@@ -1417,6 +1636,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_list_contacts_request(
     WalletListContactsRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_wallet_list_pending_payment_requests_request(
+    WalletListPendingPaymentRequestsRequest self,
     SseSerializer serializer,
   );
 
@@ -1447,6 +1672,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_prepare_melt_request(
     WalletPrepareMeltRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_box_autoadd_wallet_prepare_pay_pending_payment_request_request(
+    WalletPreparePayPendingPaymentRequestRequest self,
     SseSerializer serializer,
   );
 
@@ -1505,8 +1737,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_wallet_reject_pending_payment_request_request(
+    WalletRejectPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_wallet_request(
     WalletRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_wallet_request_payment_from_contact_request(
+    WalletRequestPaymentFromContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_box_autoadd_wallet_subscribe_to_pending_payment_requests_request(
+    WalletSubscribeToPendingPaymentRequestsRequest self,
     SseSerializer serializer,
   );
 
@@ -1561,6 +1812,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_list_payment_type(
     List<PaymentType> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_pending_payment_request(
+    List<PendingPaymentRequest> self,
     SseSerializer serializer,
   );
 
@@ -1668,6 +1925,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_payment_type(PaymentType self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_pending_payment_request(
+    PendingPaymentRequest self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_protest_status(ProtestStatus self, SseSerializer serializer);
@@ -1865,6 +2128,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_wallet_get_pending_payment_request_request(
+    WalletGetPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_get_pending_payment_request_response(
+    WalletGetPendingPaymentRequestResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_wallet_id_for_mnemonic_and_network_request(
     WalletIdForMnemonicAndNetworkRequest self,
     SseSerializer serializer,
@@ -1891,6 +2166,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_list_contacts_response(
     WalletListContactsResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_list_pending_payment_requests_request(
+    WalletListPendingPaymentRequestsRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_list_pending_payment_requests_response(
+    WalletListPendingPaymentRequestsResponse self,
     SseSerializer serializer,
   );
 
@@ -1961,8 +2248,20 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_wallet_pending_payment_request_response(
+    WalletPendingPaymentRequestResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_wallet_prepare_melt_request(
     WalletPrepareMeltRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_prepare_pay_pending_payment_request_request(
+    WalletPreparePayPendingPaymentRequestRequest self,
     SseSerializer serializer,
   );
 
@@ -2075,7 +2374,37 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_wallet_reject_pending_payment_request_request(
+    WalletRejectPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_reject_pending_payment_request_response(
+    WalletRejectPendingPaymentRequestResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_wallet_request(WalletRequest self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_wallet_request_payment_from_contact_request(
+    WalletRequestPaymentFromContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_request_payment_from_contact_response(
+    WalletRequestPaymentFromContactResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_subscribe_to_pending_payment_requests_request(
+    WalletSubscribeToPendingPaymentRequestsRequest self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_wallet_transaction_id_response(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -46,6 +46,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  FutureOr<void> Function(WalletPendingPaymentRequestResponse)
+  dco_decode_DartFn_Inputs_wallet_pending_payment_request_response_Output_unit_AnyhowException(
+    dynamic raw,
+  );
+
+  @protected
   Object dco_decode_DartOpaque(dynamic raw);
 
   @protected
@@ -125,6 +131,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_get_pending_payment_request_request(
+    dynamic raw,
+  );
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   dco_decode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
     dynamic raw,
@@ -132,6 +144,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletListContactsRequest dco_decode_box_autoadd_wallet_list_contacts_request(
+    dynamic raw,
+  );
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  dco_decode_box_autoadd_wallet_list_pending_payment_requests_request(
     dynamic raw,
   );
 
@@ -151,6 +169,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletPrepareMeltRequest dco_decode_box_autoadd_wallet_prepare_melt_request(
+    dynamic raw,
+  );
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_prepare_pay_pending_payment_request_request(
     dynamic raw,
   );
 
@@ -195,7 +219,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_box_autoadd_wallet_refresh_transaction_request(dynamic raw);
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_reject_pending_payment_request_request(
+    dynamic raw,
+  );
+
+  @protected
   WalletRequest dco_decode_box_autoadd_wallet_request(dynamic raw);
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  dco_decode_box_autoadd_wallet_request_payment_from_contact_request(
+    dynamic raw,
+  );
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  dco_decode_box_autoadd_wallet_subscribe_to_pending_payment_requests_request(
+    dynamic raw,
+  );
 
   @protected
   WalletTransactionRequest dco_decode_box_autoadd_wallet_transaction_request(
@@ -234,6 +276,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<PaymentType> dco_decode_list_payment_type(dynamic raw);
+
+  @protected
+  List<PendingPaymentRequest> dco_decode_list_pending_payment_request(
+    dynamic raw,
+  );
 
   @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
@@ -294,6 +341,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PaymentType dco_decode_payment_type(dynamic raw);
+
+  @protected
+  PendingPaymentRequest dco_decode_pending_payment_request(dynamic raw);
 
   @protected
   ProtestStatus dco_decode_protest_status(dynamic raw);
@@ -421,6 +471,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletGetContactResponse dco_decode_wallet_get_contact_response(dynamic raw);
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  dco_decode_wallet_get_pending_payment_request_request(dynamic raw);
+
+  @protected
+  WalletGetPendingPaymentRequestResponse
+  dco_decode_wallet_get_pending_payment_request_response(dynamic raw);
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   dco_decode_wallet_id_for_mnemonic_and_network_request(dynamic raw);
 
@@ -440,6 +498,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletListContactsResponse dco_decode_wallet_list_contacts_response(
     dynamic raw,
   );
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  dco_decode_wallet_list_pending_payment_requests_request(dynamic raw);
+
+  @protected
+  WalletListPendingPaymentRequestsResponse
+  dco_decode_wallet_list_pending_payment_requests_response(dynamic raw);
 
   @protected
   WalletListTransactionsRequest dco_decode_wallet_list_transactions_request(
@@ -486,7 +552,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletPendingPaymentRequestResponse
+  dco_decode_wallet_pending_payment_request_response(dynamic raw);
+
+  @protected
   WalletPrepareMeltRequest dco_decode_wallet_prepare_melt_request(dynamic raw);
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  dco_decode_wallet_prepare_pay_pending_payment_request_request(dynamic raw);
 
   @protected
   WalletPreparePaymentByTokenRequest
@@ -565,7 +639,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_wallet_refresh_transactions_response(dynamic raw);
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  dco_decode_wallet_reject_pending_payment_request_request(dynamic raw);
+
+  @protected
+  WalletRejectPendingPaymentRequestResponse
+  dco_decode_wallet_reject_pending_payment_request_response(dynamic raw);
+
+  @protected
   WalletRequest dco_decode_wallet_request(dynamic raw);
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  dco_decode_wallet_request_payment_from_contact_request(dynamic raw);
+
+  @protected
+  WalletRequestPaymentFromContactResponse
+  dco_decode_wallet_request_payment_from_contact_response(dynamic raw);
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  dco_decode_wallet_subscribe_to_pending_payment_requests_request(dynamic raw);
 
   @protected
   WalletTransactionIdResponse dco_decode_wallet_transaction_id_response(
@@ -701,6 +795,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_get_pending_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   sse_decode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
     SseDeserializer deserializer,
@@ -708,6 +808,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletListContactsRequest sse_decode_box_autoadd_wallet_list_contacts_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  sse_decode_box_autoadd_wallet_list_pending_payment_requests_request(
     SseDeserializer deserializer,
   );
 
@@ -735,6 +841,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletPrepareMeltRequest sse_decode_box_autoadd_wallet_prepare_melt_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_prepare_pay_pending_payment_request_request(
     SseDeserializer deserializer,
   );
 
@@ -789,7 +901,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_reject_pending_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletRequest sse_decode_box_autoadd_wallet_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  sse_decode_box_autoadd_wallet_request_payment_from_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  sse_decode_box_autoadd_wallet_subscribe_to_pending_payment_requests_request(
     SseDeserializer deserializer,
   );
 
@@ -836,6 +966,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<PaymentType> sse_decode_list_payment_type(SseDeserializer deserializer);
+
+  @protected
+  List<PendingPaymentRequest> sse_decode_list_pending_payment_request(
+    SseDeserializer deserializer,
+  );
 
   @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
@@ -914,6 +1049,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PaymentType sse_decode_payment_type(SseDeserializer deserializer);
+
+  @protected
+  PendingPaymentRequest sse_decode_pending_payment_request(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ProtestStatus sse_decode_protest_status(SseDeserializer deserializer);
@@ -1069,6 +1209,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletGetPendingPaymentRequestRequest
+  sse_decode_wallet_get_pending_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletGetPendingPaymentRequestResponse
+  sse_decode_wallet_get_pending_payment_request_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletIdForMnemonicAndNetworkRequest
   sse_decode_wallet_id_for_mnemonic_and_network_request(
     SseDeserializer deserializer,
@@ -1092,6 +1244,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletListContactsResponse sse_decode_wallet_list_contacts_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletListPendingPaymentRequestsRequest
+  sse_decode_wallet_list_pending_payment_requests_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletListPendingPaymentRequestsResponse
+  sse_decode_wallet_list_pending_payment_requests_response(
     SseDeserializer deserializer,
   );
 
@@ -1148,7 +1312,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletPendingPaymentRequestResponse
+  sse_decode_wallet_pending_payment_request_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletPrepareMeltRequest sse_decode_wallet_prepare_melt_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePayPendingPaymentRequestRequest
+  sse_decode_wallet_prepare_pay_pending_payment_request_request(
     SseDeserializer deserializer,
   );
 
@@ -1241,7 +1417,37 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   sse_decode_wallet_refresh_transactions_response(SseDeserializer deserializer);
 
   @protected
+  WalletRejectPendingPaymentRequestRequest
+  sse_decode_wallet_reject_pending_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletRejectPendingPaymentRequestResponse
+  sse_decode_wallet_reject_pending_payment_request_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletRequest sse_decode_wallet_request(SseDeserializer deserializer);
+
+  @protected
+  WalletRequestPaymentFromContactRequest
+  sse_decode_wallet_request_payment_from_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletRequestPaymentFromContactResponse
+  sse_decode_wallet_request_payment_from_contact_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletSubscribeToPendingPaymentRequestsRequest
+  sse_decode_wallet_subscribe_to_pending_payment_requests_request(
+    SseDeserializer deserializer,
+  );
 
   @protected
   WalletTransactionIdResponse sse_decode_wallet_transaction_id_response(
@@ -1292,6 +1498,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_DartFn_Inputs_wallet_maybe_transaction_id_response_Output_unit_AnyhowException(
     FutureOr<void> Function(WalletMaybeTransactionIdResponse) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_DartFn_Inputs_wallet_pending_payment_request_response_Output_unit_AnyhowException(
+    FutureOr<void> Function(WalletPendingPaymentRequestResponse) self,
     SseSerializer serializer,
   );
 
@@ -1411,6 +1624,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_wallet_get_pending_payment_request_request(
+    WalletGetPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
     WalletIdForMnemonicAndNetworkRequest self,
     SseSerializer serializer,
@@ -1419,6 +1638,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_list_contacts_request(
     WalletListContactsRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_wallet_list_pending_payment_requests_request(
+    WalletListPendingPaymentRequestsRequest self,
     SseSerializer serializer,
   );
 
@@ -1449,6 +1674,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_prepare_melt_request(
     WalletPrepareMeltRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_box_autoadd_wallet_prepare_pay_pending_payment_request_request(
+    WalletPreparePayPendingPaymentRequestRequest self,
     SseSerializer serializer,
   );
 
@@ -1507,8 +1739,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_wallet_reject_pending_payment_request_request(
+    WalletRejectPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_wallet_request(
     WalletRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_wallet_request_payment_from_contact_request(
+    WalletRequestPaymentFromContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_box_autoadd_wallet_subscribe_to_pending_payment_requests_request(
+    WalletSubscribeToPendingPaymentRequestsRequest self,
     SseSerializer serializer,
   );
 
@@ -1563,6 +1814,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_list_payment_type(
     List<PaymentType> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_pending_payment_request(
+    List<PendingPaymentRequest> self,
     SseSerializer serializer,
   );
 
@@ -1670,6 +1927,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_payment_type(PaymentType self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_pending_payment_request(
+    PendingPaymentRequest self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_protest_status(ProtestStatus self, SseSerializer serializer);
@@ -1867,6 +2130,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_wallet_get_pending_payment_request_request(
+    WalletGetPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_get_pending_payment_request_response(
+    WalletGetPendingPaymentRequestResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_wallet_id_for_mnemonic_and_network_request(
     WalletIdForMnemonicAndNetworkRequest self,
     SseSerializer serializer,
@@ -1893,6 +2168,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_list_contacts_response(
     WalletListContactsResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_list_pending_payment_requests_request(
+    WalletListPendingPaymentRequestsRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_list_pending_payment_requests_response(
+    WalletListPendingPaymentRequestsResponse self,
     SseSerializer serializer,
   );
 
@@ -1963,8 +2250,20 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_wallet_pending_payment_request_response(
+    WalletPendingPaymentRequestResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_wallet_prepare_melt_request(
     WalletPrepareMeltRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_prepare_pay_pending_payment_request_request(
+    WalletPreparePayPendingPaymentRequestRequest self,
     SseSerializer serializer,
   );
 
@@ -2077,7 +2376,37 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_wallet_reject_pending_payment_request_request(
+    WalletRejectPendingPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_reject_pending_payment_request_response(
+    WalletRejectPendingPaymentRequestResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_wallet_request(WalletRequest self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_wallet_request_payment_from_contact_request(
+    WalletRequestPaymentFromContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_request_payment_from_contact_response(
+    WalletRequestPaymentFromContactResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_subscribe_to_pending_payment_requests_request(
+    WalletSubscribeToPendingPaymentRequestsRequest self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_wallet_transaction_id_response(


### PR DESCRIPTION
(Diff looks like more than it is due to generated files)

* Add API for remote payment requests via Nostr
    * `wallet_request_payment_from_contact` - sends a payment request to a contact
    * `wallet_list_pending_payment_requests` - returns a list of pending payment requests
    * `wallet_subscribe_to_pending_payment_requests` - the caller can subscribe to incoming pending payment requests to react to them
    * `wallet_get_pending_payment_request` - returns the details of a given pending payment request
    * `wallet_pay_pending_payment_request` - pay a pending payment request
    * `wallet_reject_pending_payment_request` - reject payment of a pending payment request

Final next Steps:
* Open Questions regarding payment requests (what to show for requester)
* Refresh-Contact-Relays functionality
* Add More Tests