### PR TITLE
Counter and Commitment Migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,8 +321,8 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcr-common"
-version = "0.8.0"
-source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=6c66a28a10db9c7f3e8a41c138c0c1281518c278#6c66a28a10db9c7f3e8a41c138c0c1281518c278"
+version = "0.9.0"
+source = "git+https://github.com/BitcreditProtocol/bcr-common.git?rev=2417c42f785d8fabdfea1d1bfd57439ebf6dc0c6#2417c42f785d8fabdfea1d1bfd57439ebf6dc0c6"
 dependencies = [
  "bip39",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ strip = "symbols"
 
 [workspace.dependencies]
 async-trait = {version = "0.1"}
-bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "6c66a28a10db9c7f3e8a41c138c0c1281518c278"}
+bcr-common = {git = "https://github.com/BitcreditProtocol/bcr-common.git", rev = "2417c42f785d8fabdfea1d1bfd57439ebf6dc0c6"}
 bcr-wallet-core = {path = "./crates/bcr-wallet-core"}
 bcr-wallet-api = {path = "./crates/bcr-wallet-api"}
 bcr-wallet-persistence = {path = "./crates/bcr-wallet-persistence"}

--- a/crates/bcr-wallet-api/src/external/mint.rs
+++ b/crates/bcr-wallet-api/src/external/mint.rs
@@ -215,7 +215,7 @@ pub trait ClowderMintConnector: SendSync + std::fmt::Debug {
     async fn post_mint_onchain(
         &self,
         req: wire_mint::OnchainMintRequest,
-    ) -> Result<wire_mint::MintResponse>;
+    ) -> Result<wire_mint::OnchainMintResponse>;
     async fn post_protest_mint(
         &self,
         req: wire_mint::MintProtestRequest,
@@ -531,7 +531,7 @@ impl ClowderMintConnector for HttpClientExt {
     async fn post_mint_onchain(
         &self,
         req: wire_mint::OnchainMintRequest,
-    ) -> Result<wire_mint::MintResponse> {
+    ) -> Result<wire_mint::OnchainMintResponse> {
         let url = self
             .mint_url()
             .join(TreasuryEp::MINT_ONCHAIN_V1_EXT)
@@ -542,7 +542,7 @@ impl ClowderMintConnector for HttpClientExt {
 
         match res.error_for_status_ref() {
             Ok(_) => {
-                let response: wire_mint::MintResponse = res.json().await?;
+                let response: wire_mint::OnchainMintResponse = res.json().await?;
                 Ok(response)
             }
             Err(err) => {
@@ -904,7 +904,7 @@ impl ClowderMintConnector for SentinelClient {
     async fn post_mint_onchain(
         &self,
         req: wire_mint::OnchainMintRequest,
-    ) -> Result<wire_mint::MintResponse> {
+    ) -> Result<wire_mint::OnchainMintResponse> {
         let url = self
             .mint_url()
             .join(TreasuryEp::MINT_ONCHAIN_V1_EXT)
@@ -914,7 +914,7 @@ impl ClowderMintConnector for SentinelClient {
         let res = self.secondary.post(url).json(&req).send().await?;
         match res.error_for_status_ref() {
             Ok(_) => {
-                let response: wire_mint::MintResponse = res.json().await?;
+                let response: wire_mint::OnchainMintResponse = res.json().await?;
                 Ok(response)
             }
             Err(err) => {

--- a/crates/bcr-wallet-api/src/pocket/debit.rs
+++ b/crates/bcr-wallet-api/src/pocket/debit.rs
@@ -1102,6 +1102,13 @@ impl DebitPocketApi for Pocket {
                     result: None,
                 })
             }
+            wire_common::ProtestStatus::Offline => {
+                tracing::warn!("Protest for {qid} returned offline");
+                Ok(ProtestResult {
+                    status: wire_common::ProtestStatus::Offline,
+                    result: None,
+                })
+            }
         }
     }
 
@@ -1185,6 +1192,13 @@ impl DebitPocketApi for Pocket {
                     result: None,
                 })
             }
+            wire_common::ProtestStatus::Offline => {
+                tracing::warn!("Swap protest for {commitment_sig} returned offline");
+                Ok(ProtestResult {
+                    status: wire_common::ProtestStatus::Offline,
+                    result: None,
+                })
+            }
         }
     }
 
@@ -1229,6 +1243,16 @@ impl DebitPocketApi for Pocket {
                     txid: None,
                 })
             }
+            wire_common::ProtestStatus::Offline => {
+                tracing::warn!("Melt protest for {quote_id} returned offline");
+                Ok(MeltProtestResult {
+                    base: ProtestResult {
+                        status: wire_common::ProtestStatus::Offline,
+                        result: None,
+                    },
+                    txid: None,
+                })
+            }
         }
     }
 
@@ -1250,7 +1274,7 @@ mod tests {
         external::mint::{MeltQuoteResult, MockClowderMintConnector},
         pocket::{PocketApi, debit::DebitPocketApi, test_utils::tests::test_kinfos},
     };
