### PR TITLE
Add DB migration, Migrate Proofs persistence to be versioned, encrypted and borsh-serialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Improve Mint Client Errors
 * Don't send dleq proofs on same-mint swaps to avoid giving up a blinding factor unnecessarily
 * Fix offline substitute pay by token for attestation, multi-keysets and fees
+* Add a Database migration scheme
+* Migrate Proofs persistence to be versioned, encrypted and borsh-serialized 
 
 # 0.9.6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base58ck"
 version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,7 +323,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bcr-common"
 version = "0.8.0"
-source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=f103d4762da16126aac60d8641bc1832a5a3455f#f103d4762da16126aac60d8641bc1832a5a3455f"
+source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=6c66a28a10db9c7f3e8a41c138c0c1281518c278#6c66a28a10db9c7f3e8a41c138c0c1281518c278"
 dependencies = [
  "bip39",
  "bitcoin",
@@ -380,6 +411,7 @@ dependencies = [
  "bitcoin",
  "borsh",
  "chrono",
+ "ecies",
  "nostr",
  "serde",
  "strum",
@@ -396,6 +428,7 @@ dependencies = [
  "bcr-common",
  "bcr-wallet-core",
  "bitcoin",
+ "borsh",
  "chrono",
  "ciborium",
  "mockall",
@@ -919,6 +952,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,10 +1021,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
@@ -1019,6 +1076,15 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1092,6 +1158,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -1169,10 +1245,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecies"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2df85e2b13a5f7fa61e7f0ee776acfe74da80bf2fb1bcde2725af19c197b33"
+dependencies = [
+ "aes-gcm",
+ "getrandom 0.2.17",
+ "hkdf",
+ "k256",
+ "lock_api",
+ "once_cell",
+ "rand_core 0.6.4",
+ "sha2",
+ "typenum",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "ff",
+ "generic-array",
+ "group",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1231,6 +1342,16 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1432,6 +1553,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1475,6 +1597,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1622,17 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1586,6 +1729,15 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -1989,6 +2141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "elliptic-curve",
+ "once_cell",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,6 +2524,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2586,6 +2753,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
@@ -3107,6 +3286,19 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ strip = "symbols"
 
 [workspace.dependencies]
 async-trait = {version = "0.1"}
-bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "f103d4762da16126aac60d8641bc1832a5a3455f"}
+bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "6c66a28a10db9c7f3e8a41c138c0c1281518c278"}
 bcr-wallet-core = {path = "./crates/bcr-wallet-core"}
 bcr-wallet-api = {path = "./crates/bcr-wallet-api"}
 bcr-wallet-persistence = {path = "./crates/bcr-wallet-persistence"}
@@ -26,6 +26,7 @@ bitcoin = {version = "0.32"}
 borsh = {version = "1"}
 chrono = {version  = "0.4"}
 ciborium = {version="0.2"}
+ecies = { version = "0.2", default-features = false, features = ["pure"] }
 futures = {version = "0.3"}
 mockall = {version  = "0.13"}
 nostr = {version = "0.43"}

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -1178,7 +1178,7 @@ async fn build_wallet(
 ) -> Result<Arc<RwLock<wallet::Wallet>>> {
     // building wallet dbs
     let (tx_repo, debitdb, mintmeltdb, nostrdb, contactdb, pending_incoming_payment_request_db) =
-        build_wallet_dbs(db_version, &w_cfg.wallet_id, &w_cfg.debit, db).await?;
+        build_wallet_dbs(db_version, &w_cfg.wallet_id, &w_cfg.debit, db, seed).await?;
 
     let nostr_repo = Arc::new(nostrdb);
     let nostr_event_channel = NostrEventChannel::new();

--- a/crates/bcr-wallet-core/Cargo.toml
+++ b/crates/bcr-wallet-core/Cargo.toml
@@ -11,6 +11,7 @@ bip39.workspace = true
 bitcoin.workspace = true
 borsh.workspace = true
 chrono = {workspace = true}
+ecies.workspace = true
 nostr = {workspace = true}
 serde.workspace = true
 strum = {workspace = true, features = ["derive"]}

--- a/crates/bcr-wallet-core/src/crypto.rs
+++ b/crates/bcr-wallet-core/src/crypto.rs
@@ -1,0 +1,44 @@
+use bitcoin::secp256k1::{PublicKey, SecretKey};
+use thiserror::Error;
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum EncryptionError {
+    #[error("Ecies encryption error {0}")]
+    Ecies(String),
+}
+
+/// Encrypt the given bytes with the given Secp256k1 key via ECIES
+pub fn encrypt_ecies(bytes: &[u8], public_key: &PublicKey) -> Result<Vec<u8>, EncryptionError> {
+    let pub_key_bytes = public_key.serialize();
+    let encrypted = ecies::encrypt(pub_key_bytes.as_slice(), bytes)
+        .map_err(|e| EncryptionError::Ecies(e.to_string()))?;
+    Ok(encrypted)
+}
+
+/// Decrypt the given bytes with the given Secp256k1 key via ECIES
+pub fn decrypt_ecies(bytes: &[u8], private_key: &SecretKey) -> Result<Vec<u8>, EncryptionError> {
+    let decrypted = ecies::decrypt(private_key.secret_bytes().as_slice(), bytes)
+        .map_err(|e| EncryptionError::Ecies(e.to_string()))?;
+    Ok(decrypted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encrypt_decrypt_ecies_basic() {
+        let msg = "Hello, this is a very important message!"
+            .to_string()
+            .into_bytes();
+        let keypair =
+            bitcoin::secp256k1::Keypair::new_global(&mut bitcoin::secp256k1::rand::thread_rng());
+
+        let encrypted = encrypt_ecies(&msg, &keypair.public_key());
+        assert!(encrypted.is_ok());
+        let decrypted = decrypt_ecies(encrypted.as_ref().unwrap(), &keypair.secret_key());
+        assert!(decrypted.is_ok());
+
+        assert_eq!(&msg, decrypted.as_ref().unwrap());
+    }
+}

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 pub mod contact;
+pub mod crypto;
 pub mod event;
 pub mod name;
 pub mod types;

--- a/crates/bcr-wallet-persistence/Cargo.toml
+++ b/crates/bcr-wallet-persistence/Cargo.toml
@@ -13,6 +13,7 @@ async-trait.workspace = true
 bcr-common = {workspace = true}
 bcr-wallet-core = {workspace = true}
 bitcoin.workspace = true
+borsh = {workspace = true}
 chrono = {workspace = true}
 ciborium = {workspace = true}
 mockall = {workspace = true, optional = true}

--- a/crates/bcr-wallet-persistence/src/error.rs
+++ b/crates/bcr-wallet-persistence/src/error.rs
@@ -8,10 +8,16 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("cashu::nut01: {0}")]
+    Cdk01(#[from] cashu::nut01::Error),
     #[error("deserialize ciborium: {0}")]
     CiboriumDe(#[from] ciborium::de::Error<std::io::Error>),
     #[error("serialize ciborium: {0}")]
     CiboriumSer(#[from] ciborium::ser::Error<std::io::Error>),
+    #[error("borsh serialization: {0}")]
+    BorshSerialization(String),
+    #[error("encryption: {0}")]
+    Encryption(#[from] bcr_wallet_core::crypto::EncryptionError),
     #[error("Database operation error: {0}")]
     Redb(#[from] redb::Error),
     #[error("Database error: {0}")]

--- a/crates/bcr-wallet-persistence/src/redb/migration/migration_0001.rs
+++ b/crates/bcr-wallet-persistence/src/redb/migration/migration_0001.rs
@@ -1,0 +1,405 @@
+use crate::{
+    error::{Error, Result},
+    redb::{migration::WalletStorageNamespace, pocket},
+};
+use bcr_common::cashu::{
+    nut00 as cdk00, nut01 as cdk01, nut02 as cdk02, nut07 as cdk07, nut12 as cdk12, secret::Secret,
+};
+use redb::{ReadableTable, TableDefinition};
+
+///////////////////////////////////////////////////////////////// MIGRATION 0001
+const MIGRATION_0001_ADD_VERSIONED_ENVELOPES_AND_ENCRYPTION: &str =
+    "0001_add_versioned_envelopes_and_encryption";
+
+pub(super) fn migration_name_for_wallet(wallet_id: &str) -> String {
+    format!(
+        "{}_{}",
+        MIGRATION_0001_ADD_VERSIONED_ENVELOPES_AND_ENCRYPTION, wallet_id
+    )
+}
+
+pub(super) fn migration_0001_add_proof_envelope_and_encryption(
+    txn: &redb::WriteTransaction,
+    namespace: &WalletStorageNamespace,
+) -> Result<()> {
+    migrate_proof_table_to_envelope_and_encryption(txn, &namespace.proof_table, &namespace.keys)?;
+
+    Ok(())
+}
+
+// Fetch old proofs
+// convert to cdk proofs
+// put in V1 envelope and encrypt
+// Store new proofs
+fn migrate_proof_table_to_envelope_and_encryption(
+    txn: &redb::WriteTransaction,
+    table_name: &str,
+    keys: &bitcoin::secp256k1::Keypair,
+) -> Result<()> {
+    let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+
+    let mut table = match txn.open_table(table_def) {
+        Ok(table) => table,
+        Err(redb::TableError::TableDoesNotExist(_)) => {
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut migrated_proofs: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    for item in table.iter()? {
+        let (k, v) = item?;
+        let proof: ProofEntry = ciborium::from_reader(v.value().as_slice())?;
+        let state = proof.state;
+        let cdk_proof: cdk00::Proof = proof.into();
+        let stored_proof_v1 = pocket::to_stored_proof_v1(cdk_proof, Some(state), keys.to_owned())?;
+
+        let migrated_proof_bytes = borsh::to_vec(&stored_proof_v1)
+            .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+        migrated_proofs.push((k.value().to_vec(), migrated_proof_bytes));
+    }
+
+    for (key, new_proof) in migrated_proofs.iter() {
+        table.insert(key.as_slice(), new_proof)?;
+    }
+
+    Ok(())
+}
+
+///////////////////////////////////////////// pre-0001 ProofEntry for the 0001 migration
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+struct ProofEntry {
+    y: cdk01::PublicKey,
+    amount: bcr_common::cashu::Amount,
+    keyset_id: cdk02::Id,
+    secret: Secret,
+    c: cdk01::PublicKey,
+    witness: Option<cdk00::Witness>,
+    dleq: Option<cdk12::ProofDleq>,
+    state: cdk07::State,
+}
+
+impl std::convert::From<cdk00::Proof> for ProofEntry {
+    fn from(proof: cdk00::Proof) -> Self {
+        let y = proof.y().expect("Hash to curve should not fail");
+        ProofEntry {
+            y,
+            amount: proof.amount,
+            keyset_id: proof.keyset_id,
+            secret: proof.secret,
+            c: proof.c,
+            witness: proof.witness,
+            dleq: proof.dleq,
+            state: cdk07::State::Unspent,
+        }
+    }
+}
+
+impl std::convert::From<ProofEntry> for cdk00::Proof {
+    fn from(entry: ProofEntry) -> Self {
+        cdk00::Proof {
+            amount: entry.amount,
+            keyset_id: entry.keyset_id,
+            secret: entry.secret,
+            c: entry.c,
+            witness: entry.witness,
+            dleq: entry.dleq,
+            p2pk_e: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::redb::{
+        migration::collect_wallet_namespace,
+        pocket::{StoredProof, from_stored_proof_v1},
+    };
+    use bcr_common::{
+        cashu::{Amount, CurrencyUnit},
+        core_tests,
+    };
+    use redb::{Builder, Database, ReadableDatabase, TableDefinition, backends::InMemoryBackend};
+    use std::sync::Arc;
+
+    fn test_database() -> Arc<Database> {
+        let backend = InMemoryBackend::new();
+        Arc::new(
+            Builder::new()
+                .create_with_backend(backend)
+                .expect("create in-memory database"),
+        )
+    }
+
+    fn test_keypair() -> bitcoin::secp256k1::Keypair {
+        bitcoin::secp256k1::Keypair::new_global(&mut bitcoin::secp256k1::rand::thread_rng())
+    }
+
+    fn test_proof() -> cdk00::Proof {
+        let (_, keyset) = core_tests::generate_random_ecash_keyset();
+        let proofs = core_tests::generate_random_ecash_proofs(&keyset, &[Amount::from(16_u64)]);
+
+        proofs[0].clone()
+    }
+
+    fn namespace(wallet_id: &str, keys: bitcoin::secp256k1::Keypair) -> WalletStorageNamespace {
+        collect_wallet_namespace(wallet_id.to_string(), CurrencyUnit::Sat, keys)
+    }
+
+    fn insert_legacy_proof(
+        db: &Arc<Database>,
+        table_name: &str,
+        proof: cdk00::Proof,
+        state: cdk07::State,
+    ) -> cdk01::PublicKey {
+        let y = proof.y().expect("proof has valid y");
+        let mut legacy_entry = ProofEntry::from(proof);
+        legacy_entry.state = state;
+        let mut encoded = Vec::new();
+        ciborium::into_writer(&legacy_entry, &mut encoded).expect("serialize legacy proof");
+        let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+        let write_txn = db.begin_write().expect("begin write transaction");
+        {
+            let mut table = write_txn
+                .open_table(table_def)
+                .expect("open legacy proof table");
+
+            table
+                .insert(y.to_bytes().as_slice(), encoded)
+                .expect("insert legacy proof");
+        }
+        write_txn.commit().expect("commit legacy proof");
+        y
+    }
+
+    fn load_migrated_proof(
+        db: &Arc<Database>,
+        table_name: &str,
+        y: cdk01::PublicKey,
+        keys: bitcoin::secp256k1::Keypair,
+    ) -> (cdk00::Proof, cdk07::State) {
+        let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+
+        let read_txn = db.begin_read().expect("begin read transaction");
+        let table = read_txn
+            .open_table(table_def)
+            .expect("open migrated proof table");
+
+        let stored = table
+            .get(y.to_bytes().as_slice())
+            .expect("read migrated proof")
+            .expect("migrated proof exists");
+
+        let envelope: StoredProof = borsh::from_slice(stored.value().as_slice())
+            .expect("deserialize stored proof envelope");
+
+        from_stored_proof_v1(envelope, keys).expect("decrypt migrated proof")
+    }
+
+    #[test]
+    fn migration_name_contains_migration_and_wallet_ids() {
+        let wallet_id = "wallet-123";
+        let migration_name = migration_name_for_wallet(wallet_id);
+
+        assert_eq!(
+            migration_name,
+            "0001_add_versioned_envelopes_and_encryption_wallet-123"
+        );
+    }
+
+    #[test]
+    fn migration_name_is_different_for_each_wallet() {
+        let first = migration_name_for_wallet("wallet-1");
+        let second = migration_name_for_wallet("wallet-2");
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn migration_succeeds_when_proof_table_does_not_exist() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+
+        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
+            .expect("migration succeeds for missing proof table");
+
+        write_txn.commit().expect("commit migration");
+    }
+
+    #[test]
+    fn migration_converts_legacy_proof_to_encrypted_envelope() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+
+        let original = test_proof();
+        let y = insert_legacy_proof(
+            &db,
+            &namespace.proof_table,
+            original.clone(),
+            cdk07::State::Unspent,
+        );
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
+            .expect("migrate legacy proof");
+        write_txn.commit().expect("commit migration");
+        let (migrated, state) = load_migrated_proof(&db, &namespace.proof_table, y, keys);
+
+        assert_eq!(migrated, original);
+        assert_eq!(state, cdk07::State::Unspent);
+    }
+
+    #[test]
+    fn migration_preserves_state() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+
+        let original = test_proof();
+        let y = insert_legacy_proof(
+            &db,
+            &namespace.proof_table,
+            original.clone(),
+            cdk07::State::PendingSpent,
+        );
+        let write_txn = db.begin_write().expect("begin write transaction");
+        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
+            .expect("migrate legacy proof");
+        write_txn.commit().expect("commit migration");
+        let (migrated, state) = load_migrated_proof(&db, &namespace.proof_table, y, keys);
+
+        assert_eq!(migrated, original);
+        assert_eq!(state, cdk07::State::PendingSpent);
+    }
+
+    #[test]
+    fn migration_preserves_database_key() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+
+        let original = test_proof();
+        let expected_y = original.y().expect("proof has valid y");
+
+        insert_legacy_proof(&db, &namespace.proof_table, original, cdk07::State::Unspent);
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+
+        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
+            .expect("migrate legacy proof");
+
+        write_txn.commit().expect("commit migration");
+
+        let table_def: TableDefinition<&[u8], Vec<u8>> =
+            TableDefinition::new(namespace.proof_table.as_str());
+
+        let read_txn = db.begin_read().expect("begin read transaction");
+        let table = read_txn.open_table(table_def).expect("open proof table");
+
+        assert!(
+            table
+                .get(expected_y.to_bytes().as_slice())
+                .expect("read proof entry")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn migration_encrypts_stored_proof_payload() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+
+        let original = test_proof();
+        let y = insert_legacy_proof(&db, &namespace.proof_table, original, cdk07::State::Unspent);
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+
+        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
+            .expect("migrate legacy proof");
+
+        write_txn.commit().expect("commit migration");
+
+        let table_def: TableDefinition<&[u8], Vec<u8>> =
+            TableDefinition::new(namespace.proof_table.as_str());
+
+        let read_txn = db.begin_read().expect("begin read transaction");
+        let table = read_txn
+            .open_table(table_def)
+            .expect("open migrated proof table");
+
+        let stored = table
+            .get(y.to_bytes().as_slice())
+            .expect("read migrated entry")
+            .expect("migrated entry exists");
+
+        let envelope: StoredProof =
+            borsh::from_slice(stored.value().as_slice()).expect("deserialize stored proof");
+
+        match envelope {
+            StoredProof::V1(payload) => {
+                assert!(!payload.ciphertext.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn migration_converts_multiple_proofs() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+
+        let first = test_proof();
+        let second = test_proof();
+        let third = test_proof();
+
+        let first_y = insert_legacy_proof(
+            &db,
+            &namespace.proof_table,
+            first.clone(),
+            cdk07::State::Unspent,
+        );
+
+        let second_y = insert_legacy_proof(
+            &db,
+            &namespace.proof_table,
+            second.clone(),
+            cdk07::State::PendingSpent,
+        );
+
+        let third_y = insert_legacy_proof(
+            &db,
+            &namespace.proof_table,
+            third.clone(),
+            cdk07::State::Spent,
+        );
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+
+        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
+            .expect("migrate all legacy proofs");
+
+        write_txn.commit().expect("commit migration");
+
+        let (migrated_first, first_state) =
+            load_migrated_proof(&db, &namespace.proof_table, first_y, keys);
+        let (migrated_second, second_state) =
+            load_migrated_proof(&db, &namespace.proof_table, second_y, keys);
+        let (migrated_third, third_state) =
+            load_migrated_proof(&db, &namespace.proof_table, third_y, keys);
+
+        assert_eq!(migrated_first, first);
+        assert_eq!(first_state, cdk07::State::Unspent);
+
+        assert_eq!(migrated_second, second);
+        assert_eq!(second_state, cdk07::State::PendingSpent);
+
+        assert_eq!(migrated_third, third);
+        assert_eq!(third_state, cdk07::State::Spent);
+    }
+}

--- a/crates/bcr-wallet-persistence/src/redb/migration/mod.rs
+++ b/crates/bcr-wallet-persistence/src/redb/migration/mod.rs
@@ -1,0 +1,237 @@
+use crate::{
+    error::{Error, Result},
+    redb::pocket::PocketDB,
+};
+use bcr_common::cashu::CurrencyUnit;
+use borsh::{BorshDeserialize, BorshSerialize};
+use chrono::Utc;
+use redb::{Database, ReadableTable, TableDefinition};
+use std::sync::Arc;
+
+mod migration_0001;
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct AppliedMigration {
+    id: String,
+    applied_at: u64,
+}
+
+const MIGRATIONS_TABLE: TableDefinition<&str, Vec<u8>> = TableDefinition::new("migrations");
+
+pub async fn migrate(db: Arc<Database>, namespace: WalletStorageNamespace) -> Result<()> {
+    tokio::task::spawn_blocking(move || migrate_sync(db, namespace))
+        .await
+        .map_err(|e| Error::Custom(format!("migration task failed: {e}")))?
+}
+
+fn migrate_sync(db: Arc<Database>, namespace: WalletStorageNamespace) -> Result<()> {
+    tracing::info!(
+        "Checking DB migrations for wallet {}..",
+        &namespace.wallet_id
+    );
+    let write_txn = db.begin_write()?;
+
+    let applied = load_applied_migrations(&write_txn)?;
+
+    let migration_0001_id_for_wallet =
+        migration_0001::migration_name_for_wallet(&namespace.wallet_id);
+    if !applied.contains(&migration_0001_id_for_wallet) {
+        tracing::info!(
+            "Applying Migration 0001 for wallet {}",
+            &namespace.wallet_id
+        );
+        migration_0001::migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)?;
+        mark_migration_applied(&write_txn, &migration_0001_id_for_wallet)?;
+        tracing::info!("Applied Migration 0001 for wallet {}", &namespace.wallet_id);
+    }
+
+    write_txn.commit()?;
+    tracing::info!(
+        "Finished DB migrations for wallet {}.",
+        &namespace.wallet_id
+    );
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+/// Collected the storage namespace a wallet
+pub struct WalletStorageNamespace {
+    wallet_id: String,
+    proof_table: String,
+    keys: bitcoin::secp256k1::Keypair,
+}
+
+pub fn collect_wallet_namespace(
+    wallet_id: String,
+    unit: CurrencyUnit,
+    keys: bitcoin::secp256k1::Keypair,
+) -> WalletStorageNamespace {
+    WalletStorageNamespace {
+        wallet_id: wallet_id.to_string(),
+        proof_table: PocketDB::proof_table_name(&wallet_id, &unit),
+        keys,
+    }
+}
+
+fn load_applied_migrations(
+    txn: &redb::WriteTransaction,
+) -> Result<std::collections::HashSet<String>> {
+    let table = match txn.open_table(MIGRATIONS_TABLE) {
+        Ok(table) => table,
+        Err(redb::TableError::TableDoesNotExist(_)) => {
+            return Ok(std::collections::HashSet::new());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut applied = std::collections::HashSet::new();
+    for item in table.iter()? {
+        let (key, _) = item?;
+        applied.insert(key.value().to_string());
+    }
+
+    Ok(applied)
+}
+
+fn mark_migration_applied(txn: &redb::WriteTransaction, migration_id: &str) -> Result<()> {
+    let mut table = txn.open_table(MIGRATIONS_TABLE)?;
+
+    let record = AppliedMigration {
+        id: migration_id.to_string(),
+        applied_at: Utc::now().timestamp() as u64,
+    };
+
+    let serialized =
+        borsh::to_vec(&record).map_err(|e| Error::BorshSerialization(e.to_string()))?;
+    table.insert(migration_id, serialized)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use redb::{Builder, backends::InMemoryBackend};
+
+    fn test_database() -> Arc<Database> {
+        let backend = InMemoryBackend::new();
+        Arc::new(
+            Builder::new()
+                .create_with_backend(backend)
+                .expect("create in-memory database"),
+        )
+    }
+
+    fn test_keypair() -> bitcoin::secp256k1::Keypair {
+        bitcoin::secp256k1::Keypair::new_global(&mut bitcoin::secp256k1::rand::thread_rng())
+    }
+
+    fn test_namespace(wallet_id: &str) -> WalletStorageNamespace {
+        collect_wallet_namespace(wallet_id.to_string(), CurrencyUnit::Sat, test_keypair())
+    }
+
+    #[test]
+    fn collect_wallet_namespace_builds_expected_values() {
+        let wallet_id = "wallet-1";
+        let keys = test_keypair();
+        let namespace = collect_wallet_namespace(wallet_id.to_string(), CurrencyUnit::Sat, keys);
+
+        assert_eq!(namespace.wallet_id, wallet_id);
+        assert_eq!(
+            namespace.proof_table,
+            PocketDB::proof_table_name(wallet_id, &CurrencyUnit::Sat)
+        );
+        assert_eq!(namespace.keys.public_key(), keys.public_key());
+        assert_eq!(namespace.keys.secret_key(), keys.secret_key());
+    }
+
+    #[test]
+    fn load_applied_migrations_is_empty_for_new_database() {
+        let db = test_database();
+        let write_txn = db.begin_write().expect("begin write transaction");
+        let applied = load_applied_migrations(&write_txn).expect("load applied migrations");
+
+        assert!(applied.is_empty());
+    }
+
+    #[test]
+    fn mark_migration_applied_persists_migration() {
+        let db = test_database();
+        let migration_id = "migration-0001-wallet-1";
+
+        {
+            let write_txn = db.begin_write().expect("begin write transaction");
+            mark_migration_applied(&write_txn, migration_id).expect("mark migration as applied");
+            write_txn.commit().expect("commit migration record");
+        }
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+        let applied = load_applied_migrations(&write_txn).expect("load applied migrations");
+
+        assert_eq!(applied.len(), 1);
+        assert!(applied.contains(migration_id));
+    }
+
+    #[test]
+    fn multiple_migrations_are_loaded() {
+        let db = test_database();
+        let first = "migration-0001-wallet-1";
+        let second = "migration-0001-wallet-2";
+
+        {
+            let write_txn = db.begin_write().expect("begin write transaction");
+            mark_migration_applied(&write_txn, first).expect("mark first migration");
+            mark_migration_applied(&write_txn, second).expect("mark second migration");
+            write_txn.commit().expect("commit migration records");
+        }
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+        let applied = load_applied_migrations(&write_txn).expect("load applied migrations");
+
+        assert_eq!(applied.len(), 2);
+        assert!(applied.contains(first));
+        assert!(applied.contains(second));
+    }
+
+    #[tokio::test]
+    async fn migrate_records_migration_for_wallet() {
+        let db = test_database();
+        let namespace = test_namespace("wallet-1");
+        let expected_id = migration_0001::migration_name_for_wallet(&namespace.wallet_id);
+
+        migrate(db.clone(), namespace)
+            .await
+            .expect("migration succeeds");
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+        let applied = load_applied_migrations(&write_txn).expect("load applied migrations");
+
+        assert!(applied.contains(&expected_id));
+    }
+
+    #[tokio::test]
+    async fn migrations_are_scoped_per_wallet() {
+        let db = test_database();
+        let first_namespace = test_namespace("wallet-1");
+        let second_namespace = test_namespace("wallet-2");
+
+        let first_id = migration_0001::migration_name_for_wallet(&first_namespace.wallet_id);
+        let second_id = migration_0001::migration_name_for_wallet(&second_namespace.wallet_id);
+
+        assert_ne!(first_id, second_id);
+
+        migrate(db.clone(), first_namespace)
+            .await
+            .expect("first wallet migration succeeds");
+
+        migrate(db.clone(), second_namespace)
+            .await
+            .expect("second wallet migration succeeds");
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+        let applied = load_applied_migrations(&write_txn).expect("load applied migrations");
+
+        assert!(applied.contains(&first_id));
+        assert!(applied.contains(&second_id));
+    }
+}

--- a/crates/bcr-wallet-persistence/src/redb/mod.rs
+++ b/crates/bcr-wallet-persistence/src/redb/mod.rs
@@ -1,4 +1,5 @@
 pub mod contact;
+pub mod migration;
 pub mod mintmelt;
 pub mod nostr;
 pub mod payment_request;
@@ -9,6 +10,8 @@ pub mod transaction;
 use crate::error::Result;
 pub use ::redb::Database;
 use bcr_common::cashu::CurrencyUnit;
+use bcr_wallet_core::types::Seed;
+use bcr_wallet_core::util::keypair_from_seed;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -26,6 +29,7 @@ pub async fn build_wallet_dbs(
     wallet_id: &str,
     debit: &CurrencyUnit,
     db: Arc<Database>,
+    seed: Seed,
 ) -> Result<(
     transaction::TransactionDB,
     pocket::PocketDB,
@@ -34,8 +38,15 @@ pub async fn build_wallet_dbs(
     contact::ContactDB,
     payment_request::PaymentRequestDB,
 )> {
+    let keys = keypair_from_seed(seed);
+
+    // Execute Migrations for wallet
+    let wallet_namespace =
+        migration::collect_wallet_namespace(wallet_id.to_owned(), debit.to_owned(), keys);
+    migration::migrate(db.clone(), wallet_namespace).await?;
+
     let txdb = transaction::TransactionDB::new(db.clone(), wallet_id)?;
-    let debitdb = pocket::PocketDB::new(db.clone(), wallet_id, debit)?;
+    let debitdb = pocket::PocketDB::new(db.clone(), wallet_id, debit, keys)?;
     let mintmeltdb = mintmelt::MintMeltDB::new(db.clone(), wallet_id, debit)?;
     let nostrdb = nostr::NostrDB::new(db.clone(), wallet_id)?;
     let contactdb = contact::ContactDB::new(db.clone(), wallet_id)?;

--- a/crates/bcr-wallet-persistence/src/redb/pocket.rs
+++ b/crates/bcr-wallet-persistence/src/redb/pocket.rs
@@ -7,7 +7,14 @@ use bcr_common::cashu::{
     self, CurrencyUnit, nut00 as cdk00, nut01 as cdk01, nut02 as cdk02, nut07 as cdk07,
     nut12 as cdk12, secret::Secret,
 };
+use bcr_common::wire::borsh::{
+    deserialize_cashu_amount, deserialize_from_str, deserialize_optionproofdleq,
+    deserialize_optionproofwitness, serialize_as_str, serialize_cashu_amount,
+    serialize_optionproofdleq, serialize_optionproofwitness,
+};
+use bcr_wallet_core::crypto;
 use bitcoin::secp256k1;
+use borsh::{BorshDeserialize, BorshSerialize};
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, TableError};
 use std::{collections::HashMap, sync::Arc};
 use tokio::task::spawn_blocking;
@@ -74,23 +81,65 @@ fn premints_from_storage(stored: PremintStorage) -> HashMap<cashu::Id, cdk00::Pr
         .collect()
 }
 
-///////////////////////////////////////////// ProofEntry
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
-struct ProofEntry {
+/// StoredProof is a versioned, encrypted, borsh-serialized
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) enum StoredProof {
+    V1(EncryptedProofPayloadV1),
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) struct EncryptedProofPayloadV1 {
+    pub ciphertext: Vec<u8>,
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) struct StoredProofPayloadV1 {
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
     y: cdk01::PublicKey,
+    #[borsh(
+        serialize_with = "serialize_cashu_amount",
+        deserialize_with = "deserialize_cashu_amount"
+    )]
     amount: bcr_common::cashu::Amount,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
     keyset_id: cdk02::Id,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
     secret: Secret,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
     c: cdk01::PublicKey,
+    #[borsh(
+        serialize_with = "serialize_optionproofwitness",
+        deserialize_with = "deserialize_optionproofwitness"
+    )]
     witness: Option<cdk00::Witness>,
+    #[borsh(
+        serialize_with = "serialize_optionproofdleq",
+        deserialize_with = "deserialize_optionproofdleq"
+    )]
     dleq: Option<cdk12::ProofDleq>,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
     state: cdk07::State,
 }
 
-impl std::convert::From<cdk00::Proof> for ProofEntry {
+impl std::convert::From<cdk00::Proof> for StoredProofPayloadV1 {
     fn from(proof: cdk00::Proof) -> Self {
         let y = proof.y().expect("Hash to curve should not fail");
-        ProofEntry {
+        StoredProofPayloadV1 {
             y,
             amount: proof.amount,
             keyset_id: proof.keyset_id,
@@ -103,8 +152,8 @@ impl std::convert::From<cdk00::Proof> for ProofEntry {
     }
 }
 
-impl std::convert::From<ProofEntry> for cdk00::Proof {
-    fn from(entry: ProofEntry) -> Self {
+impl std::convert::From<StoredProofPayloadV1> for cdk00::Proof {
+    fn from(entry: StoredProofPayloadV1) -> Self {
         cdk00::Proof {
             amount: entry.amount,
             keyset_id: entry.keyset_id,
@@ -115,6 +164,34 @@ impl std::convert::From<ProofEntry> for cdk00::Proof {
             p2pk_e: None,
         }
     }
+}
+
+pub(super) fn to_stored_proof_v1(
+    proof: cdk00::Proof,
+    state: Option<cdk07::State>,
+    keys: bitcoin::secp256k1::Keypair,
+) -> Result<StoredProof> {
+    let mut payload = StoredProofPayloadV1::from(proof);
+    if let Some(state) = state {
+        payload.state = state;
+    }
+    let encoded = borsh::to_vec(&payload).map_err(|e| Error::BorshSerialization(e.to_string()))?;
+    let encrypted = crypto::encrypt_ecies(&encoded, &keys.public_key())?;
+    Ok(StoredProof::V1(EncryptedProofPayloadV1 {
+        ciphertext: encrypted,
+    }))
+}
+
+pub(super) fn from_stored_proof_v1(
+    proof: StoredProof,
+    keys: bitcoin::secp256k1::Keypair,
+) -> Result<(cdk00::Proof, cdk07::State)> {
+    let StoredProof::V1(encrypted_payload) = proof;
+    let decrypted = crypto::decrypt_ecies(&encrypted_payload.ciphertext, &keys.secret_key())?;
+    let decoded: StoredProofPayloadV1 =
+        borsh::from_slice(&decrypted).map_err(|e| Error::BorshSerialization(e.to_string()))?;
+    let state = decoded.state;
+    Ok((decoded.into(), state))
 }
 
 ///////////////////////////////////////////// CounterEntry
@@ -130,6 +207,7 @@ pub struct PocketDB {
     proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
     counter_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
     commitment_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+    keys: bitcoin::secp256k1::Keypair,
 }
 
 impl PocketDB {
@@ -137,16 +215,31 @@ impl PocketDB {
     const COUNTER_BASE_DB_NAME: &'static str = "counters";
     const COMMITMENT_BASE_DB_NAME: &'static str = "commitments";
 
-    pub fn new(db: Arc<Database>, wallet_id: &str, unit: &CurrencyUnit) -> Result<Self> {
+    pub fn proof_table_name(wallet_id: &str, unit: &CurrencyUnit) -> String {
+        format!("{wallet_id}_{unit}_{}", Self::PROOF_BASE_DB_NAME)
+    }
+
+    pub fn counter_table_name(wallet_id: &str, unit: &CurrencyUnit) -> String {
+        format!("{wallet_id}_{unit}_{}", Self::COUNTER_BASE_DB_NAME)
+    }
+
+    pub fn commitment_table_name(wallet_id: &str, unit: &CurrencyUnit) -> String {
+        format!("{wallet_id}_{unit}_{}", Self::COMMITMENT_BASE_DB_NAME)
+    }
+
+    pub fn new(
+        db: Arc<Database>,
+        wallet_id: &str,
+        unit: &CurrencyUnit,
+        keys: bitcoin::secp256k1::Keypair,
+    ) -> Result<Self> {
         // Leak once to get static string, because of dynamically generated table names
         let proof_name: &'static str =
-            Box::leak(format!("{wallet_id}_{unit}_{}", Self::PROOF_BASE_DB_NAME).into_boxed_str());
-        let counter_name: &'static str = Box::leak(
-            format!("{wallet_id}_{unit}_{}", Self::COUNTER_BASE_DB_NAME).into_boxed_str(),
-        );
-        let commitment_name: &'static str = Box::leak(
-            format!("{wallet_id}_{unit}_{}", Self::COMMITMENT_BASE_DB_NAME).into_boxed_str(),
-        );
+            Box::leak(Self::proof_table_name(wallet_id, unit).into_boxed_str());
+        let counter_name: &'static str =
+            Box::leak(Self::counter_table_name(wallet_id, unit).into_boxed_str());
+        let commitment_name: &'static str =
+            Box::leak(Self::commitment_table_name(wallet_id, unit).into_boxed_str());
 
         let proof_table = TableDefinition::new(proof_name);
         let counter_table = TableDefinition::new(counter_name);
@@ -156,24 +249,26 @@ impl PocketDB {
             proof_table,
             counter_table,
             commitment_table,
+            keys,
         })
     }
 
     fn store_new_sync(
         db: Arc<Database>,
         proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        keys: bitcoin::secp256k1::Keypair,
         proof: cdk00::Proof,
     ) -> Result<cdk01::PublicKey> {
-        let entry = ProofEntry::from(proof);
-        let y = entry.y;
+        let y = proof.y().expect("valid y");
+        let entry = to_stored_proof_v1(proof, None, keys)?;
 
         let write_txn = db.begin_write()?;
 
         {
             let mut table = write_txn.open_table(proof_table)?;
 
-            let mut serialized = Vec::new();
-            ciborium::into_writer(&entry, &mut serialized)?;
+            let serialized =
+                borsh::to_vec(&entry).map_err(|e| Error::BorshSerialization(e.to_string()))?;
             table.insert(y.to_bytes().as_slice(), serialized)?;
         }
 
@@ -184,19 +279,19 @@ impl PocketDB {
     fn store_pendingspent_sync(
         db: Arc<Database>,
         proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        keys: bitcoin::secp256k1::Keypair,
         proof: cdk00::Proof,
     ) -> Result<cdk01::PublicKey> {
-        let mut entry = ProofEntry::from(proof);
-        entry.state = cdk07::State::PendingSpent;
-        let y = entry.y;
+        let y = proof.y().expect("valid y");
+        let entry = to_stored_proof_v1(proof, Some(cdk07::State::PendingSpent), keys)?;
 
         let write_txn = db.begin_write()?;
 
         {
             let mut table = write_txn.open_table(proof_table)?;
+            let serialized =
+                borsh::to_vec(&entry).map_err(|e| Error::BorshSerialization(e.to_string()))?;
 
-            let mut serialized = Vec::new();
-            ciborium::into_writer(&entry, &mut serialized)?;
             table.insert(y.to_bytes().as_slice(), serialized)?;
         }
 
@@ -207,8 +302,9 @@ impl PocketDB {
     fn load_proof_sync(
         db: Arc<Database>,
         proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        keys: bitcoin::secp256k1::Keypair,
         y: cdk01::PublicKey,
-    ) -> Result<Option<ProofEntry>> {
+    ) -> Result<Option<(cdk00::Proof, cdk07::State)>> {
         let read_txn = db.begin_read()?;
 
         match read_txn.open_table(proof_table) {
@@ -216,8 +312,10 @@ impl PocketDB {
                 let entry = table.get(y.to_bytes().as_slice())?;
                 match entry {
                     Some(e) => {
-                        let proof: ProofEntry = ciborium::from_reader(e.value().as_slice())?;
-                        Ok(Some(proof))
+                        let deserialized: StoredProof = borsh::from_slice(e.value().as_slice())
+                            .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                        let (proof, state) = from_stored_proof_v1(deserialized, keys)?;
+                        Ok(Some((proof, state)))
                     }
                     None => Ok(None),
                 }
@@ -230,8 +328,9 @@ impl PocketDB {
     fn load_proofs_sync(
         db: Arc<Database>,
         proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        keys: bitcoin::secp256k1::Keypair,
         ys: Vec<cdk01::PublicKey>,
-    ) -> Result<Vec<ProofEntry>> {
+    ) -> Result<Vec<(cdk00::Proof, cdk07::State)>> {
         let read_txn = db.begin_read()?;
         match read_txn.open_table(proof_table) {
             Ok(table) => {
@@ -239,9 +338,11 @@ impl PocketDB {
                 for y in ys.iter() {
                     match table.get(y.to_bytes().as_slice())? {
                         Some(entry) => {
-                            let proof: ProofEntry =
-                                ciborium::from_reader(entry.value().as_slice())?;
-                            res.push(proof)
+                            let deserialized: StoredProof =
+                                borsh::from_slice(entry.value().as_slice())
+                                    .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                            let (proof, state) = from_stored_proof_v1(deserialized, keys)?;
+                            res.push((proof, state))
                         }
                         None => {
                             return Err(Error::ProofNotFound(y.to_owned()));
@@ -258,16 +359,19 @@ impl PocketDB {
     fn delete_proof_sync(
         db: Arc<Database>,
         proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        keys: bitcoin::secp256k1::Keypair,
         y: cdk01::PublicKey,
-    ) -> Result<Option<ProofEntry>> {
+    ) -> Result<Option<(cdk00::Proof, cdk07::State)>> {
         let write_txn = db.begin_write()?;
 
         let old = {
             let mut table = write_txn.open_table(proof_table)?;
             match table.remove(y.to_bytes().as_slice())? {
                 Some(old) => {
-                    let proof: ProofEntry = ciborium::from_reader(old.value().as_slice())?;
-                    Some(proof)
+                    let deserialized: StoredProof = borsh::from_slice(old.value().as_slice())
+                        .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                    let (proof, state) = from_stored_proof_v1(deserialized, keys)?;
+                    Some((proof, state))
                 }
                 None => None,
             }
@@ -286,9 +390,10 @@ impl PocketDB {
         match read_txn.open_table(proof_table) {
             Ok(table) => {
                 let mut res = Vec::new();
-                for (_, v) in table.range::<&[u8]>(..)?.flatten() {
-                    let proof: ProofEntry = ciborium::from_reader(v.value().as_slice())?;
-                    res.push(proof.y);
+                for item in table.range::<&[u8]>(..)? {
+                    let (k, _) = item?;
+                    let y = cdk01::PublicKey::from_slice(k.value().to_vec().as_slice())?;
+                    res.push(y);
                 }
                 Ok(res)
             }
@@ -300,21 +405,24 @@ impl PocketDB {
     fn list_sync(
         db: Arc<Database>,
         proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        keys: bitcoin::secp256k1::Keypair,
         state: Option<cdk07::State>,
-    ) -> Result<Vec<ProofEntry>> {
+    ) -> Result<Vec<(cdk00::Proof, cdk07::State)>> {
         let read_txn = db.begin_read()?;
 
         match read_txn.open_table(proof_table) {
             Ok(table) => {
                 let mut res = Vec::new();
                 for (_, v) in table.range::<&[u8]>(..)?.flatten() {
-                    let proof: ProofEntry = ciborium::from_reader(v.value().as_slice())?;
+                    let deserialized: StoredProof = borsh::from_slice(v.value().as_slice())
+                        .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                    let (proof, proof_state) = from_stored_proof_v1(deserialized, keys)?;
                     if let Some(s) = state {
-                        if s == proof.state {
-                            res.push(proof);
+                        if s == proof_state {
+                            res.push((proof, proof_state));
                         }
                     } else {
-                        res.push(proof)
+                        res.push((proof, proof_state))
                     }
                 }
                 Ok(res)
@@ -327,28 +435,31 @@ impl PocketDB {
     fn update_entry_state_sync(
         db: Arc<Database>,
         proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        keys: bitcoin::secp256k1::Keypair,
         y: cdk01::PublicKey,
         old_state_set: &[cdk07::State],
         new_state: cdk07::State,
-    ) -> Result<ProofEntry> {
+    ) -> Result<(cdk00::Proof, cdk07::State)> {
         let write_txn = db.begin_write()?;
         let new_value = {
             let mut table = write_txn.open_table(proof_table)?;
             let old_value = table.get(y.to_bytes().as_slice())?.map(|v| v.value());
 
             if let Some(old_value) = old_value {
-                let mut proof: ProofEntry = ciborium::from_reader(old_value.as_slice())?;
+                let deserialized: StoredProof = borsh::from_slice(old_value.as_slice())
+                    .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                let (proof, proof_state) = from_stored_proof_v1(deserialized, keys)?;
 
-                if !old_state_set.contains(&proof.state) {
+                if !old_state_set.contains(&proof_state) {
                     return Err(Error::InvalidProofState(y));
                 }
 
-                proof.state = new_state;
+                let entry = to_stored_proof_v1(proof.clone(), Some(new_state), keys)?;
+                let serialized =
+                    borsh::to_vec(&entry).map_err(|e| Error::BorshSerialization(e.to_string()))?;
 
-                let mut serialized = Vec::new();
-                ciborium::into_writer(&proof, &mut serialized)?;
                 table.insert(y.to_bytes().as_slice(), serialized)?;
-                proof
+                (proof, new_state)
             } else {
                 return Err(Error::ProofNotFound(y));
             }
@@ -586,22 +697,24 @@ impl PocketRepository for PocketDB {
     async fn store_new(&self, proof: cdk00::Proof) -> Result<cdk01::PublicKey> {
         let db_clone = self.db.clone();
         let table = self.proof_table;
-        spawn_blocking(move || Self::store_new_sync(db_clone, table, proof)).await?
+        let keys = self.keys;
+        spawn_blocking(move || Self::store_new_sync(db_clone, table, keys, proof)).await?
     }
 
     async fn store_pendingspent(&self, proof: cdk00::Proof) -> Result<cdk01::PublicKey> {
         let db_clone = self.db.clone();
         let table = self.proof_table;
-        spawn_blocking(move || Self::store_pendingspent_sync(db_clone, table, proof)).await?
+        let keys = self.keys;
+        spawn_blocking(move || Self::store_pendingspent_sync(db_clone, table, keys, proof)).await?
     }
 
     async fn load_proof(&self, y: cdk01::PublicKey) -> Result<(cdk00::Proof, cdk07::State)> {
         let db_clone = self.db.clone();
         let table = self.proof_table;
-        let res = spawn_blocking(move || Self::load_proof_sync(db_clone, table, y)).await??;
-        let proof = res.ok_or(Error::ProofNotFound(y))?;
-        let state = proof.state;
-        Ok((proof.into(), state))
+        let keys = self.keys;
+        let res = spawn_blocking(move || Self::load_proof_sync(db_clone, table, keys, y)).await??;
+        let (proof, state) = res.ok_or(Error::ProofNotFound(y))?;
+        Ok((proof, state))
     }
 
     async fn load_proofs(
@@ -611,11 +724,12 @@ impl PocketRepository for PocketDB {
         let db_clone = self.db.clone();
         let ys_clone = ys.to_owned();
         let table = self.proof_table;
-        let res =
-            spawn_blocking(move || Self::load_proofs_sync(db_clone, table, ys_clone)).await??;
+        let keys = self.keys;
+        let res = spawn_blocking(move || Self::load_proofs_sync(db_clone, table, keys, ys_clone))
+            .await??;
         Ok(res
             .into_iter()
-            .map(|entry| (entry.y, cdk00::Proof::from(entry)))
+            .map(|(entry, _)| (entry.y().expect("valid y"), entry))
             .collect())
     }
 
@@ -625,34 +739,37 @@ impl PocketRepository for PocketDB {
     ) -> Result<Option<(cdk00::Proof, cdk07::State)>> {
         let db_clone = self.db.clone();
         let table = self.proof_table;
-        let proof = spawn_blocking(move || Self::delete_proof_sync(db_clone, table, y)).await??;
-        Ok(proof.map(|p| {
-            let state = p.state;
-            (p.into(), state)
-        }))
+        let keys = self.keys;
+        let res =
+            spawn_blocking(move || Self::delete_proof_sync(db_clone, table, keys, y)).await??;
+        Ok(res)
     }
 
     async fn list_unspent(&self) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>> {
         let db_clone = self.db.clone();
         let table = self.proof_table;
-        let list =
-            spawn_blocking(move || Self::list_sync(db_clone, table, Some(cdk07::State::Unspent)))
-                .await??;
+        let keys = self.keys;
+        let list = spawn_blocking(move || {
+            Self::list_sync(db_clone, table, keys, Some(cdk07::State::Unspent))
+        })
+        .await??;
         Ok(list
             .into_iter()
-            .map(|entry| (entry.y, cdk00::Proof::from(entry)))
+            .map(|(entry, _)| (entry.y().expect("valid y"), entry))
             .collect())
     }
 
     async fn list_spent(&self) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>> {
         let db_clone = self.db.clone();
         let table = self.proof_table;
-        let list =
-            spawn_blocking(move || Self::list_sync(db_clone, table, Some(cdk07::State::Spent)))
-                .await??;
+        let keys = self.keys;
+        let list = spawn_blocking(move || {
+            Self::list_sync(db_clone, table, keys, Some(cdk07::State::Spent))
+        })
+        .await??;
         Ok(list
             .into_iter()
-            .map(|entry| (entry.y, cdk00::Proof::from(entry)))
+            .map(|(entry, _)| (entry.y().expect("valid y"), entry))
             .collect())
     }
 
@@ -660,19 +777,21 @@ impl PocketRepository for PocketDB {
         let db_clone = self.db.clone();
         let db_clone_two = self.db.clone();
         let table = self.proof_table;
-        let pending: HashMap<cdk01::PublicKey, cdk00::Proof> =
-            spawn_blocking(move || Self::list_sync(db_clone, table, Some(cdk07::State::Pending)))
-                .await??
-                .into_iter()
-                .map(|entry| (entry.y, cdk00::Proof::from(entry)))
-                .collect();
+        let keys = self.keys;
+        let pending: HashMap<cdk01::PublicKey, cdk00::Proof> = spawn_blocking(move || {
+            Self::list_sync(db_clone, table, keys, Some(cdk07::State::Pending))
+        })
+        .await??
+        .into_iter()
+        .map(|(entry, _)| (entry.y().expect("valid y"), entry))
+        .collect();
         let mut pending_spent: HashMap<cdk01::PublicKey, cdk00::Proof> =
             spawn_blocking(move || {
-                Self::list_sync(db_clone_two, table, Some(cdk07::State::PendingSpent))
+                Self::list_sync(db_clone_two, table, keys, Some(cdk07::State::PendingSpent))
             })
             .await??
             .into_iter()
-            .map(|entry| (entry.y, cdk00::Proof::from(entry)))
+            .map(|(entry, _)| (entry.y().expect("valid y"), entry))
             .collect();
 
         pending_spent.extend(pending);
@@ -682,12 +801,14 @@ impl PocketRepository for PocketDB {
     async fn list_reserved(&self) -> Result<HashMap<cdk01::PublicKey, cdk00::Proof>> {
         let db_clone = self.db.clone();
         let table = self.proof_table;
-        let list =
-            spawn_blocking(move || Self::list_sync(db_clone, table, Some(cdk07::State::Reserved)))
-                .await??;
+        let keys = self.keys;
+        let list = spawn_blocking(move || {
+            Self::list_sync(db_clone, table, keys, Some(cdk07::State::Reserved))
+        })
+        .await??;
         Ok(list
             .into_iter()
-            .map(|entry| (entry.y, cdk00::Proof::from(entry)))
+            .map(|(entry, _)| (entry.y().expect("valid y"), entry))
             .collect())
     }
 
@@ -700,49 +821,55 @@ impl PocketRepository for PocketDB {
     async fn mark_as_pendingspent(&self, y: cdk01::PublicKey) -> Result<cdk00::Proof> {
         let db_clone = self.db.clone();
         let table = self.proof_table;
-        let proof = spawn_blocking(move || {
+        let keys = self.keys;
+        let (proof, _) = spawn_blocking(move || {
             Self::update_entry_state_sync(
                 db_clone,
                 table,
+                keys,
                 y,
                 &[cdk07::State::Unspent],
                 cdk07::State::PendingSpent,
             )
         })
         .await??;
-        Ok(proof.into())
+        Ok(proof)
     }
 
     async fn mark_pending_as_spent(&self, y: cdk01::PublicKey) -> Result<cdk00::Proof> {
         let db_clone = self.db.clone();
         let table = self.proof_table;
-        let proof = spawn_blocking(move || {
+        let keys = self.keys;
+        let (proof, _) = spawn_blocking(move || {
             Self::update_entry_state_sync(
                 db_clone,
                 table,
+                keys,
                 y,
                 &[cdk07::State::Pending, cdk07::State::PendingSpent],
                 cdk07::State::Spent,
             )
         })
         .await??;
-        Ok(proof.into())
+        Ok(proof)
     }
 
     async fn revert_pendingspent_to_unspent(&self, y: cdk01::PublicKey) -> Result<cdk00::Proof> {
         let db_clone = self.db.clone();
         let table = self.proof_table;
-        let proof = spawn_blocking(move || {
+        let keys = self.keys;
+        let (proof, _) = spawn_blocking(move || {
             Self::update_entry_state_sync(
                 db_clone,
                 table,
+                keys,
                 y,
                 &[cdk07::State::PendingSpent],
                 cdk07::State::Unspent,
             )
         })
         .await??;
-        Ok(proof.into())
+        Ok(proof)
     }
 
     async fn counter(&self, kid: bcr_common::cashu::Id) -> Result<u32> {
@@ -827,7 +954,8 @@ mod tests {
                 .create_with_backend(in_mem)
                 .expect("can create in-memory redb"),
         );
-        PocketDB::new(db, wallet_id, &unit).expect("can create PocketDB")
+        let keypair = secp256k1::Keypair::new_global(&mut secp256k1::rand::thread_rng());
+        PocketDB::new(db, wallet_id, &unit, keypair).expect("can create PocketDB")
     }
 
     fn test_proof() -> cdk00::Proof {


### PR DESCRIPTION
First part of the DB migration and versioning effort in Wallet-Core

* Add a Database migration scheme per wallet
* Migrate Proofs persistence to be versioned, encrypted and borsh-serialized 