-    use bcr_common::{core_tests, wire::mint::MintResponse};
+    use bcr_common::{core_tests, wire::mint::OnchainMintResponse};
     use bcr_wallet_persistence::{
         MockMintMeltRepository, MockPocketRepository,
         test_utils::tests::valid_payment_address_testnet,
@@ -1939,7 +1963,7 @@ mod tests {
         connector
             .expect_post_mint_onchain()
             .times(1)
-            .returning(move |_| Ok(MintResponse { signatures: vec![] }));
+            .returning(move |_| Ok(OnchainMintResponse { signatures: vec![] }));
 
         let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
 
@@ -2566,7 +2590,7 @@ mod tests {
             .expect_post_mint_onchain()
             .times(1)
             .returning(move |_| {
-                Ok(MintResponse {
+                Ok(OnchainMintResponse {
                     signatures: blind_sigs.clone(),
                 })
             });

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -486,6 +486,9 @@ pub async fn cmd_protest_mint(
         bcr_common::wire::common::ProtestStatus::Rabid => {
             res.push_str("Protest returned Rabid - mint declared rabid by betas");
         }
+        bcr_common::wire::common::ProtestStatus::Offline => {
+            res.push_str("Protest returned Offline - mint declared offline by betas");
+        }
     }
 
     Ok(res)
@@ -521,6 +524,9 @@ pub async fn cmd_protest_swap(
         bcr_common::wire::common::ProtestStatus::Rabid => {
             res.push_str("Protest returned Rabid - mint declared rabid by betas");
         }
+        bcr_common::wire::common::ProtestStatus::Offline => {
+            res.push_str("Protest returned Offline - mint declared offline by betas");
+        }
     }
 
     Ok(res)
@@ -553,6 +559,9 @@ pub async fn cmd_protest_melt(
         }
         bcr_common::wire::common::ProtestStatus::Rabid => {
             res.push_str("Protest returned Rabid - mint declared rabid by betas");
+        }
+        bcr_common::wire::common::ProtestStatus::Offline => {
+            res.push_str("Protest returned Offline - mint declared offline by betas");
         }
     }
 

--- a/crates/bcr-wallet-core/src/borsh.rs
+++ b/crates/bcr-wallet-core/src/borsh.rs
@@ -1,4 +1,8 @@
-use bcr_common::cashu;
+use bcr_common::cashu::{self, nut00 as cdk00, nut01 as cdk01, secret::Secret};
+use bcr_common::wire::borsh::{
+    deserialize_blindedmessage, deserialize_cashu_amount, deserialize_from_str, serialize_as_str,
+    serialize_blindedmessage, serialize_cashu_amount,
+};
 use borsh::{
     BorshDeserialize, BorshSerialize,
     io::{Error as BorshError, ErrorKind, Read, Write},
@@ -70,8 +74,103 @@ pub fn deserialize_mint_keyset_infos(
     Ok(infos)
 }
 
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct PremintEntry {
+    #[borsh(
+        serialize_with = "serialize_blindedmessage",
+        deserialize_with = "deserialize_blindedmessage"
+    )]
+    pub blinded_message: cdk00::BlindedMessage,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub secret: Secret,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub secret_key: cdk01::SecretKey,
+    #[borsh(
+        serialize_with = "serialize_cashu_amount",
+        deserialize_with = "deserialize_cashu_amount"
+    )]
+    pub amount: cashu::Amount,
+}
+
+type PremintStorage = Vec<(String, Vec<PremintEntry>)>;
+
+pub fn serialize_premints(
+    premints: &HashMap<cashu::Id, cdk00::PreMintSecrets>,
+    writer: &mut impl Write,
+) -> Result<()> {
+    let stored = premints_to_storage(premints);
+    BorshSerialize::serialize(&stored, writer)
+}
+
+pub fn deserialize_premints(
+    reader: &mut impl Read,
+) -> Result<HashMap<cashu::Id, cdk00::PreMintSecrets>> {
+    let stored = PremintStorage::deserialize_reader(reader)?;
+    premints_from_storage(stored)
+}
+
+fn premints_to_storage(premints: &HashMap<cashu::Id, cdk00::PreMintSecrets>) -> PremintStorage {
+    let mut stored: PremintStorage = premints
+        .iter()
+        .map(|(keyset_id, premint_secrets)| {
+            let entries = premint_secrets
+                .secrets
+                .iter()
+                .map(|premint| PremintEntry {
+                    blinded_message: premint.blinded_message.clone(),
+                    secret: premint.secret.clone(),
+                    secret_key: premint.r.clone(),
+                    amount: premint.amount,
+                })
+                .collect();
+
+            (keyset_id.to_string(), entries)
+        })
+        .collect();
+    stored.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    stored
+}
+
+fn premints_from_storage(
+    stored: PremintStorage,
+) -> Result<HashMap<cashu::Id, cdk00::PreMintSecrets>> {
+    stored
+        .into_iter()
+        .map(|(keyset_id, entries)| {
+            let keyset_id = keyset_id.parse::<cashu::Id>().map_err(|err| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("invalid keyset ID `{keyset_id}`: {err}"),
+                )
+            })?;
+
+            let secrets = entries
+                .into_iter()
+                .map(|entry| cdk00::PreMint {
+                    blinded_message: entry.blinded_message,
+                    secret: entry.secret,
+                    r: entry.secret_key,
+                    amount: entry.amount,
+                })
+                .collect();
+
+            Ok((keyset_id, cdk00::PreMintSecrets { secrets, keyset_id }))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
+    use bcr_common::core_tests::{
+        generate_random_ecash_blindedmessages, generate_random_ecash_keyset,
+    };
+
     use super::*;
     use std::io::Cursor;
 
@@ -97,13 +196,13 @@ mod tests {
         }
     }
 
-    fn serialize(infos: &HashMap<cashu::Id, cashu::KeySetInfo>) -> Vec<u8> {
+    fn serialize_mint_ks_infos(infos: &HashMap<cashu::Id, cashu::KeySetInfo>) -> Vec<u8> {
         let mut bytes = Vec::new();
         serialize_mint_keyset_infos(infos, &mut bytes).expect("serialization should succeed");
         bytes
     }
 
-    fn deserialize(bytes: &[u8]) -> Result<HashMap<cashu::Id, cashu::KeySetInfo>> {
+    fn deserialize_mint_ks_infos(bytes: &[u8]) -> Result<HashMap<cashu::Id, cashu::KeySetInfo>> {
         let mut reader = Cursor::new(bytes);
         deserialize_mint_keyset_infos(&mut reader)
     }
@@ -119,8 +218,9 @@ mod tests {
     #[test]
     fn round_trip_empty_map() {
         let original = HashMap::new();
-        let bytes = serialize(&original);
-        let deserialized = deserialize(&bytes).expect("deserialization should succeed");
+        let bytes = serialize_mint_ks_infos(&original);
+        let deserialized =
+            deserialize_mint_ks_infos(&bytes).expect("deserialization should succeed");
         assert!(deserialized.is_empty());
     }
 
@@ -129,8 +229,9 @@ mod tests {
         let info = keyset_info(KEYSET_ID_1, "sat", true, 100, Some(1_900_000_000));
         let mut original = HashMap::new();
         original.insert(info.id, info);
-        let bytes = serialize(&original);
-        let deserialized = deserialize(&bytes).expect("deserialization should succeed");
+        let bytes = serialize_mint_ks_infos(&original);
+        let deserialized =
+            deserialize_mint_ks_infos(&bytes).expect("deserialization should succeed");
         assert_eq!(deserialized.len(), 1);
         let id = cashu::Id::from_str(KEYSET_ID_1).unwrap();
         let actual = deserialized.get(&id).expect("keyset should exist");
@@ -145,8 +246,9 @@ mod tests {
         let mut original = HashMap::new();
         original.insert(first.id, first);
         original.insert(second.id, second);
-        let bytes = serialize(&original);
-        let deserialized = deserialize(&bytes).expect("deserialization should succeed");
+        let bytes = serialize_mint_ks_infos(&original);
+        let deserialized =
+            deserialize_mint_ks_infos(&bytes).expect("deserialization should succeed");
         assert_eq!(deserialized.len(), original.len());
         for (id, expected) in &original {
             let actual = deserialized
@@ -167,7 +269,10 @@ mod tests {
         let mut map_b = HashMap::new();
         map_b.insert(second.id, second);
         map_b.insert(first.id, first);
-        assert_eq!(serialize(&map_a), serialize(&map_b));
+        assert_eq!(
+            serialize_mint_ks_infos(&map_a),
+            serialize_mint_ks_infos(&map_b)
+        );
     }
 
     #[test]
@@ -176,8 +281,9 @@ mod tests {
         let info = keyset_info(KEYSET_ID_2, "sat", true, 100, None);
         let mut original = HashMap::new();
         original.insert(map_id, info);
-        let bytes = serialize(&original);
-        let deserialized = deserialize(&bytes).expect("deserialization should succeed");
+        let bytes = serialize_mint_ks_infos(&original);
+        let deserialized =
+            deserialize_mint_ks_infos(&bytes).expect("deserialization should succeed");
         let actual = deserialized
             .get(&map_id)
             .expect("map key should be preserved");
@@ -197,7 +303,92 @@ mod tests {
             },
         )];
         let bytes = borsh::to_vec(&stored).expect("test data should serialize");
-        let error = deserialize(&bytes).expect_err("invalid ID must be rejected");
+        let error = deserialize_mint_ks_infos(&bytes).expect_err("invalid ID must be rejected");
         assert_eq!(error.kind(), ErrorKind::InvalidData);
+    }
+
+    // serialize premints
+    fn sample_premints() -> HashMap<cashu::Id, cdk00::PreMintSecrets> {
+        let (_, keyset) = generate_random_ecash_keyset();
+
+        let amounts = [
+            cashu::Amount::from(1),
+            cashu::Amount::from(2),
+            cashu::Amount::from(4),
+            cashu::Amount::from(8),
+        ];
+
+        let secrets = generate_random_ecash_blindedmessages(keyset.id, &amounts)
+            .into_iter()
+            .map(|(blinded_message, secret, r)| cdk00::PreMint {
+                amount: blinded_message.amount,
+                blinded_message,
+                secret,
+                r,
+            })
+            .collect();
+
+        HashMap::from([(
+            keyset.id,
+            cdk00::PreMintSecrets {
+                keyset_id: keyset.id,
+                secrets,
+            },
+        )])
+    }
+
+    #[test]
+    fn serialize_and_deserialize_premints_roundtrip() {
+        let original = sample_premints();
+        let mut encoded = Vec::new();
+        serialize_premints(&original, &mut encoded).expect("premints should serialize");
+        let decoded =
+            deserialize_premints(&mut Cursor::new(encoded)).expect("premints should deserialize");
+        assert_eq!(decoded.len(), original.len());
+        for (keyset_id, original_premints) in &original {
+            let decoded_premints = decoded
+                .get(keyset_id)
+                .expect("decoded map should contain keyset");
+            assert_eq!(decoded_premints.keyset_id, original_premints.keyset_id);
+            assert_eq!(
+                decoded_premints.secrets.len(),
+                original_premints.secrets.len()
+            );
+            for (decoded, original) in decoded_premints
+                .secrets
+                .iter()
+                .zip(&original_premints.secrets)
+            {
+                assert_eq!(decoded.blinded_message, original.blinded_message);
+                assert_eq!(decoded.secret, original.secret);
+                assert_eq!(decoded.r, original.r);
+                assert_eq!(decoded.amount, original.amount);
+            }
+        }
+    }
+
+    #[test]
+    fn empty_premints_roundtrip() {
+        let original = HashMap::new();
+        let mut encoded = Vec::new();
+        serialize_premints(&original, &mut encoded).expect("empty premints should serialize");
+        let decoded = deserialize_premints(&mut Cursor::new(encoded))
+            .expect("empty premints should deserialize");
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn deserialize_premints_rejects_invalid_keyset_id() {
+        let stored: PremintStorage = vec![("not-a-valid-keyset-id".to_owned(), Vec::new())];
+        let mut encoded = Vec::new();
+        BorshSerialize::serialize(&stored, &mut encoded)
+            .expect("storage representation should serialize");
+        let error = deserialize_premints(&mut Cursor::new(encoded))
+            .expect_err("invalid keyset id should fail");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            error.to_string().contains("invalid keyset ID"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -1282,6 +1282,7 @@ pub enum ProtestStatus {
     #[default]
     Resolved,
     Rabid,
+    Offline,
 }
 
 impl From<bcr_common::wire::common::ProtestStatus> for ProtestStatus {
@@ -1289,6 +1290,7 @@ impl From<bcr_common::wire::common::ProtestStatus> for ProtestStatus {
         match s {
             bcr_common::wire::common::ProtestStatus::Resolved => ProtestStatus::Resolved,
             bcr_common::wire::common::ProtestStatus::Rabid => ProtestStatus::Rabid,
+            bcr_common::wire::common::ProtestStatus::Offline => ProtestStatus::Offline,
         }
     }
 }

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -3058,6 +3058,7 @@ impl SseDecode for crate::api::ProtestStatus {
         return match inner {
             0 => crate::api::ProtestStatus::Resolved,
             1 => crate::api::ProtestStatus::Rabid,
+            2 => crate::api::ProtestStatus::Offline,
             _ => unreachable!("Invalid variant for ProtestStatus: {}", inner),
         };
     }
@@ -4691,6 +4692,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::ProtestStatus {
         match self {
             Self::Resolved => 0.into_dart(),
             Self::Rabid => 1.into_dart(),
+            Self::Offline => 2.into_dart(),
             _ => unreachable!(),
         }
     }
@@ -6837,6 +6839,7 @@ impl SseEncode for crate::api::ProtestStatus {
             match self {
                 crate::api::ProtestStatus::Resolved => 0,
                 crate::api::ProtestStatus::Rabid => 1,
+                crate::api::ProtestStatus::Offline => 2,
                 _ => {
                     unimplemented!("");
                 }

--- a/crates/bcr-wallet-persistence/src/error.rs
+++ b/crates/bcr-wallet-persistence/src/error.rs
@@ -62,4 +62,6 @@ pub enum Error {
     PaymentRequestAlreadyExists(String),
     #[error("Payment Request not found {0}")]
     PaymentRequestNotFound(String),
+    #[error("Counter Exhausted")]
+    CounterExhausted,
 }

--- a/crates/bcr-wallet-persistence/src/redb/migration/migration_0001.rs
+++ b/crates/bcr-wallet-persistence/src/redb/migration/migration_0001.rs
@@ -1,10 +1,18 @@
+use std::collections::HashMap;
+
 use crate::{
+    SwapCommitmentRecord,
     error::{Error, Result},
-    redb::{migration::WalletStorageNamespace, pocket},
+    redb::{
+        migration::WalletStorageNamespace,
+        pocket::{self, StoredCounter, StoredCounterPayloadV1},
+    },
 };
 use bcr_common::cashu::{
-    nut00 as cdk00, nut01 as cdk01, nut02 as cdk02, nut07 as cdk07, nut12 as cdk12, secret::Secret,
+    self, nut00 as cdk00, nut01 as cdk01, nut02 as cdk02, nut07 as cdk07, nut12 as cdk12,
+    secret::Secret,
 };
+use bitcoin::secp256k1;
 use redb::{ReadableTable, TableDefinition};
 
 ///////////////////////////////////////////////////////////////// MIGRATION 0001
@@ -18,11 +26,23 @@ pub(super) fn migration_name_for_wallet(wallet_id: &str) -> String {
     )
 }
 
-pub(super) fn migration_0001_add_proof_envelope_and_encryption(
+pub(super) fn migration_0001_envelope_and_encryption(
     txn: &redb::WriteTransaction,
     namespace: &WalletStorageNamespace,
 ) -> Result<()> {
+    tracing::info!("Migrating proofs..");
     migrate_proof_table_to_envelope_and_encryption(txn, &namespace.proof_table, &namespace.keys)?;
+    tracing::info!("Migrated proofs.");
+    tracing::info!("Migrating counters..");
+    migrate_counter_table_to_envelope(txn, &namespace.counter_table)?;
+    tracing::info!("Migrated counters.");
+    tracing::info!("Migrating commitments..");
+    migrate_commitment_table_to_envelope_and_encryption(
+        txn,
+        &namespace.commitment_table,
+        &namespace.keys,
+    )?;
+    tracing::info!("Migrated commitments.");
 
     Ok(())
 }
@@ -64,6 +84,97 @@ fn migrate_proof_table_to_envelope_and_encryption(
     }
 
     Ok(())
+}
+
+// Fetch old counters
+// put in V1 envelope
+// Store new counters
+fn migrate_counter_table_to_envelope(txn: &redb::WriteTransaction, table_name: &str) -> Result<()> {
+    let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+
+    let mut table = match txn.open_table(table_def) {
+        Ok(table) => table,
+        Err(redb::TableError::TableDoesNotExist(_)) => {
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut migrated_counters: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    for item in table.iter()? {
+        let (k, v) = item?;
+        let counter: CounterEntry = ciborium::from_reader(v.value().as_slice())?;
+        let stored_counter_v1 = StoredCounter::V1(StoredCounterPayloadV1 {
+            kid: counter.kid,
+            counter: counter.counter,
+        });
+
+        let migrated_counter_bytes = borsh::to_vec(&stored_counter_v1)
+            .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+        migrated_counters.push((k.value().to_vec(), migrated_counter_bytes));
+    }
+
+    for (key, new_counter) in migrated_counters.iter() {
+        table.insert(key.as_slice(), new_counter)?;
+    }
+
+    Ok(())
+}
+
+// Fetch old commitments
+// convert to records
+// put in V1 envelope and encrypt
+// Store new commitments
+fn migrate_commitment_table_to_envelope_and_encryption(
+    txn: &redb::WriteTransaction,
+    table_name: &str,
+    keys: &bitcoin::secp256k1::Keypair,
+) -> Result<()> {
+    let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+
+    let mut table = match txn.open_table(table_def) {
+        Ok(table) => table,
+        Err(redb::TableError::TableDoesNotExist(_)) => {
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut migrated_commitments: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    for item in table.iter()? {
+        let (k, v) = item?;
+        let c: Commitment = ciborium::from_reader(v.value().as_slice())?;
+        let secret = secp256k1::SecretKey::from_slice(&c.ephemeral_secret)
+            .map_err(|e| Error::Custom(format!("invalid ephemeral secret: {e}")))?;
+        let record = SwapCommitmentRecord {
+            inputs: c.inputs,
+            outputs: c.outputs,
+            expiry: c.expiry,
+            commitment: c.commitment,
+            ephemeral_secret: secret,
+            body_content: c.body_content,
+            wallet_key: c.wallet_key,
+            premints: premints_from_storage(c.premints),
+        };
+        let stored_commitment_v1 = pocket::to_stored_commitment_v1(record, keys.to_owned())?;
+
+        let migrated_commitment_bytes = borsh::to_vec(&stored_commitment_v1)
+            .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+        migrated_commitments.push((k.value().to_vec(), migrated_commitment_bytes));
+    }
+
+    for (key, new_commitment) in migrated_commitments.iter() {
+        table.insert(key.as_slice(), new_commitment)?;
+    }
+
+    Ok(())
+}
+
+///////////////////////////////////////////// CounterEntry
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct CounterEntry {
+    kid: cdk02::Id,
+    counter: u32,
 }
 
 ///////////////////////////////////////////// pre-0001 ProofEntry for the 0001 migration
@@ -108,13 +219,60 @@ impl std::convert::From<ProofEntry> for cdk00::Proof {
         }
     }
 }
+///////////////////////////////////////////// Commitment
+type PremintStorage = Vec<(
+    cashu::Id,
+    Vec<(
+        cdk00::BlindedMessage,
+        Secret,
+        cdk01::SecretKey,
+        cashu::Amount,
+    )>,
+)>;
+
+fn premints_from_storage(stored: PremintStorage) -> HashMap<cashu::Id, cdk00::PreMintSecrets> {
+    stored
+        .into_iter()
+        .map(|(kid, tuples)| {
+            let secrets = tuples
+                .into_iter()
+                .map(|(bm, secret, r, amount)| cdk00::PreMint {
+                    blinded_message: bm,
+                    secret,
+                    r,
+                    amount,
+                })
+                .collect();
+            (
+                kid,
+                cdk00::PreMintSecrets {
+                    secrets,
+                    keyset_id: kid,
+                },
+            )
+        })
+        .collect()
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+struct Commitment {
+    inputs: Vec<cashu::PublicKey>,
+    outputs: Vec<cashu::BlindedMessage>,
+    expiry: u64,
+    commitment: secp256k1::schnorr::Signature,
+    ephemeral_secret: Vec<u8>,
+    body_content: String,
+    wallet_key: cashu::PublicKey,
+    #[serde(default)]
+    premints: PremintStorage,
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::redb::{
         migration::collect_wallet_namespace,
-        pocket::{StoredProof, from_stored_proof_v1},
+        pocket::{StoredCommitment, StoredProof, from_stored_commitment_v1, from_stored_proof_v1},
     };
     use bcr_common::{
         cashu::{Amount, CurrencyUnit},
@@ -224,8 +382,12 @@ mod tests {
 
         let write_txn = db.begin_write().expect("begin write transaction");
 
-        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
-            .expect("migration succeeds for missing proof table");
+        migrate_proof_table_to_envelope_and_encryption(
+            &write_txn,
+            &namespace.proof_table,
+            &namespace.keys,
+        )
+        .expect("migration succeeds for missing proof table");
 
         write_txn.commit().expect("commit migration");
     }
@@ -245,8 +407,12 @@ mod tests {
         );
 
         let write_txn = db.begin_write().expect("begin write transaction");
-        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
-            .expect("migrate legacy proof");
+        migrate_proof_table_to_envelope_and_encryption(
+            &write_txn,
+            &namespace.proof_table,
+            &namespace.keys,
+        )
+        .expect("migrate legacy proof");
         write_txn.commit().expect("commit migration");
         let (migrated, state) = load_migrated_proof(&db, &namespace.proof_table, y, keys);
 
@@ -268,8 +434,12 @@ mod tests {
             cdk07::State::PendingSpent,
         );
         let write_txn = db.begin_write().expect("begin write transaction");
-        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
-            .expect("migrate legacy proof");
+        migrate_proof_table_to_envelope_and_encryption(
+            &write_txn,
+            &namespace.proof_table,
+            &namespace.keys,
+        )
+        .expect("migrate legacy proof");
         write_txn.commit().expect("commit migration");
         let (migrated, state) = load_migrated_proof(&db, &namespace.proof_table, y, keys);
 
@@ -290,8 +460,12 @@ mod tests {
 
         let write_txn = db.begin_write().expect("begin write transaction");
 
-        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
-            .expect("migrate legacy proof");
+        migrate_proof_table_to_envelope_and_encryption(
+            &write_txn,
+            &namespace.proof_table,
+            &namespace.keys,
+        )
+        .expect("migrate legacy proof");
 
         write_txn.commit().expect("commit migration");
 
@@ -320,8 +494,12 @@ mod tests {
 
         let write_txn = db.begin_write().expect("begin write transaction");
 
-        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
-            .expect("migrate legacy proof");
+        migrate_proof_table_to_envelope_and_encryption(
+            &write_txn,
+            &namespace.proof_table,
+            &namespace.keys,
+        )
+        .expect("migrate legacy proof");
 
         write_txn.commit().expect("commit migration");
 
@@ -381,8 +559,12 @@ mod tests {
 
         let write_txn = db.begin_write().expect("begin write transaction");
 
-        migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)
-            .expect("migrate all legacy proofs");
+        migrate_proof_table_to_envelope_and_encryption(
+            &write_txn,
+            &namespace.proof_table,
+            &namespace.keys,
+        )
+        .expect("migrate all legacy proofs");
 
         write_txn.commit().expect("commit migration");
 
@@ -401,5 +583,396 @@ mod tests {
 
         assert_eq!(migrated_third, third);
         assert_eq!(third_state, cdk07::State::Spent);
+    }
+
+    // counter
+    fn insert_legacy_counter(
+        db: &Arc<Database>,
+        table_name: &str,
+        key: &[u8],
+        counter: CounterEntry,
+    ) {
+        let mut encoded = Vec::new();
+        ciborium::into_writer(&counter, &mut encoded).expect("serialize legacy counter");
+        let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+        let write_txn = db.begin_write().expect("begin write transaction");
+        {
+            let mut table = write_txn
+                .open_table(table_def)
+                .expect("open legacy counter table");
+
+            table.insert(key, encoded).expect("insert legacy counter");
+        }
+        write_txn.commit().expect("commit legacy counter");
+    }
+
+    fn load_migrated_counter(db: &Arc<Database>, table_name: &str, key: &[u8]) -> StoredCounter {
+        let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+        let read_txn = db.begin_read().expect("begin read transaction");
+        let table = read_txn
+            .open_table(table_def)
+            .expect("open migrated counter table");
+        let stored = table
+            .get(key)
+            .expect("read migrated counter")
+            .expect("migrated counter exists");
+        borsh::from_slice(stored.value().as_slice()).expect("deserialize stored counter envelope")
+    }
+
+    #[test]
+    fn counter_migration_succeeds_when_table_does_not_exist() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+        let write_txn = db.begin_write().expect("begin write transaction");
+        migrate_counter_table_to_envelope(&write_txn, &namespace.counter_table)
+            .expect("migration succeeds for missing counter table");
+        write_txn.commit().expect("commit migration");
+    }
+
+    #[test]
+    fn counter_migration_converts_legacy_counter_to_v1_envelope() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+        let proof = test_proof();
+        let expected_kid = proof.keyset_id;
+        let expected_counter = 42;
+        let database_key = b"counter-key";
+        insert_legacy_counter(
+            &db,
+            &namespace.counter_table,
+            database_key,
+            CounterEntry {
+                kid: expected_kid,
+                counter: expected_counter,
+            },
+        );
+        let write_txn = db.begin_write().expect("begin write transaction");
+        migrate_counter_table_to_envelope(&write_txn, &namespace.counter_table)
+            .expect("migrate legacy counter");
+        write_txn.commit().expect("commit migration");
+        let migrated = load_migrated_counter(&db, &namespace.counter_table, database_key);
+        match migrated {
+            StoredCounter::V1(payload) => {
+                assert_eq!(payload.kid, expected_kid);
+                assert_eq!(payload.counter, expected_counter);
+            }
+        }
+    }
+
+    #[test]
+    fn counter_migration_preserves_database_key() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+        let database_key = b"original-counter-key";
+        let proof = test_proof();
+        insert_legacy_counter(
+            &db,
+            &namespace.counter_table,
+            database_key,
+            CounterEntry {
+                kid: proof.keyset_id,
+                counter: 7,
+            },
+        );
+        let write_txn = db.begin_write().expect("begin write transaction");
+        migrate_counter_table_to_envelope(&write_txn, &namespace.counter_table)
+            .expect("migrate legacy counter");
+        write_txn.commit().expect("commit migration");
+        let table_def: TableDefinition<&[u8], Vec<u8>> =
+            TableDefinition::new(namespace.counter_table.as_str());
+        let read_txn = db.begin_read().expect("begin read transaction");
+        let table = read_txn.open_table(table_def).expect("open counter table");
+        assert!(
+            table
+                .get(database_key.as_slice())
+                .expect("read counter entry")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn counter_migration_converts_multiple_counters() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+
+        let first_kid = test_proof().keyset_id;
+        let second_kid = test_proof().keyset_id;
+        let third_kid = test_proof().keyset_id;
+
+        insert_legacy_counter(
+            &db,
+            &namespace.counter_table,
+            b"first",
+            CounterEntry {
+                kid: first_kid,
+                counter: 1,
+            },
+        );
+
+        insert_legacy_counter(
+            &db,
+            &namespace.counter_table,
+            b"second",
+            CounterEntry {
+                kid: second_kid,
+                counter: 20,
+            },
+        );
+
+        insert_legacy_counter(
+            &db,
+            &namespace.counter_table,
+            b"third",
+            CounterEntry {
+                kid: third_kid,
+                counter: u32::MAX,
+            },
+        );
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+
+        migrate_counter_table_to_envelope(&write_txn, &namespace.counter_table)
+            .expect("migrate all legacy counters");
+
+        write_txn.commit().expect("commit migration");
+
+        let first = load_migrated_counter(&db, &namespace.counter_table, b"first");
+        let second = load_migrated_counter(&db, &namespace.counter_table, b"second");
+        let third = load_migrated_counter(&db, &namespace.counter_table, b"third");
+
+        match first {
+            StoredCounter::V1(payload) => {
+                assert_eq!(payload.kid, first_kid);
+                assert_eq!(payload.counter, 1);
+            }
+        }
+
+        match second {
+            StoredCounter::V1(payload) => {
+                assert_eq!(payload.kid, second_kid);
+                assert_eq!(payload.counter, 20);
+            }
+        }
+
+        match third {
+            StoredCounter::V1(payload) => {
+                assert_eq!(payload.kid, third_kid);
+                assert_eq!(payload.counter, u32::MAX);
+            }
+        }
+    }
+
+    // commitments
+    fn test_commitment() -> Commitment {
+        let secp = secp256k1::Secp256k1::new();
+        let signing_keys = test_keypair();
+        let ephemeral_secret = secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng());
+        let message = secp256k1::Message::from_digest([42_u8; 32]);
+        let signature = secp.sign_schnorr_no_aux_rand(&message, &signing_keys);
+        let proof = test_proof();
+
+        Commitment {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            expiry: 1_750_000_000,
+            commitment: signature,
+            ephemeral_secret: ephemeral_secret.secret_bytes().to_vec(),
+            body_content: "test commitment body".to_string(),
+            wallet_key: proof.c,
+            premints: Vec::new(),
+        }
+    }
+
+    fn insert_legacy_commitment(
+        db: &Arc<Database>,
+        table_name: &str,
+        key: &[u8],
+        commitment: &Commitment,
+    ) {
+        let mut encoded = Vec::new();
+        ciborium::into_writer(commitment, &mut encoded).expect("serialize legacy commitment");
+        let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+        let write_txn = db.begin_write().expect("begin write transaction");
+
+        {
+            let mut table = write_txn
+                .open_table(table_def)
+                .expect("open legacy commitment table");
+
+            table
+                .insert(key, encoded)
+                .expect("insert legacy commitment");
+        }
+
+        write_txn.commit().expect("commit legacy commitment");
+    }
+
+    fn load_migrated_commitment(
+        db: &Arc<Database>,
+        table_name: &str,
+        key: &[u8],
+        keys: bitcoin::secp256k1::Keypair,
+    ) -> SwapCommitmentRecord {
+        let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+        let read_txn = db.begin_read().expect("begin read transaction");
+        let table = read_txn
+            .open_table(table_def)
+            .expect("open migrated commitment table");
+
+        let stored = table
+            .get(key)
+            .expect("read migrated commitment")
+            .expect("migrated commitment exists");
+
+        let envelope: StoredCommitment = borsh::from_slice(stored.value().as_slice())
+            .expect("deserialize stored commitment envelope");
+
+        from_stored_commitment_v1(envelope, keys).expect("decrypt migrated commitment")
+    }
+
+    fn assert_commitment_matches_record(legacy: &Commitment, migrated: &SwapCommitmentRecord) {
+        assert_eq!(migrated.inputs, legacy.inputs);
+        assert_eq!(migrated.outputs, legacy.outputs);
+        assert_eq!(migrated.expiry, legacy.expiry);
+        assert_eq!(migrated.commitment, legacy.commitment);
+        assert_eq!(
+            migrated.ephemeral_secret.secret_bytes(),
+            legacy.ephemeral_secret.as_slice()
+        );
+        assert_eq!(migrated.body_content, legacy.body_content);
+        assert_eq!(migrated.wallet_key, legacy.wallet_key);
+        assert_eq!(
+            migrated.premints,
+            premints_from_storage(legacy.premints.clone())
+        );
+    }
+
+    #[test]
+    fn commitment_migration_succeeds_when_table_does_not_exist() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+        let write_txn = db.begin_write().expect("begin write transaction");
+        migrate_commitment_table_to_envelope_and_encryption(
+            &write_txn,
+            &namespace.commitment_table,
+            &namespace.keys,
+        )
+        .expect("migration succeeds for missing commitment table");
+        write_txn.commit().expect("commit migration");
+    }
+
+    #[test]
+    fn commitment_migration_converts_legacy_commitment_to_encrypted_envelope() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+        let database_key = b"commitment-key";
+        let original = test_commitment();
+        insert_legacy_commitment(&db, &namespace.commitment_table, database_key, &original);
+        let write_txn = db.begin_write().expect("begin write transaction");
+        migrate_commitment_table_to_envelope_and_encryption(
+            &write_txn,
+            &namespace.commitment_table,
+            &namespace.keys,
+        )
+        .expect("migrate legacy commitment");
+        write_txn.commit().expect("commit migration");
+        let migrated =
+            load_migrated_commitment(&db, &namespace.commitment_table, database_key, keys);
+        assert_commitment_matches_record(&original, &migrated);
+    }
+
+    #[test]
+    fn commitment_migration_encrypts_stored_payload() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+        let database_key = b"encrypted-commitment";
+        let original = test_commitment();
+
+        insert_legacy_commitment(&db, &namespace.commitment_table, database_key, &original);
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+
+        migrate_commitment_table_to_envelope_and_encryption(
+            &write_txn,
+            &namespace.commitment_table,
+            &namespace.keys,
+        )
+        .expect("migrate legacy commitment");
+
+        write_txn.commit().expect("commit migration");
+
+        let table_def: TableDefinition<&[u8], Vec<u8>> =
+            TableDefinition::new(namespace.commitment_table.as_str());
+
+        let read_txn = db.begin_read().expect("begin read transaction");
+        let table = read_txn
+            .open_table(table_def)
+            .expect("open migrated commitment table");
+
+        let stored = table
+            .get(database_key.as_slice())
+            .expect("read migrated entry")
+            .expect("migrated entry exists");
+
+        let envelope: StoredCommitment =
+            borsh::from_slice(stored.value().as_slice()).expect("deserialize stored commitment");
+
+        match envelope {
+            StoredCommitment::V1(payload) => {
+                assert!(!payload.ciphertext.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn commitment_migration_converts_multiple_commitments() {
+        let db = test_database();
+        let keys = test_keypair();
+        let namespace = namespace("wallet-1", keys);
+
+        let mut first = test_commitment();
+        first.expiry = 1;
+        first.body_content = "first".to_string();
+
+        let mut second = test_commitment();
+        second.expiry = 2;
+        second.body_content = "second".to_string();
+
+        let mut third = test_commitment();
+        third.expiry = u64::MAX;
+        third.body_content = "third".to_string();
+
+        insert_legacy_commitment(&db, &namespace.commitment_table, b"first", &first);
+        insert_legacy_commitment(&db, &namespace.commitment_table, b"second", &second);
+        insert_legacy_commitment(&db, &namespace.commitment_table, b"third", &third);
+
+        let write_txn = db.begin_write().expect("begin write transaction");
+
+        migrate_commitment_table_to_envelope_and_encryption(
+            &write_txn,
+            &namespace.commitment_table,
+            &namespace.keys,
+        )
+        .expect("migrate all legacy commitments");
+
+        write_txn.commit().expect("commit migration");
+
+        let migrated_first =
+            load_migrated_commitment(&db, &namespace.commitment_table, b"first", keys);
+        let migrated_second =
+            load_migrated_commitment(&db, &namespace.commitment_table, b"second", keys);
+        let migrated_third =
+            load_migrated_commitment(&db, &namespace.commitment_table, b"third", keys);
+
+        assert_commitment_matches_record(&first, &migrated_first);
+        assert_commitment_matches_record(&second, &migrated_second);
+        assert_commitment_matches_record(&third, &migrated_third);
     }
 }

--- a/crates/bcr-wallet-persistence/src/redb/migration/mod.rs
+++ b/crates/bcr-wallet-persistence/src/redb/migration/mod.rs
@@ -66,7 +66,7 @@ fn migrate_wallet_sync(db: Arc<Database>, namespace: WalletStorageNamespace) -> 
             "Applying Migration 0001 for wallet {}",
             &namespace.wallet_id
         );
-        migration_0001::migration_0001_add_proof_envelope_and_encryption(&write_txn, &namespace)?;
+        migration_0001::migration_0001_envelope_and_encryption(&write_txn, &namespace)?;
         mark_migration_applied(&write_txn, &migration_0001_id_for_wallet)?;
         tracing::info!("Applied Migration 0001 for wallet {}", &namespace.wallet_id);
     }
@@ -84,6 +84,8 @@ fn migrate_wallet_sync(db: Arc<Database>, namespace: WalletStorageNamespace) -> 
 pub struct WalletStorageNamespace {
     wallet_id: String,
     proof_table: String,
+    counter_table: String,
+    commitment_table: String,
     keys: bitcoin::secp256k1::Keypair,
 }
 
@@ -95,6 +97,8 @@ pub fn collect_wallet_namespace(
     WalletStorageNamespace {
         wallet_id: wallet_id.to_string(),
         proof_table: PocketDB::proof_table_name(&wallet_id, &unit),
+        counter_table: PocketDB::counter_table_name(&wallet_id, &unit),
+        commitment_table: PocketDB::commitment_table_name(&wallet_id, &unit),
         keys,
     }
 }

--- a/crates/bcr-wallet-persistence/src/redb/pocket.rs
+++ b/crates/bcr-wallet-persistence/src/redb/pocket.rs
@@ -9,76 +9,105 @@ use bcr_common::cashu::{
 };
 use bcr_common::wire::borsh::{
     deserialize_cashu_amount, deserialize_from_str, deserialize_optionproofdleq,
-    deserialize_optionproofwitness, serialize_as_str, serialize_cashu_amount,
-    serialize_optionproofdleq, serialize_optionproofwitness,
+    deserialize_optionproofwitness, deserialize_vec_of_strs, deserialize_vecof_blindedmessage,
+    serialize_as_str, serialize_cashu_amount, serialize_optionproofdleq,
+    serialize_optionproofwitness, serialize_vec_of_strs, serialize_vecof_blindedmessage,
 };
-use bcr_wallet_core::crypto;
+use bcr_wallet_core::{
+    borsh::{deserialize_premints, serialize_premints},
+    crypto,
+};
 use bitcoin::secp256k1;
 use borsh::{BorshDeserialize, BorshSerialize};
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, TableError};
 use std::{collections::HashMap, sync::Arc};
 use tokio::task::spawn_blocking;
 
-///////////////////////////////////////////// Commitment
-type PremintStorage = Vec<(
-    cashu::Id,
-    Vec<(
-        cdk00::BlindedMessage,
-        Secret,
-        cdk01::SecretKey,
-        cashu::Amount,
-    )>,
-)>;
+/// StoredCommitment is a versioned, encrypted, borsh-serialized commitment
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) enum StoredCommitment {
+    V1(EncryptedCommitmentPayloadV1),
+}
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
-struct Commitment {
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) struct EncryptedCommitmentPayloadV1 {
+    pub ciphertext: Vec<u8>,
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) struct StoredCommitmentPayloadV1 {
+    #[borsh(
+        serialize_with = "serialize_vec_of_strs",
+        deserialize_with = "deserialize_vec_of_strs"
+    )]
     inputs: Vec<cashu::PublicKey>,
+    #[borsh(
+        serialize_with = "serialize_vecof_blindedmessage",
+        deserialize_with = "deserialize_vecof_blindedmessage"
+    )]
     outputs: Vec<cashu::BlindedMessage>,
     expiry: u64,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
     commitment: secp256k1::schnorr::Signature,
     ephemeral_secret: Vec<u8>,
     body_content: String,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
     wallet_key: cashu::PublicKey,
-    #[serde(default)]
-    premints: PremintStorage,
+    #[borsh(
+        serialize_with = "serialize_premints",
+        deserialize_with = "deserialize_premints"
+    )]
+    premints: HashMap<cashu::Id, cdk00::PreMintSecrets>,
 }
 
-fn premints_to_storage(premints: HashMap<cashu::Id, cdk00::PreMintSecrets>) -> PremintStorage {
-    premints
-        .into_iter()
-        .map(|(kid, ps)| {
-            let tuples = ps
-                .secrets
-                .into_iter()
-                .map(|p| (p.blinded_message, p.secret, p.r, p.amount))
-                .collect();
-            (kid, tuples)
-        })
-        .collect()
+pub(super) fn to_stored_commitment_v1(
+    record: SwapCommitmentRecord,
+    keys: bitcoin::secp256k1::Keypair,
+) -> Result<StoredCommitment> {
+    let payload = StoredCommitmentPayloadV1 {
+        inputs: record.inputs,
+        outputs: record.outputs,
+        expiry: record.expiry,
+        commitment: record.commitment,
+        ephemeral_secret: record.ephemeral_secret.secret_bytes().to_vec(),
+        body_content: record.body_content,
+        wallet_key: record.wallet_key,
+        premints: record.premints,
+    };
+    let encoded = borsh::to_vec(&payload).map_err(|e| Error::BorshSerialization(e.to_string()))?;
+    let encrypted = crypto::encrypt_ecies(&encoded, &keys.public_key())?;
+    Ok(StoredCommitment::V1(EncryptedCommitmentPayloadV1 {
+        ciphertext: encrypted,
+    }))
 }
 
-fn premints_from_storage(stored: PremintStorage) -> HashMap<cashu::Id, cdk00::PreMintSecrets> {
-    stored
-        .into_iter()
-        .map(|(kid, tuples)| {
-            let secrets = tuples
-                .into_iter()
-                .map(|(bm, secret, r, amount)| cdk00::PreMint {
-                    blinded_message: bm,
-                    secret,
-                    r,
-                    amount,
-                })
-                .collect();
-            (
-                kid,
-                cdk00::PreMintSecrets {
-                    secrets,
-                    keyset_id: kid,
-                },
-            )
-        })
-        .collect()
+pub(super) fn from_stored_commitment_v1(
+    commitment: StoredCommitment,
+    keys: bitcoin::secp256k1::Keypair,
+) -> Result<SwapCommitmentRecord> {
+    let StoredCommitment::V1(encrypted_payload) = commitment;
+    let decrypted = crypto::decrypt_ecies(&encrypted_payload.ciphertext, &keys.secret_key())?;
+    let c: StoredCommitmentPayloadV1 =
+        borsh::from_slice(&decrypted).map_err(|e| Error::BorshSerialization(e.to_string()))?;
+
+    let secret = secp256k1::SecretKey::from_slice(&c.ephemeral_secret)
+        .map_err(|e| Error::Custom(format!("invalid ephemeral secret: {e}")))?;
+    Ok(SwapCommitmentRecord {
+        inputs: c.inputs,
+        outputs: c.outputs,
+        expiry: c.expiry,
+        commitment: c.commitment,
+        ephemeral_secret: secret,
+        body_content: c.body_content,
+        wallet_key: c.wallet_key,
+        premints: c.premints,
+    })
 }
 
 /// StoredProof is a versioned, encrypted, borsh-serialized
@@ -194,11 +223,20 @@ pub(super) fn from_stored_proof_v1(
     Ok((decoded.into(), state))
 }
 
-///////////////////////////////////////////// CounterEntry
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
-pub struct CounterEntry {
-    kid: cdk02::Id,
-    counter: u32,
+/// StoredCounter is a versioned, borsh-serialized wallet counter
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) enum StoredCounter {
+    V1(StoredCounterPayloadV1),
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) struct StoredCounterPayloadV1 {
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub kid: cdk02::Id,
+    pub counter: u32,
 }
 
 ///////////////////////////////////////////// PocketDB
@@ -473,7 +511,7 @@ impl PocketDB {
         db: Arc<Database>,
         counter_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
         kid: cdk02::Id,
-    ) -> Result<CounterEntry> {
+    ) -> Result<StoredCounter> {
         let read_txn = db.begin_read()?;
 
         match read_txn.open_table(counter_table) {
@@ -481,8 +519,10 @@ impl PocketDB {
                 let entry = table.get(kid.to_bytes().as_slice())?;
                 match entry {
                     Some(e) => {
-                        let counter: CounterEntry = ciborium::from_reader(e.value().as_slice())?;
-                        Ok(counter)
+                        let deserialized: StoredCounter =
+                            borsh::from_slice(e.value().as_slice())
+                                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                        Ok(deserialized)
                     }
                     None => Self::insert_counter_sync(db, counter_table, kid),
                 }
@@ -498,15 +538,15 @@ impl PocketDB {
         db: Arc<Database>,
         counter_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
         kid: cdk02::Id,
-    ) -> Result<CounterEntry> {
-        let entry = CounterEntry { kid, counter: 0 };
+    ) -> Result<StoredCounter> {
+        let entry = StoredCounter::V1(StoredCounterPayloadV1 { kid, counter: 0 });
         let write_txn = db.begin_write()?;
 
         {
             let mut table = write_txn.open_table(counter_table)?;
 
-            let mut serialized = Vec::new();
-            ciborium::into_writer(&entry, &mut serialized)?;
+            let serialized =
+                borsh::to_vec(&entry).map_err(|e| Error::BorshSerialization(e.to_string()))?;
             table.insert(kid.to_bytes().as_slice(), serialized)?;
         }
 
@@ -517,9 +557,11 @@ impl PocketDB {
     fn increment_counter_sync(
         db: Arc<Database>,
         counter_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-        old: CounterEntry,
-        new: CounterEntry,
+        old: StoredCounter,
+        new: StoredCounter,
     ) -> Result<()> {
+        let StoredCounter::V1(old) = old;
+        let StoredCounter::V1(new) = new;
         if old.kid != new.kid {
             return Err(Error::CounterKidMismatch);
         }
@@ -530,14 +572,16 @@ impl PocketDB {
             let old_value = table.get(old.kid.to_bytes().as_slice())?.map(|v| v.value());
 
             if let Some(old_value) = old_value {
-                let old_counter: CounterEntry = ciborium::from_reader(old_value.as_slice())?;
+                let deserialized: StoredCounter = borsh::from_slice(&old_value)
+                    .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                let StoredCounter::V1(old_counter) = deserialized;
 
                 if old_counter.kid != old.kid {
                     return Err(Error::CounterKidMismatch);
                 }
 
-                let mut serialized = Vec::new();
-                ciborium::into_writer(&new, &mut serialized)?;
+                let serialized = borsh::to_vec(&StoredCounter::V1(new))
+                    .map_err(|e| Error::BorshSerialization(e.to_string()))?;
                 table.insert(old.kid.to_bytes().as_slice(), serialized)?;
             } else {
                 return Err(Error::CounterNotFound(old.kid));
@@ -552,25 +596,17 @@ impl PocketDB {
         db: Arc<Database>,
         commitment_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
         record: crate::SwapCommitmentRecord,
+        keys: bitcoin::secp256k1::Keypair,
     ) -> Result<()> {
         let commitment = record.commitment;
-        let entry = Commitment {
-            inputs: record.inputs,
-            outputs: record.outputs,
-            expiry: record.expiry,
-            commitment,
-            ephemeral_secret: record.ephemeral_secret.secret_bytes().to_vec(),
-            body_content: record.body_content,
-            wallet_key: record.wallet_key,
-            premints: premints_to_storage(record.premints),
-        };
+        let entry = to_stored_commitment_v1(record, keys)?;
         let write_txn = db.begin_write()?;
 
         {
             let mut table = write_txn.open_table(commitment_table)?;
+            let serialized =
+                borsh::to_vec(&entry).map_err(|e| Error::BorshSerialization(e.to_string()))?;
 
-            let mut serialized = Vec::new();
-            ciborium::into_writer(&entry, &mut serialized)?;
             table.insert(commitment.serialize().as_slice(), serialized)?;
         }
 
@@ -582,6 +618,7 @@ impl PocketDB {
         db: Arc<Database>,
         commitment_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
         commitment: secp256k1::schnorr::Signature,
+        keys: bitcoin::secp256k1::Keypair,
     ) -> Result<SwapCommitmentRecord> {
         let read_txn = db.begin_read()?;
 
@@ -590,19 +627,11 @@ impl PocketDB {
                 let entry = table.get(commitment.serialize().as_slice())?;
                 match entry {
                     Some(e) => {
-                        let c: Commitment = ciborium::from_reader(e.value().as_slice())?;
-                        let secret = secp256k1::SecretKey::from_slice(&c.ephemeral_secret)
-                            .map_err(|e| Error::Custom(format!("invalid ephemeral secret: {e}")))?;
-                        Ok(SwapCommitmentRecord {
-                            inputs: c.inputs,
-                            outputs: c.outputs,
-                            expiry: c.expiry,
-                            commitment: c.commitment,
-                            ephemeral_secret: secret,
-                            body_content: c.body_content,
-                            wallet_key: c.wallet_key,
-                            premints: premints_from_storage(c.premints),
-                        })
+                        let deserialized: StoredCommitment =
+                            borsh::from_slice(e.value().as_slice())
+                                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                        let record = from_stored_commitment_v1(deserialized, keys)?;
+                        Ok(record)
                     }
                     None => Err(Error::Custom(format!(
                         "commitment not found: {}",
@@ -621,6 +650,7 @@ impl PocketDB {
     fn list_commitments_sync(
         db: Arc<Database>,
         commitment_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        keys: bitcoin::secp256k1::Keypair,
     ) -> Result<Vec<SwapCommitmentRecord>> {
         let read_txn = db.begin_read()?;
 
@@ -628,19 +658,10 @@ impl PocketDB {
             Ok(table) => {
                 let mut res = Vec::new();
                 for (_, v) in table.range::<&[u8]>(..)?.flatten() {
-                    let c: Commitment = ciborium::from_reader(v.value().as_slice())?;
-                    let secret = secp256k1::SecretKey::from_slice(&c.ephemeral_secret)
-                        .map_err(|e| Error::Custom(format!("invalid ephemeral secret: {e}")))?;
-                    res.push(SwapCommitmentRecord {
-                        inputs: c.inputs,
-                        outputs: c.outputs,
-                        expiry: c.expiry,
-                        commitment: c.commitment,
-                        ephemeral_secret: secret,
-                        body_content: c.body_content,
-                        wallet_key: c.wallet_key,
-                        premints: premints_from_storage(c.premints),
-                    });
+                    let deserialized: StoredCommitment = borsh::from_slice(v.value().as_slice())
+                        .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                    let record = from_stored_commitment_v1(deserialized, keys)?;
+                    res.push(record);
                 }
                 Ok(res)
             }
@@ -877,6 +898,7 @@ impl PocketRepository for PocketDB {
         let table = self.counter_table;
         let counter =
             spawn_blocking(move || Self::load_counter_sync(db_clone, table, kid)).await??;
+        let StoredCounter::V1(counter) = counter;
         Ok(counter.counter)
     }
 
@@ -888,18 +910,24 @@ impl PocketRepository for PocketDB {
     ) -> Result<()> {
         let db_clone = self.db.clone();
         let table = self.counter_table;
-        let old = CounterEntry { kid, counter: old };
-        let new = CounterEntry {
+        let old_c = StoredCounterPayloadV1 { kid, counter: old };
+        let old = StoredCounter::V1(old_c.clone());
+        let new = StoredCounter::V1(StoredCounterPayloadV1 {
             kid,
-            counter: old.counter + increment,
-        };
+            counter: old_c
+                .counter
+                .checked_add(increment)
+                // TODO (future): how do we handle this? we can switch seeds / switch keyset, but if we hit u32::Max, this fails
+                .ok_or(Error::CounterExhausted)?,
+        });
         spawn_blocking(move || Self::increment_counter_sync(db_clone, table, old, new)).await?
     }
 
     async fn store_commitment(&self, record: crate::SwapCommitmentRecord) -> Result<()> {
         let db_clone = self.db.clone();
         let table = self.commitment_table;
-        spawn_blocking(move || Self::store_commitment_sync(db_clone, table, record)).await?
+        let keys = self.keys;
+        spawn_blocking(move || Self::store_commitment_sync(db_clone, table, record, keys)).await?
     }
 
     async fn load_commitment(
@@ -908,7 +936,9 @@ impl PocketRepository for PocketDB {
     ) -> Result<SwapCommitmentRecord> {
         let db_clone = self.db.clone();
         let table = self.commitment_table;
-        spawn_blocking(move || Self::load_commitment_sync(db_clone, table, commitment)).await?
+        let keys = self.keys;
+        spawn_blocking(move || Self::load_commitment_sync(db_clone, table, commitment, keys))
+            .await?
     }
 
     async fn delete_commitment(&self, commitment: secp256k1::schnorr::Signature) -> Result<()> {
@@ -920,7 +950,8 @@ impl PocketRepository for PocketDB {
     async fn list_commitments(&self) -> Result<Vec<SwapCommitmentRecord>> {
         let db_clone = self.db.clone();
         let table = self.commitment_table;
-        spawn_blocking(move || Self::list_commitments_sync(db_clone, table)).await?
+        let keys = self.keys;
+        spawn_blocking(move || Self::list_commitments_sync(db_clone, table, keys)).await?
     }
 
     async fn delete_repo(&self) -> Result<()> {

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -575,7 +575,8 @@ enum PaymentType {
 
 enum ProtestStatus {
   resolved,
-  rabid;
+  rabid,
+  offline;
 
   static Future<ProtestStatus> default_() =>
       RustLib.instance.api.crateApiProtestStatusDefault();


### PR DESCRIPTION
* Use latest bcr-common types and adapt to changes there
* Counter and Commitment Migration
* Next and for now final part of the migrations - the rest of the DB migrations will be done on-demand, if there's a breaking change (there's plenty of code to orient oneselves by at this point)
  * After most of the migrations are done, it might make sense to move the stuff from core/borsh.rs to bcr-common as well