### PR TITLE
Transactions Rework & Migration & Reclaim Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@
 * Migrate Proofs persistence to be versioned, encrypted and borsh-serialized 
 * Migrated DB models to versioned payload, borsh serialization and in some cases encryption at rest
     * purse: versioned & borsh
+* Rework Transaction Data Model
+    * API changes:
+        * id is now a `Uuid`
+        * rename `tx_id` to `btc_tx_id`
+        * rename `contact` to `contact_node_id`
+        * add `payment_request_id`
+        * add `linked_txs` - a list of linked transactions for this transaction
+    * Use a custom `Transaction` data model internally and phase out the `cashu` one
+        * TransactionId across the whole stack is now a `Uuid`
+    * Implement database migration to this new model
+    * Rework `reclaim` code paths to create two linked transactions instead of overwriting one
 
 # 0.9.6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,6 +4251,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/bcr-wallet-api/src/error.rs
+++ b/crates/bcr-wallet-api/src/error.rs
@@ -78,7 +78,7 @@ pub enum Error {
     #[error("no reference to prepare request_id: {0}")]
     NoPrepareRef(uuid::Uuid),
     #[error("transaction can't be reclaimed - not outgoing or pending {0}")]
-    TransactionCantBeReclaimed(cdk_common::wallet::TransactionId),
+    TransactionCantBeReclaimed(uuid::Uuid),
     #[error("Mint not supporting debit currency")]
     NoDebitCurrencyInMint(Vec<cashu::CurrencyUnit>),
     #[error("network mismatch, ours: {0}, theirs: {1}")]

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -4,11 +4,9 @@ use crate::wallet::api::WalletApi;
 use crate::wallet::types::{
     WalletBalance, WalletDetailedBalanceEntry, WalletInfo, WalletProtestResult,
 };
-use bcr_common::cdk_common::wallet::Transaction;
 use bcr_common::core::NodeId;
 use bcr_common::{
     cashu::{self, CurrencyUnit},
-    cdk_common::wallet::TransactionId,
     wallet::Token,
 };
 use bcr_wallet_core::contact::Contact;
@@ -16,7 +14,7 @@ use bcr_wallet_core::name::Name;
 use bcr_wallet_core::types::{
     self, ListTransactionsResult, MintSummary, PaymentRequest, PaymentRequestDirection,
     PaymentRequestState, PaymentResultCallback, PaymentSummary, PendingPaymentSubscriptionCallback,
-    Seed, TransactionCursor, TransactionFilters, TransactionSort, WalletConfig,
+    Seed, Transaction, TransactionCursor, TransactionFilters, TransactionSort, WalletConfig,
 };
 use bcr_wallet_core::util::{
     build_wallet_id, keypair_from_mnemonic, keypair_from_seed, seed_from_mnemonic,
@@ -298,11 +296,7 @@ impl AppState {
         wallet.read().await.balance().await
     }
 
-    pub async fn wallet_receive_token(
-        &self,
-        wallet_id: String,
-        token: String,
-    ) -> Result<TransactionId> {
+    pub async fn wallet_receive_token(&self, wallet_id: String, token: String) -> Result<Uuid> {
         let tstamp = chrono::Utc::now().timestamp() as u64;
         tracing::debug!("wallet_receive({wallet_id}, {token}, {tstamp})");
 
@@ -392,11 +386,7 @@ impl AppState {
         Ok(summary)
     }
 
-    pub async fn wallet_pay_to_contact(
-        &self,
-        wallet_id: String,
-        rid: String,
-    ) -> Result<TransactionId> {
+    pub async fn wallet_pay_to_contact(&self, wallet_id: String, rid: String) -> Result<Uuid> {
         let tstamp = chrono::Utc::now().timestamp() as u64;
         tracing::debug!("wallet_pay_to_contact({wallet_id}, {rid}, {tstamp})");
         let p_id = Uuid::from_str(&rid)?;
@@ -501,11 +491,7 @@ impl AppState {
         Ok(tx_id)
     }
 
-    pub async fn wallet_pay_payment_request(
-        &self,
-        wallet_id: String,
-        rid: String,
-    ) -> Result<TransactionId> {
+    pub async fn wallet_pay_payment_request(&self, wallet_id: String, rid: String) -> Result<Uuid> {
         tracing::debug!("wallet_pay_payment_request({wallet_id}, {rid})");
         let tstamp = chrono::Utc::now().timestamp() as u64;
         let p_id = Uuid::from_str(&rid)?;
@@ -575,7 +561,7 @@ impl AppState {
         Ok(summary)
     }
 
-    pub async fn wallet_melt(&self, wallet_id: String, rid: String) -> Result<TransactionId> {
+    pub async fn wallet_melt(&self, wallet_id: String, rid: String) -> Result<Uuid> {
         let tstamp = chrono::Utc::now().timestamp() as u64;
         tracing::debug!("wallet_melt({wallet_id}, {rid}, {tstamp})");
 
@@ -601,10 +587,7 @@ impl AppState {
         Ok(summary)
     }
 
-    pub async fn wallet_check_pending_mints(
-        &self,
-        wallet_id: String,
-    ) -> Result<Vec<TransactionId>> {
+    pub async fn wallet_check_pending_mints(&self, wallet_id: String) -> Result<Vec<Uuid>> {
         tracing::debug!("wallet_check_pending_mints({wallet_id})");
         let wallet = self.get_wallet(&wallet_id).await?;
         let tx_ids = wallet.read().await.check_pending_mints().await?;
@@ -685,7 +668,7 @@ impl AppState {
         Ok(summary)
     }
 
-    pub async fn wallet_pay(&self, wallet_id: String, rid: String) -> Result<TransactionId> {
+    pub async fn wallet_pay(&self, wallet_id: String, rid: String) -> Result<Uuid> {
         let tstamp = chrono::Utc::now().timestamp() as u64;
         tracing::debug!("wallet_pay({wallet_id}, {rid}, {tstamp})");
 
@@ -741,7 +724,7 @@ impl AppState {
         Ok(())
     }
 
-    pub async fn wallet_list_tx_ids(&self, wallet_id: String) -> Result<Vec<TransactionId>> {
+    pub async fn wallet_list_tx_ids(&self, wallet_id: String) -> Result<Vec<Uuid>> {
         tracing::debug!("wallet_list_tx_ids({wallet_id})");
 
         let wallet = self.get_wallet(&wallet_id).await?;
@@ -771,7 +754,7 @@ impl AppState {
     pub async fn wallet_load_tx(&self, wallet_id: String, tx_id: &str) -> Result<Transaction> {
         tracing::debug!("wallet_load_tx({wallet_id}, {tx_id})");
 
-        let tx_id = TransactionId::from_str(tx_id)?;
+        let tx_id = Uuid::from_str(tx_id)?;
         let wallet = self.get_wallet(&wallet_id).await?;
         let tx = wallet.read().await.load_tx(tx_id).await?;
         Ok(tx)
@@ -785,7 +768,7 @@ impl AppState {
     ) -> Result<()> {
         tracing::debug!("wallet_edit_tx_memo({wallet_id}, {tx_id}, {new_memo:?})");
 
-        let tx_id = TransactionId::from_str(&tx_id)?;
+        let tx_id = Uuid::from_str(&tx_id)?;
         let wallet = self.get_wallet(&wallet_id).await?;
         wallet.read().await.edit_tx_memo(tx_id, new_memo).await?;
         Ok(())
@@ -793,7 +776,7 @@ impl AppState {
 
     pub async fn wallet_reclaim_tx(&self, wallet_id: String, tx_id: &str) -> Result<cashu::Amount> {
         tracing::debug!("wallet_reclaim_tx({wallet_id}, {tx_id})");
-        let tx_id = TransactionId::from_str(tx_id)?;
+        let tx_id = Uuid::from_str(tx_id)?;
         let wallet = self.get_wallet(&wallet_id).await?;
         let amount = wallet.read().await.reclaim_tx(tx_id).await?;
         Ok(amount)
@@ -910,7 +893,7 @@ impl AppState {
     pub async fn wallet_refresh_tx(&self, wallet_id: String, tx_id: &str) -> Result<bool> {
         tracing::debug!("wallet_refresh_tx({wallet_id}, {tx_id})");
 
-        let tx_id = TransactionId::from_str(tx_id)?;
+        let tx_id = Uuid::from_str(tx_id)?;
         let wallet = self.get_wallet(&wallet_id).await?;
         let updated = wallet.read().await.refresh_tx(tx_id).await?;
         Ok(updated)
@@ -1107,7 +1090,7 @@ pub struct WalletCurrencyUnit {
 
 #[derive(Clone, Debug)]
 pub struct CreatedToken {
-    pub tx_id: TransactionId,
+    pub tx_id: Uuid,
     pub token: Token,
 }
 

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -5,10 +5,7 @@ use crate::{
         RandomBetaProvider,
         debit::{MeltProtestResult, ProtestResult},
     },
-    types::{
-        MintSummary, PAYMENT_TYPE_METADATA_KEY, PaymentSummary, TRANSACTION_STATUS_METADATA_KEY,
-        WalletConfig,
-    },
+    types::{MintSummary, PaymentSummary, WalletConfig},
     wallet::{
         api,
         types::{PayReference, SwapConfig, WalletInfo, WalletPaymentType, WalletProtestResult},
@@ -17,7 +14,7 @@ use crate::{
 use async_trait::async_trait;
 use bcr_common::{
     cashu::{self, Amount, CurrencyUnit, KeySet, ProofsMethods, nut00 as cdk00, nut18 as cdk18},
-    cdk_common::wallet::{Transaction, TransactionDirection, TransactionId},
+    cdk_common::wallet::TransactionDirection,
     core::NodeId,
     wallet::Token,
     wire::clowder::{self as wire_clowder},
@@ -28,9 +25,8 @@ use bcr_wallet_core::{
     event::{ContactPaymentRequestPayload, EventEnvelope},
     name::Name,
     types::{
-        BTC_TX_ID_TYPE_METADATA_KEY, CONTACT_NODE_ID_METADATA_KEY, PAYMENT_REQUEST_ID_METADATA_KEY,
         PaymentRequest, PaymentRequestDirection, PaymentRequestState, PaymentResultCallback,
-        PaymentType, PendingPaymentSubscriptionCallback, TransactionStatus,
+        PaymentType, PendingPaymentSubscriptionCallback, Transaction, TransactionStatus,
     },
     util::{from_mint_url, to_mint_url},
 };
@@ -38,7 +34,7 @@ use bcr_wallet_transport::NostrWalletEvent;
 use bitcoin::{base58, secp256k1};
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
-use nostr::RelayUrl;
+use nostr::{RelayUrl, event::EventId};
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
@@ -90,9 +86,9 @@ pub trait WalletApi: SendSync {
         p_id: Uuid,
         http_cl: &reqwest::Client,
         tstamp: u64,
-    ) -> Result<(TransactionId, Option<Token>)>;
+    ) -> Result<(Uuid, Option<Token>)>;
     async fn mint(&self, amount: bitcoin::Amount) -> Result<MintSummary>;
-    async fn check_pending_mints(&self) -> Result<Vec<TransactionId>>;
+    async fn check_pending_mints(&self) -> Result<Vec<Uuid>>;
     async fn check_pending_commitments(&self) -> Result<()>;
     async fn protest_mint(&self, quote_id: Uuid) -> Result<WalletProtestResult>;
     async fn protest_swap(
@@ -112,8 +108,12 @@ pub trait WalletApi: SendSync {
         mint: url::Url,
         tstamp: u64,
         memo: Option<String>,
-        metadata: HashMap<String, String>,
-    ) -> Result<TransactionId>;
+        payment_type: PaymentType,
+        status: TransactionStatus,
+        payment_request_id: Option<Uuid>,
+        contact_node_id: Option<NodeId>,
+        nostr_event_id: Option<EventId>,
+    ) -> Result<Uuid>;
     async fn prepare_pay_by_token(
         &self,
         amount: Amount,
@@ -134,7 +134,7 @@ pub trait WalletApi: SendSync {
         fees: Amount,
         memo: Option<String>,
         now: u64,
-    ) -> Result<(TransactionId, Option<Token>)>;
+    ) -> Result<(Uuid, Option<Token>)>;
     async fn is_nostr_connected(&self) -> bool;
     async fn delete(&self) -> Result<()>;
     // contacts
@@ -170,11 +170,7 @@ pub trait WalletApi: SendSync {
     async fn prepare_pay_payment_request(&self, payment_req_id: Uuid) -> Result<PaymentSummary>;
     async fn reject_payment_request(&self, payment_req_id: Uuid) -> Result<()>;
     async fn cancel_payment_request(&self, payment_req_id: Uuid) -> Result<()>;
-    async fn mark_payment_request_as_paid(
-        &self,
-        payment_req_id: Uuid,
-        tx_id: TransactionId,
-    ) -> Result<()>;
+    async fn mark_payment_request_as_paid(&self, payment_req_id: Uuid, tx_id: Uuid) -> Result<()>;
 }
 
 #[async_trait]
@@ -357,7 +353,7 @@ impl WalletApi for super::Wallet {
                         },
                     };
 
-                    let NostrWalletEvent::Cdk18Payment { event_id, payload, sender } = received_evt else {
+                    let NostrWalletEvent::Cdk18Payment { event_id, payload, .. } = received_evt else {
                         continue;
                     };
 
@@ -375,19 +371,6 @@ impl WalletApi for super::Wallet {
                         );
                         continue;
                     }
-                    let meta = HashMap::from([
-                        (String::from("sender"), sender.to_string()),
-                        (String::from("payment_id"), p_id.to_string()),
-                        (String::from("nostr_event_id"), event_id.to_string()),
-                        (
-                            String::from(PAYMENT_TYPE_METADATA_KEY),
-                            PaymentType::Cdk18.to_string(),
-                        ),
-                        (
-                            String::from(TRANSACTION_STATUS_METADATA_KEY),
-                            TransactionStatus::Settled.to_string(),
-                        ),
-                    ]);
 
                     let response = <Self as api::WalletApi>::receive_proofs(
                         self,
@@ -396,7 +379,11 @@ impl WalletApi for super::Wallet {
                         from_mint_url(&payload.mint),
                         chrono::Utc::now().timestamp() as u64,
                         payload.memo,
-                        meta,
+                        PaymentType::Cdk18,
+                        TransactionStatus::Settled,
+                        Some(p_id),
+                        None,
+                        Some(event_id)
                     )
                         .await;
 
@@ -421,7 +408,7 @@ impl WalletApi for super::Wallet {
         p_id: Uuid,
         http_cl: &reqwest::Client,
         now: u64,
-    ) -> Result<(TransactionId, Option<Token>)> {
+    ) -> Result<(Uuid, Option<Token>)> {
         let p_ref = self.current_payment.lock().await.take();
         let Some(p_ref) = p_ref else {
             tracing::error!("wallet: No current payment reference found");
@@ -455,32 +442,25 @@ impl WalletApi for super::Wallet {
                 let (ys, proofs): (Vec<cashu::PublicKey>, Vec<cashu::Proof>) =
                     proofs.into_iter().unzip();
                 let amount = proofs.total_amount()?;
-                let mut metadata = HashMap::default();
-                metadata.insert(
-                    PAYMENT_TYPE_METADATA_KEY.to_owned(),
-                    PaymentType::Cdk18.to_string(),
-                );
-                metadata.insert(
-                    TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-                    TransactionStatus::Pending.to_string(),
-                );
 
                 let partial_tx = Transaction {
+                    id: Uuid::new_v4(),
                     mint_url: to_mint_url(self.client.mint_url()),
-                    fee: fees,
+                    fees,
                     direction: TransactionDirection::Outgoing,
                     memo,
-                    timestamp: now,
+                    tstamp: now,
                     unit: unit.clone(),
                     ys,
                     amount,
-                    // payments might need to fill some extra metadata later
-                    metadata,
                     quote_id: None,
-                    payment_request: None,
-                    payment_proof: None,
-                    payment_method: None,
-                    saga_id: None,
+                    payment_request_id: None,
+                    payment_type: PaymentType::Cdk18,
+                    status: TransactionStatus::Pending,
+                    btc_tx_id: None,
+                    nostr_event_id: None,
+                    contact_node_id: None,
+                    linked_txs: vec![],
                 };
                 let tx_id = self
                     .pay_nut18(
@@ -529,31 +509,25 @@ impl WalletApi for super::Wallet {
                 let (ys, proofs): (Vec<cashu::PublicKey>, Vec<cashu::Proof>) =
                     proofs.into_iter().unzip();
                 let amount = proofs.total_amount()?;
-                let mut metadata = HashMap::default();
-                metadata.insert(
-                    PAYMENT_TYPE_METADATA_KEY.to_owned(),
-                    PaymentType::Token.to_string(),
-                );
-                metadata.insert(
-                    TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-                    TransactionStatus::Pending.to_string(),
-                );
 
                 let partial_tx = Transaction {
+                    id: Uuid::new_v4(),
                     mint_url: to_mint_url(self.client.mint_url()),
-                    fee: fees,
+                    fees,
                     direction: TransactionDirection::Outgoing,
                     memo,
-                    timestamp: now,
+                    tstamp: now,
                     unit: unit.clone(),
                     ys,
                     amount,
-                    metadata,
                     quote_id: None,
-                    payment_request: None,
-                    payment_proof: None,
-                    payment_method: None,
-                    saga_id: None,
+                    payment_request_id: None,
+                    payment_type: PaymentType::Token,
+                    status: TransactionStatus::Pending,
+                    btc_tx_id: None,
+                    nostr_event_id: None,
+                    contact_node_id: None,
+                    linked_txs: vec![],
                 };
                 let tx_id = self.tx_repo.store_tx(partial_tx).await?;
                 Ok((tx_id, Some(token)))
@@ -566,35 +540,25 @@ impl WalletApi for super::Wallet {
                 let (ys, proofs): (Vec<cashu::PublicKey>, Vec<cashu::Proof>) =
                     proofs.into_iter().unzip();
                 let amount = proofs.total_amount()?;
-                let mut metadata = HashMap::default();
-                metadata.insert(
-                    PAYMENT_TYPE_METADATA_KEY.to_owned(),
-                    PaymentType::OnChain.to_string(),
-                );
-                metadata.insert(
-                    TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-                    TransactionStatus::Settled.to_string(),
-                );
-                metadata.insert(
-                    BTC_TX_ID_TYPE_METADATA_KEY.to_owned(),
-                    btc_tx_id.to_string(),
-                );
 
                 let partial_tx = Transaction {
+                    id: Uuid::new_v4(),
                     mint_url: to_mint_url(self.client.mint_url()),
-                    fee: fees,
+                    fees,
                     direction: TransactionDirection::Outgoing,
                     memo,
-                    timestamp: now,
+                    tstamp: now,
                     unit: unit.clone(),
                     ys,
                     amount,
-                    metadata,
                     quote_id: None,
-                    payment_request: None,
-                    payment_proof: None,
-                    payment_method: None,
-                    saga_id: None,
+                    payment_type: PaymentType::OnChain,
+                    status: TransactionStatus::Settled,
+                    btc_tx_id: Some(btc_tx_id),
+                    nostr_event_id: None,
+                    contact_node_id: None,
+                    payment_request_id: None,
+                    linked_txs: vec![],
                 };
                 let tx_id = self.tx_repo.store_tx(partial_tx).await?;
                 Ok((tx_id, None))
@@ -615,40 +579,25 @@ impl WalletApi for super::Wallet {
                 let (ys, proofs): (Vec<cashu::PublicKey>, Vec<cashu::Proof>) =
                     proofs.into_iter().unzip();
                 let amount = proofs.total_amount()?;
-                let mut metadata = HashMap::default();
-                metadata.insert(
-                    PAYMENT_TYPE_METADATA_KEY.to_owned(),
-                    PaymentType::Contact.to_string(),
-                );
-                metadata.insert(
-                    TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-                    TransactionStatus::Pending.to_string(),
-                );
-                metadata.insert(CONTACT_NODE_ID_METADATA_KEY.to_owned(), node_id.to_string());
-                // if there is a payment request id, set it
-                if let Some(p_req_id) = payment_request_id {
-                    metadata.insert(
-                        PAYMENT_REQUEST_ID_METADATA_KEY.to_owned(),
-                        p_req_id.to_string(),
-                    );
-                }
 
                 let partial_tx = Transaction {
+                    id: Uuid::new_v4(),
                     mint_url: to_mint_url(self.client.mint_url()),
-                    fee: fees,
+                    fees,
                     direction: TransactionDirection::Outgoing,
                     memo,
-                    timestamp: now,
+                    tstamp: now,
                     unit: unit.clone(),
                     ys,
                     amount,
-                    // payments might need to fill some extra metadata later
-                    metadata,
+                    payment_type: PaymentType::Contact,
+                    status: TransactionStatus::Pending,
+                    payment_request_id,
+                    btc_tx_id: None,
                     quote_id: None,
-                    payment_request: None,
-                    payment_proof: None,
-                    payment_method: None,
-                    saga_id: None,
+                    nostr_event_id: None,
+                    contact_node_id: Some(node_id),
+                    linked_txs: vec![],
                 };
                 let tx_id = self
                     .pay_to_contact(
@@ -681,7 +630,7 @@ impl WalletApi for super::Wallet {
         Ok(summary)
     }
 
-    async fn check_pending_mints(&self) -> Result<Vec<TransactionId>> {
+    async fn check_pending_mints(&self) -> Result<Vec<Uuid>> {
         let mut res = Vec::new();
         let keysets_info = self.get_wallet_mint_keyset_infos().await?;
         let now = chrono::Utc::now();
@@ -696,31 +645,24 @@ impl WalletApi for super::Wallet {
             .await?;
 
         for (qid, mint_result) in pending_mints_result {
-            let mut metadata = HashMap::default();
-            metadata.insert(
-                PAYMENT_TYPE_METADATA_KEY.to_owned(),
-                PaymentType::OnChain.to_string(),
-            );
-            metadata.insert(
-                TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-                TransactionStatus::Settled.to_string(),
-            );
-
             let tx = Transaction {
+                id: Uuid::new_v4(),
                 mint_url: to_mint_url(self.client.mint_url()),
-                fee: mint_result.fee,
+                fees: mint_result.fee,
                 direction: TransactionDirection::Incoming,
                 memo: None,
-                timestamp: now.timestamp() as u64,
+                status: TransactionStatus::Settled,
+                payment_type: PaymentType::OnChain,
+                tstamp: now.timestamp() as u64,
                 unit: self.debit_unit(),
                 ys: mint_result.ys,
                 amount: mint_result.amount,
-                metadata,
-                quote_id: Some(qid.to_string()),
-                payment_request: None,
-                payment_proof: None,
-                payment_method: None,
-                saga_id: None,
+                quote_id: Some(qid),
+                payment_request_id: None,
+                btc_tx_id: None,
+                nostr_event_id: None,
+                contact_node_id: None,
+                linked_txs: vec![],
             };
             let tx_id = self.tx_repo.store_tx(tx).await?;
             res.push(tx_id);
@@ -747,31 +689,24 @@ impl WalletApi for super::Wallet {
 
         if let Some((amount, ref ys)) = result {
             let now = chrono::Utc::now();
-            let mut metadata = HashMap::default();
-            metadata.insert(
-                PAYMENT_TYPE_METADATA_KEY.to_owned(),
-                PaymentType::OnChain.to_string(),
-            );
-            metadata.insert(
-                TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-                TransactionStatus::Settled.to_string(),
-            );
-
             let tx = Transaction {
+                id: Uuid::new_v4(),
                 mint_url: to_mint_url(self.client.mint_url()),
-                fee: cashu::Amount::ZERO,
+                fees: cashu::Amount::ZERO,
                 direction: TransactionDirection::Incoming,
                 memo: Some("Mint protest resolved".to_string()),
-                timestamp: now.timestamp() as u64,
+                tstamp: now.timestamp() as u64,
                 unit: self.debit_unit(),
                 ys: ys.clone(),
                 amount,
-                metadata,
-                quote_id: Some(quote_id.to_string()),
-                payment_request: None,
-                payment_proof: None,
-                payment_method: None,
-                saga_id: None,
+                status: TransactionStatus::Settled,
+                payment_type: PaymentType::OnChain,
+                quote_id: Some(quote_id),
+                nostr_event_id: None,
+                btc_tx_id: None,
+                contact_node_id: None,
+                payment_request_id: None,
+                linked_txs: vec![],
             };
             self.tx_repo.store_tx(tx).await?;
         }
@@ -798,31 +733,24 @@ impl WalletApi for super::Wallet {
 
         if let Some((amount, ref ys)) = result {
             let now = chrono::Utc::now();
-            let mut metadata = HashMap::default();
-            metadata.insert(
-                PAYMENT_TYPE_METADATA_KEY.to_owned(),
-                PaymentType::Swap.to_string(),
-            );
-            metadata.insert(
-                TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-                TransactionStatus::Settled.to_string(),
-            );
-
             let tx = Transaction {
+                id: Uuid::new_v4(),
                 mint_url: to_mint_url(self.client.mint_url()),
-                fee: cashu::Amount::ZERO,
+                fees: cashu::Amount::ZERO,
                 direction: TransactionDirection::Incoming,
                 memo: Some("Swap protest resolved".to_string()),
-                timestamp: now.timestamp() as u64,
+                tstamp: now.timestamp() as u64,
                 unit: self.debit_unit(),
                 ys: ys.clone(),
+                payment_type: PaymentType::Swap,
+                status: TransactionStatus::Settled,
                 amount,
-                metadata,
                 quote_id: None,
-                payment_request: None,
-                payment_proof: None,
-                payment_method: None,
-                saga_id: None,
+                nostr_event_id: None,
+                btc_tx_id: None,
+                contact_node_id: None,
+                payment_request_id: None,
+                linked_txs: vec![],
             };
             self.tx_repo.store_tx(tx).await?;
         }
@@ -838,34 +766,25 @@ impl WalletApi for super::Wallet {
 
         if let Some((amount, ref ys)) = result {
             let now = chrono::Utc::now();
-            let mut metadata = HashMap::default();
-            metadata.insert(
-                PAYMENT_TYPE_METADATA_KEY.to_owned(),
-                PaymentType::OnChain.to_string(),
-            );
-            metadata.insert(
-                TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-                TransactionStatus::Settled.to_string(),
-            );
-            if let Some(tx_id) = txid {
-                metadata.insert(BTC_TX_ID_TYPE_METADATA_KEY.to_owned(), tx_id.to_string());
-            }
 
             let tx = Transaction {
+                id: Uuid::new_v4(),
                 mint_url: to_mint_url(self.client.mint_url()),
-                fee: cashu::Amount::ZERO,
+                fees: cashu::Amount::ZERO,
                 direction: TransactionDirection::Outgoing,
                 memo: Some("Melt protest resolved".to_string()),
-                timestamp: now.timestamp() as u64,
+                tstamp: now.timestamp() as u64,
                 unit: self.debit_unit(),
                 ys: ys.clone(),
+                payment_type: PaymentType::OnChain,
+                status: TransactionStatus::Settled,
                 amount,
-                metadata,
-                quote_id: Some(quote_id.to_string()),
-                payment_request: None,
-                payment_proof: None,
-                payment_method: None,
-                saga_id: None,
+                quote_id: Some(quote_id),
+                nostr_event_id: None,
+                btc_tx_id: txid,
+                contact_node_id: None,
+                payment_request_id: None,
+                linked_txs: vec![],
             };
             self.tx_repo.store_tx(tx).await?;
         }
@@ -900,8 +819,12 @@ impl WalletApi for super::Wallet {
         mint: url::Url,
         tstamp: u64,
         memo: Option<String>,
-        metadata: HashMap<String, String>,
-    ) -> Result<TransactionId> {
+        payment_type: PaymentType,
+        status: TransactionStatus,
+        payment_request_id: Option<Uuid>,
+        contact_node_id: Option<NodeId>,
+        nostr_event_id: Option<EventId>,
+    ) -> Result<Uuid> {
         let (intermint_infos, local_alpha_keysets_info) =
             self.get_clowder_path_and_keysets_info(mint.clone()).await?;
         self._receive_proofs(
@@ -912,7 +835,11 @@ impl WalletApi for super::Wallet {
             intermint_infos,
             tstamp,
             memo,
-            metadata,
+            payment_type,
+            status,
+            payment_request_id,
+            contact_node_id,
+            nostr_event_id,
         )
         .await
     }
@@ -1181,7 +1108,7 @@ impl WalletApi for super::Wallet {
         fees: Amount,
         memo: Option<String>,
         now: u64,
-    ) -> Result<(TransactionId, Option<Token>)> {
+    ) -> Result<(Uuid, Option<Token>)> {
         tracing::warn!(
             "Pay by Token: Wallet mint is offline - find substitute and attempt offline exchange for tokens"
         );
@@ -1275,32 +1202,25 @@ impl WalletApi for super::Wallet {
                 self.debit.unit(),
             );
 
-            let mut metadata = HashMap::default();
-            metadata.insert(
-                PAYMENT_TYPE_METADATA_KEY.to_owned(),
-                PaymentType::Token.to_string(),
-            );
-            metadata.insert(
-                TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-                TransactionStatus::Pending.to_string(),
-            );
-
             // Create Transaction
             let partial_tx = Transaction {
+                id: Uuid::new_v4(),
                 mint_url: to_mint_url(&substitute),
-                fee: fees,
+                fees,
                 direction: TransactionDirection::Outgoing,
                 memo,
-                timestamp: now,
+                tstamp: now,
                 unit: unit.clone(),
                 ys,
+                status: TransactionStatus::Pending,
+                payment_type: PaymentType::Token,
                 amount,
-                metadata,
                 quote_id: None,
-                payment_request: None,
-                payment_proof: None,
-                payment_method: None,
-                saga_id: None,
+                payment_request_id: None,
+                nostr_event_id: None,
+                btc_tx_id: None,
+                contact_node_id: None,
+                linked_txs: vec![],
             };
             let tx_id = self.tx_repo.store_tx(partial_tx).await?;
             Ok((tx_id, Some(token)))
@@ -1644,11 +1564,7 @@ impl WalletApi for super::Wallet {
         Ok(())
     }
 
-    async fn mark_payment_request_as_paid(
-        &self,
-        payment_req_id: Uuid,
-        tx_id: TransactionId,
-    ) -> Result<()> {
+    async fn mark_payment_request_as_paid(&self, payment_req_id: Uuid, tx_id: Uuid) -> Result<()> {
         if self
             .payment_request_repo
             .get_payment_request(payment_req_id)

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -8,7 +8,6 @@ use crate::{
     ClowderMintConnector,
     error::{Error, Result},
     pocket::debit::DebitPocketApi,
-    types::{PAYMENT_TYPE_METADATA_KEY, TRANSACTION_STATUS_METADATA_KEY},
     wallet::{
         api::WalletApi,
         types::{PayReference, SwapConfig, WalletBalance, WalletDetailedBalanceEntry},
@@ -17,7 +16,7 @@ use crate::{
 };
 use bcr_common::{
     cashu::{self, Amount, CurrencyUnit, KeySetInfo, Proof, ProofsMethods},
-    cdk_common::wallet::{Transaction, TransactionDirection, TransactionId},
+    cdk_common::wallet::TransactionDirection,
     core::NodeId,
     wallet::Token,
     wire::clowder::{ConnectedMintResponse, ConnectedMintsResponse},
@@ -26,9 +25,9 @@ use bcr_wallet_core::{
     contact::Contact,
     event::{ContactPaymentPayload, EventEnvelope},
     types::{
-        CONTACT_NODE_ID_METADATA_KEY, ListTransactionsResult, PAYMENT_REQUEST_ID_METADATA_KEY,
-        PaymentRequest, PaymentType, TransactionCursor, TransactionFilters, TransactionSort,
-        TransactionStatus, extract_fees_per_month,
+        ListTransactionsResult, PaymentRequest, PaymentType, Transaction, TransactionCursor,
+        TransactionFilters, TransactionLinkReason, TransactionSort, TransactionStatus,
+        extract_fees_per_month,
     },
     util::{from_mint_url, to_mint_url},
 };
@@ -42,6 +41,7 @@ use bitcoin::{
     secp256k1,
 };
 use chrono::Utc;
+use nostr::event::EventId;
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 use tokio::sync::{Mutex, RwLock, broadcast};
 use tokio_util::sync::CancellationToken;
@@ -239,32 +239,10 @@ impl Wallet {
                             bcr_wallet_transport::NostrWalletEvent::Cdk18Payment { .. } => {
                                 // ignore - cdk18 payments are handled by explicitly awaiting them
                             },
-                            bcr_wallet_transport::NostrWalletEvent::ContactPayment { sender, payload, event_id } => {
+                            bcr_wallet_transport::NostrWalletEvent::ContactPayment { payload, event_id, .. } => {
                                 if payload.sender.network() != wallet_network {
                                     tracing::warn!("Rejected incoming Contact payment from a different network: {}", payload.sender);
                                     continue;
-                                }
-                                let mut meta = HashMap::from([
-                                    (String::from("sender"), sender.to_string()),
-                                    (String::from("nostr_event_id"), event_id.to_string()),
-                                    (
-                                        String::from(PAYMENT_TYPE_METADATA_KEY),
-                                        PaymentType::Contact.to_string(),
-                                    ),
-                                    (
-                                        String::from(TRANSACTION_STATUS_METADATA_KEY),
-                                        TransactionStatus::Settled.to_string(),
-                                    ),
-                                    (
-                                        String::from(CONTACT_NODE_ID_METADATA_KEY),
-                                        payload.sender.to_string()
-                                    ),
-                                ]);
-                                if let Some(p_req_id) = payload.payment_request_id {
-                                    meta.insert(
-                                        PAYMENT_REQUEST_ID_METADATA_KEY.to_owned(),
-                                        p_req_id.to_string(),
-                                    );
                                 }
 
                                 let amount = payload.proofs.total_amount().unwrap_or(Amount::ZERO);
@@ -276,7 +254,11 @@ impl Wallet {
                                     from_mint_url(&payload.mint),
                                     chrono::Utc::now().timestamp() as u64,
                                     payload.memo,
-                                    meta,
+                                    PaymentType::Contact,
+                                    TransactionStatus::Settled,
+                                    payload.payment_request_id,
+                                    Some(payload.sender.clone()),
+                                    Some(event_id)
                                 ).await {
                                     Ok(tx_id) => {
                                         // if it's from a payment request - attempt to set it to paid
@@ -315,7 +297,7 @@ impl Wallet {
         }
     }
 
-    pub async fn list_tx_ids(&self) -> Result<Vec<TransactionId>> {
+    pub async fn list_tx_ids(&self) -> Result<Vec<Uuid>> {
         let res = self.tx_repo.list_tx_ids().await?;
         Ok(res)
     }
@@ -343,27 +325,19 @@ impl Wallet {
         // apply sorting
         match sort {
             TransactionSort::TimeAsc => {
-                res.sort_by(|a, b| {
-                    a.timestamp
-                        .cmp(&b.timestamp)
-                        .then_with(|| a.id().cmp(&b.id()))
-                });
+                res.sort_by(|a, b| a.tstamp.cmp(&b.tstamp).then_with(|| a.id.cmp(&b.id)));
             }
 
             TransactionSort::TimeDesc => {
-                res.sort_by(|a, b| {
-                    b.timestamp
-                        .cmp(&a.timestamp)
-                        .then_with(|| b.id().cmp(&a.id()))
-                });
+                res.sort_by(|a, b| b.tstamp.cmp(&a.tstamp).then_with(|| b.id.cmp(&a.id)));
             }
 
             TransactionSort::AmountAsc => {
-                res.sort_by(|a, b| a.amount.cmp(&b.amount).then_with(|| a.id().cmp(&b.id())));
+                res.sort_by(|a, b| a.amount.cmp(&b.amount).then_with(|| a.id.cmp(&b.id)));
             }
 
             TransactionSort::AmountDesc => {
-                res.sort_by(|a, b| b.amount.cmp(&a.amount).then_with(|| b.id().cmp(&a.id())));
+                res.sort_by(|a, b| b.amount.cmp(&a.amount).then_with(|| b.id.cmp(&a.id)));
             }
         }
         // apply limit
@@ -517,12 +491,12 @@ impl Wallet {
         Ok(())
     }
 
-    pub async fn load_tx(&self, tx_id: TransactionId) -> Result<Transaction> {
+    pub async fn load_tx(&self, tx_id: Uuid) -> Result<Transaction> {
         let tx = self.tx_repo.load_tx(tx_id).await?;
         Ok(tx)
     }
 
-    pub async fn edit_tx_memo(&self, tx_id: TransactionId, new_memo: Option<String>) -> Result<()> {
+    pub async fn edit_tx_memo(&self, tx_id: Uuid, new_memo: Option<String>) -> Result<()> {
         let _ = self.tx_repo.update_memo(tx_id, new_memo).await?;
         Ok(())
     }
@@ -530,7 +504,7 @@ impl Wallet {
     // Fetches the transaction with the given ID from the database and, if it's in a pending state
     // it attempts to get the current state from the mint and, if it's spent, changes it to spent
     // Returns whether the transaction has been updated
-    pub async fn refresh_tx(&self, tx_id: TransactionId) -> Result<bool> {
+    pub async fn refresh_tx(&self, tx_id: Uuid) -> Result<bool> {
         let mut updated = false;
         let tx = self.tx_repo.load_tx(tx_id).await?;
         if !util::tx_can_be_refreshed(&tx) {
@@ -543,11 +517,7 @@ impl Wallet {
             .any(|s| matches!(s.state, cashu::State::Spent));
         if is_any_spent {
             self.tx_repo
-                .update_metadata(
-                    tx_id,
-                    String::from(TRANSACTION_STATUS_METADATA_KEY),
-                    TransactionStatus::Settled.to_string(),
-                )
+                .update_status(tx_id, TransactionStatus::Settled)
                 .await?;
             updated = true;
         }
@@ -563,9 +533,9 @@ impl Wallet {
                 continue;
             }
 
-            let tx_id = tx.id();
+            let tx_id = tx.id;
 
-            match self.refresh_tx(tx_id).await {
+            match self.refresh_tx(tx.id).await {
                 Ok(tx_updated) => {
                     if tx_updated {
                         updated += 1;
@@ -616,7 +586,11 @@ impl Wallet {
         Ok(cleaned_up)
     }
 
-    pub async fn reclaim_tx(&self, tx_id: TransactionId) -> Result<Amount> {
+    /// Check that the transaction can be reclaimed, then
+    /// * Create a new transaction with state `Canceled`
+    /// * Set the initial transaction to `Settled`
+    /// * Link the two transactions with reason `Reclaim`
+    pub async fn reclaim_tx(&self, tx_id: Uuid) -> Result<Amount> {
         let infos = self.get_wallet_mint_keyset_infos().await?;
         self.refresh_tx(tx_id).await?;
         let tx = self.load_tx(tx_id).await?;
@@ -639,11 +613,7 @@ impl Wallet {
         // If amount is zero - this means the transaction was already claimed - we set the transaction to Settled
         if amount == Amount::ZERO {
             self.tx_repo
-                .update_metadata(
-                    tx_id,
-                    String::from(TRANSACTION_STATUS_METADATA_KEY),
-                    TransactionStatus::Settled.to_string(),
-                )
+                .update_status(tx_id, TransactionStatus::Settled)
                 .await?;
         } else {
             let fee = if tx.amount > amount {
@@ -652,18 +622,37 @@ impl Wallet {
                 Amount::ZERO
             };
 
-            // Set reclaimed transaction to canceled
+            // Create new, cancelled transaction
+            let reclaim_tx = Transaction {
+                id: Uuid::new_v4(),
+                mint_url: tx.mint_url.clone(),
+                direction: TransactionDirection::Incoming, // incoming, since we're getting back the funds
+                fees: fee,
+                amount: tx.amount,
+                memo: tx.memo.clone(),
+                tstamp: Utc::now().timestamp() as u64,
+                unit: tx.unit,
+                payment_type: tx.payment_type,
+                status: TransactionStatus::Canceled, // canceled, since it's the reclaim tx
+                ys: tx.ys.clone(),
+                quote_id: tx.quote_id,
+                contact_node_id: tx.contact_node_id.clone(),
+                payment_request_id: tx.payment_request_id,
+                nostr_event_id: tx.nostr_event_id,
+                btc_tx_id: tx.btc_tx_id,
+                linked_txs: vec![],
+            };
+            let reclaim_txid = self.tx_repo.store_tx(reclaim_tx).await?;
+
+            // Set the initial transaction to Settled
             self.tx_repo
-                .update_metadata(
-                    tx_id,
-                    String::from(TRANSACTION_STATUS_METADATA_KEY),
-                    TransactionStatus::Canceled.to_string(),
-                )
+                .update_status(tx_id, TransactionStatus::Settled)
                 .await?;
-            if fee > Amount::ZERO {
-                // Set fee in reclaimed transaction
-                self.tx_repo.update_fee(tx_id, fee).await?;
-            }
+
+            // Link the two transactions with reason Reclaim
+            self.tx_repo
+                .link_txs(tx_id, reclaim_txid, TransactionLinkReason::Reclaim)
+                .await?;
         }
 
         Ok(amount)
@@ -678,26 +667,17 @@ impl Wallet {
         intermint_infos: Option<(ConnectedMintsResponse, HashMap<cashu::Id, KeySetInfo>)>,
         tstamp: u64,
         memo: Option<String>,
-        metadata: HashMap<String, String>,
-    ) -> Result<TransactionId> {
+        payment_type: PaymentType,
+        status: TransactionStatus,
+        payment_request_id: Option<Uuid>,
+        contact_node_id: Option<NodeId>,
+        nostr_event_id: Option<EventId>,
+    ) -> Result<Uuid> {
         if unit != self.debit.unit() {
             return Err(Error::InvalidCurrencyUnit(unit.to_string()));
         }
         let initial_amount = proofs.total_amount()?;
         let mut proofs = proofs;
-
-        // check if these are proofs we created ourselves - if they are and are still outgoing and pending, we reclaim them
-        let tx_id_to_check_for_reclaim = TransactionId::new(proofs.ys()?);
-        if let Ok(tx_for_ys) = self.tx_repo.load_tx(tx_id_to_check_for_reclaim).await {
-            // if it's Outgoing and Pending, we attempt to reclaim it
-            if util::tx_can_be_refreshed(&tx_for_ys) {
-                tracing::debug!(
-                    "Detected incoming proofs from an outgoing, pending transaction of ourselves - reclaiming"
-                );
-                self.reclaim_tx(tx_id_to_check_for_reclaim).await?;
-                return Ok(tx_id_to_check_for_reclaim);
-            }
-        }
 
         let mut is_intermint = false;
         if &mint != self.client.mint_url() {
@@ -779,20 +759,23 @@ impl Wallet {
             Amount::ZERO
         };
         let tx = Transaction {
+            id: Uuid::new_v4(),
             mint_url: to_mint_url(self.client.mint_url()),
             direction: TransactionDirection::Incoming,
-            fee,
+            fees: fee,
             amount: initial_amount,
             memo,
-            metadata,
-            timestamp: tstamp,
+            tstamp,
             unit,
+            payment_type,
+            status,
             ys,
             quote_id: None,
-            payment_request: None,
-            payment_proof: None,
-            payment_method: None,
-            saga_id: None,
+            contact_node_id,
+            payment_request_id,
+            nostr_event_id,
+            btc_tx_id: None,
+            linked_txs: vec![],
         };
         let txid = self.tx_repo.store_tx(tx).await?;
         Ok(txid)
@@ -927,7 +910,7 @@ impl Wallet {
         Ok(beta_proofs)
     }
 
-    pub async fn receive_token(&self, token: Token, tstamp: u64) -> Result<TransactionId> {
+    pub async fn receive_token(&self, token: Token, tstamp: u64) -> Result<Uuid> {
         let token_teaser = token.to_string().chars().take(20).collect::<String>();
         let token_mint_url = from_mint_url(&token.mint_url());
         let (intermint_infos, keysets_info) = self
@@ -949,16 +932,6 @@ impl Wallet {
             return Err(Error::EmptyToken(token_teaser));
         }
 
-        let mut metadata = HashMap::default();
-        metadata.insert(
-            PAYMENT_TYPE_METADATA_KEY.to_owned(),
-            PaymentType::Token.to_string(),
-        );
-        metadata.insert(
-            TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-            TransactionStatus::Settled.to_string(),
-        );
-
         let tx_id = if token.unit().is_some() && token.unit() == Some(self.debit.unit()) {
             tracing::debug!("import debit token");
 
@@ -970,7 +943,11 @@ impl Wallet {
                 intermint_infos,
                 tstamp,
                 token.memo().clone(),
-                metadata,
+                PaymentType::Token,
+                TransactionStatus::Settled,
+                None,
+                None,
+                None,
             )
             .await?
         } else {
@@ -986,7 +963,7 @@ impl Wallet {
         contact: Contact,
         payment_request_id: Option<Uuid>,
         mut partial_tx: Transaction,
-    ) -> Result<TransactionId> {
+    ) -> Result<Uuid> {
         let payload = ContactPaymentPayload {
             payment_request_id,
             sender: self.node_id(),
@@ -1019,9 +996,7 @@ impl Wallet {
                 }
             }
         };
-        partial_tx
-            .metadata
-            .insert(String::from("nostr::event_id"), event_id.to_string());
+        partial_tx.nostr_event_id = Some(event_id);
         let txid = self.tx_repo.store_tx(partial_tx).await?;
         Ok(txid)
     }
@@ -1034,7 +1009,7 @@ impl Wallet {
         transport: cashu::Transport,
         p_id: Option<String>,
         mut partial_tx: Transaction,
-    ) -> Result<TransactionId> {
+    ) -> Result<Uuid> {
         let payload = cashu::PaymentRequestPayload {
             id: p_id,
             memo: partial_tx.memo.clone(),
@@ -1068,9 +1043,7 @@ impl Wallet {
                         }
                     }
                 };
-                partial_tx
-                    .metadata
-                    .insert(String::from("nostr::event_id"), event_id.to_string());
+                partial_tx.nostr_event_id = Some(event_id);
             }
         }
         let txid = self.tx_repo.store_tx(partial_tx).await?;
@@ -1148,7 +1121,7 @@ mod tests {
         name::Name,
         types::{
             MintSummary, PaymentRequestDirection, PaymentRequestState, PaymentResultCallback,
-            TimeRange, get_payment_type, get_transaction_status,
+            TimeRange,
         },
     };
     use bcr_wallet_persistence::{
@@ -1310,23 +1283,23 @@ mod tests {
 
     fn reclaimable_tx(amount: Amount) -> Transaction {
         Transaction {
+            id: Uuid::new_v4(),
             mint_url: cashu::MintUrl::from_str("https://mint.example").unwrap(),
             direction: TransactionDirection::Outgoing,
-            fee: Amount::ZERO,
+            fees: Amount::ZERO,
             amount,
             memo: None,
-            metadata: HashMap::from([(
-                String::from(TRANSACTION_STATUS_METADATA_KEY),
-                TransactionStatus::Pending.to_string(),
-            )]),
-            timestamp: 123,
+            payment_type: PaymentType::Token,
+            status: TransactionStatus::Pending,
+            tstamp: 123,
             unit: CurrencyUnit::Sat,
             ys: vec![],
             quote_id: None,
-            payment_request: None,
-            payment_proof: None,
-            payment_method: None,
-            saga_id: None,
+            payment_request_id: None,
+            btc_tx_id: None,
+            nostr_event_id: None,
+            contact_node_id: None,
+            linked_txs: vec![],
         }
     }
 
@@ -1339,26 +1312,23 @@ mod tests {
         status: TransactionStatus,
     ) -> Transaction {
         Transaction {
+            id: Uuid::new_v4(),
             mint_url: cashu::MintUrl::from_str("https://mint.example").unwrap(),
             direction,
-            fee: Amount::ZERO,
+            fees: Amount::ZERO,
             amount: Amount::from(amount),
             memo: None,
-            metadata: HashMap::from([
-                (String::from(PAYMENT_TYPE_METADATA_KEY), ptype.to_string()),
-                (
-                    String::from(TRANSACTION_STATUS_METADATA_KEY),
-                    status.to_string(),
-                ),
-            ]),
-            timestamp,
+            status,
+            payment_type: ptype,
+            tstamp: timestamp,
             unit: CurrencyUnit::Sat,
             ys: vec![test_cashu_pubkey(n)],
             quote_id: None,
-            payment_request: None,
-            payment_proof: None,
-            payment_method: None,
-            saga_id: None,
+            payment_request_id: None,
+            btc_tx_id: None,
+            nostr_event_id: None,
+            contact_node_id: None,
+            linked_txs: vec![],
         }
     }
 
@@ -1426,32 +1396,24 @@ mod tests {
     fn sort_expected(mut txs: Vec<Transaction>, sort: TransactionSort) -> Vec<Transaction> {
         match sort {
             TransactionSort::TimeAsc => {
-                txs.sort_by(|a, b| {
-                    a.timestamp
-                        .cmp(&b.timestamp)
-                        .then_with(|| a.id().cmp(&b.id()))
-                });
+                txs.sort_by(|a, b| a.tstamp.cmp(&b.tstamp).then_with(|| a.id.cmp(&b.id)));
             }
             TransactionSort::TimeDesc => {
-                txs.sort_by(|a, b| {
-                    b.timestamp
-                        .cmp(&a.timestamp)
-                        .then_with(|| b.id().cmp(&a.id()))
-                });
+                txs.sort_by(|a, b| b.tstamp.cmp(&a.tstamp).then_with(|| b.id.cmp(&a.id)));
             }
             TransactionSort::AmountAsc => {
-                txs.sort_by(|a, b| a.amount.cmp(&b.amount).then_with(|| a.id().cmp(&b.id())));
+                txs.sort_by(|a, b| a.amount.cmp(&b.amount).then_with(|| a.id.cmp(&b.id)));
             }
             TransactionSort::AmountDesc => {
-                txs.sort_by(|a, b| b.amount.cmp(&a.amount).then_with(|| b.id().cmp(&a.id())));
+                txs.sort_by(|a, b| b.amount.cmp(&a.amount).then_with(|| b.id.cmp(&a.id)));
             }
         }
 
         txs
     }
 
-    fn tx_ids(txs: &[Transaction]) -> Vec<TransactionId> {
-        txs.iter().map(|tx| tx.id()).collect()
+    fn tx_ids(txs: &[Transaction]) -> Vec<Uuid> {
+        txs.iter().map(|tx| tx.id).collect()
     }
 
     #[tokio::test]
@@ -1898,7 +1860,7 @@ mod tests {
         ctx.tx_repo
             .expect_store_tx()
             .times(1)
-            .returning(|_tx| Ok(TransactionId::new(vec![])));
+            .returning(|_tx| Ok(Uuid::new_v4()));
 
         let wlt = wallet(ctx).await;
         *wlt.read().await.current_payment.lock().await = Some(PayReference {
@@ -1968,7 +1930,7 @@ mod tests {
         let mut ctx = wallet_ctx();
 
         let pid = Uuid::new_v4();
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
 
         ctx.client
             .expect_get_mint_keysets()
@@ -1993,18 +1955,12 @@ mod tests {
         ctx.tx_repo.expect_store_tx().times(1).returning(move |tx| {
             assert_eq!(tx.direction, TransactionDirection::Outgoing);
             assert_eq!(tx.amount, Amount::ZERO);
-            assert_eq!(tx.fee, Amount::ZERO);
+            assert_eq!(tx.fees, Amount::ZERO);
             assert_eq!(tx.unit, CurrencyUnit::Sat);
-            assert_eq!(tx.timestamp, 123);
+            assert_eq!(tx.tstamp, 123);
             assert_eq!(tx.memo, Some("melt memo".to_string()));
-            assert_eq!(
-                tx.metadata.get(PAYMENT_TYPE_METADATA_KEY),
-                Some(&PaymentType::OnChain.to_string())
-            );
-            assert_eq!(
-                tx.metadata.get(TRANSACTION_STATUS_METADATA_KEY),
-                Some(&TransactionStatus::Settled.to_string())
-            );
+            assert_eq!(tx.payment_type, PaymentType::OnChain);
+            assert_eq!(tx.status, TransactionStatus::Settled);
             Ok(tx_id)
         });
 
@@ -2031,7 +1987,7 @@ mod tests {
         let mut ctx = wallet_ctx();
 
         let pid = Uuid::new_v4();
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
 
         ctx.client
             .expect_get_mint_keysets()
@@ -2061,19 +2017,13 @@ mod tests {
         ctx.tx_repo.expect_store_tx().times(1).returning(move |tx| {
             assert_eq!(tx.direction, TransactionDirection::Outgoing);
             assert_eq!(tx.amount, Amount::ZERO);
-            assert_eq!(tx.fee, Amount::ZERO);
+            assert_eq!(tx.fees, Amount::ZERO);
             assert_eq!(tx.unit, CurrencyUnit::Sat);
-            assert_eq!(tx.timestamp, 123);
+            assert_eq!(tx.tstamp, 123);
             assert_eq!(tx.memo, Some("cdk18 memo".to_string()));
-            assert_eq!(
-                tx.metadata.get(PAYMENT_TYPE_METADATA_KEY),
-                Some(&PaymentType::Cdk18.to_string())
-            );
-            assert_eq!(
-                tx.metadata.get(TRANSACTION_STATUS_METADATA_KEY),
-                Some(&TransactionStatus::Pending.to_string())
-            );
-            assert!(tx.metadata.contains_key("nostr::event_id"));
+            assert_eq!(tx.payment_type, PaymentType::Cdk18,);
+            assert_eq!(tx.status, TransactionStatus::Pending,);
+            assert!(tx.nostr_event_id.is_some());
             Ok(tx_id)
         });
 
@@ -2114,7 +2064,7 @@ mod tests {
         let mut ctx = wallet_ctx();
 
         let pid = Uuid::new_v4();
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
         let contact_node_id = node_id(NODE_ID_1);
 
         ctx.client
@@ -2168,23 +2118,14 @@ mod tests {
         ctx.tx_repo.expect_store_tx().times(1).returning(move |tx| {
             assert_eq!(tx.direction, TransactionDirection::Outgoing);
             assert_eq!(tx.amount, Amount::ZERO);
-            assert_eq!(tx.fee, Amount::ZERO);
+            assert_eq!(tx.fees, Amount::ZERO);
             assert_eq!(tx.unit, CurrencyUnit::Sat);
-            assert_eq!(tx.timestamp, 123);
+            assert_eq!(tx.tstamp, 123);
             assert_eq!(tx.memo, Some("contact memo".to_string()));
-            assert_eq!(
-                tx.metadata.get(PAYMENT_TYPE_METADATA_KEY),
-                Some(&PaymentType::Contact.to_string())
-            );
-            assert_eq!(
-                tx.metadata.get(TRANSACTION_STATUS_METADATA_KEY),
-                Some(&TransactionStatus::Pending.to_string())
-            );
-            assert_eq!(
-                tx.metadata.get(CONTACT_NODE_ID_METADATA_KEY),
-                Some(&contact_node_id.to_string())
-            );
-            assert!(tx.metadata.contains_key("nostr::event_id"));
+            assert_eq!(tx.payment_type, PaymentType::Contact,);
+            assert_eq!(tx.status, TransactionStatus::Pending);
+            assert_eq!(tx.contact_node_id, Some(contact_node_id.clone()));
+            assert!(tx.nostr_event_id.is_some());
             Ok(tx_id)
         });
 
@@ -2268,7 +2209,7 @@ mod tests {
     #[tokio::test]
     async fn test_reclaim_tx_errors_if_transaction_cant_be_reclaimed() {
         let mut ctx = wallet_ctx();
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
 
         ctx.client
             .expect_get_mint_keysets()
@@ -2276,10 +2217,7 @@ mod tests {
             .returning(|| Ok(vec![]));
 
         let tx = Transaction {
-            metadata: HashMap::from([(
-                String::from(TRANSACTION_STATUS_METADATA_KEY),
-                TransactionStatus::Settled.to_string(),
-            )]),
+            status: TransactionStatus::Settled,
             ..reclaimable_tx(Amount::from(10))
         };
 
@@ -2300,7 +2238,7 @@ mod tests {
     #[tokio::test]
     async fn test_reclaim_tx_sets_settled_if_nothing_reclaimed() {
         let mut ctx = wallet_ctx();
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
         let tx = reclaimable_tx(Amount::from(10));
 
         ctx.client
@@ -2329,13 +2267,10 @@ mod tests {
             .returning(|_, _, _, _| Ok(Amount::ZERO));
 
         ctx.tx_repo
-            .expect_update_metadata()
+            .expect_update_status()
             .times(1)
-            .withf(|_, key, value| {
-                key == TRANSACTION_STATUS_METADATA_KEY
-                    && value == &TransactionStatus::Settled.to_string()
-            })
-            .returning(|_, _, _| Ok(None));
+            .withf(|_, status| *status == TransactionStatus::Settled)
+            .returning(|_, _| Ok(None));
 
         let wlt = wallet(ctx).await;
         let amount = wlt.read().await.reclaim_tx(tx_id).await.unwrap();
@@ -2344,9 +2279,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reclaim_tx_sets_canceled_without_fee_if_fully_reclaimed() {
+    async fn test_reclaim_tx_creates_second_linked_tx() {
         let mut ctx = wallet_ctx();
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
         let tx = reclaimable_tx(Amount::from(10));
 
         ctx.client
@@ -2364,53 +2299,11 @@ mod tests {
             .times(2)
             .returning(move |_| Ok(tx.clone()));
 
-        ctx.debit
-            .expect_unit()
-            .times(1)
-            .returning(|| CurrencyUnit::Sat);
-
-        ctx.debit
-            .expect_reclaim_proofs()
-            .times(1)
-            .returning(|_, _, _, _| Ok(Amount::from(10)));
-
+        // store new tx
         ctx.tx_repo
-            .expect_update_metadata()
+            .expect_store_tx()
             .times(1)
-            .withf(|_, key, value| {
-                key == TRANSACTION_STATUS_METADATA_KEY
-                    && value == &TransactionStatus::Canceled.to_string()
-            })
-            .returning(|_, _, _| Ok(None));
-
-        ctx.tx_repo.expect_update_fee().times(0);
-
-        let wlt = wallet(ctx).await;
-        let amount = wlt.read().await.reclaim_tx(tx_id).await.unwrap();
-
-        assert_eq!(amount, Amount::from(10));
-    }
-
-    #[tokio::test]
-    async fn test_reclaim_tx_sets_canceled_and_fee_if_partially_reclaimed() {
-        let mut ctx = wallet_ctx();
-        let tx_id = TransactionId::new(vec![]);
-        let tx = reclaimable_tx(Amount::from(10));
-
-        ctx.client
-            .expect_get_mint_keysets()
-            .times(1)
-            .returning(|| Ok(vec![]));
-
-        ctx.client
-            .expect_post_check_state()
-            .times(1)
-            .returning(|_| Ok(vec![]));
-
-        ctx.tx_repo
-            .expect_load_tx()
-            .times(2)
-            .returning(move |_| Ok(tx.clone()));
+            .returning(move |_| Ok(Uuid::new_v4()));
 
         ctx.debit
             .expect_unit()
@@ -2422,20 +2315,18 @@ mod tests {
             .times(1)
             .returning(|_, _, _, _| Ok(Amount::from(7)));
 
+        // update status of initial transaction to Settled
         ctx.tx_repo
-            .expect_update_metadata()
+            .expect_update_status()
             .times(1)
-            .withf(|_, key, value| {
-                key == TRANSACTION_STATUS_METADATA_KEY
-                    && value == &TransactionStatus::Canceled.to_string()
-            })
-            .returning(|_, _, _| Ok(None));
+            .withf(|_, status| *status == TransactionStatus::Settled)
+            .returning(|_, _| Ok(None));
 
+        // link txs
         ctx.tx_repo
-            .expect_update_fee()
+            .expect_link_txs()
             .times(1)
-            .withf(|_, fee| *fee == Amount::from(3))
-            .returning(|_, _| Ok(()));
+            .returning(|_, _, _| Ok(()));
 
         let wlt = wallet(ctx).await;
         let amount = wlt.read().await.reclaim_tx(tx_id).await.unwrap();
@@ -2446,7 +2337,7 @@ mod tests {
     #[tokio::test]
     async fn test_edit_tx_memo() {
         let mut ctx = wallet_ctx();
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
         ctx.tx_repo
             .expect_update_memo()
             .times(2)
@@ -2594,11 +2485,11 @@ mod tests {
             .clone()
             .into_iter()
             .filter(|tx| {
-                get_payment_type(&tx.metadata) == PaymentType::Token
-                    && get_transaction_status(&tx.metadata) == TransactionStatus::Pending
+                tx.payment_type == PaymentType::Token
+                    && tx.status == TransactionStatus::Pending
                     && tx.direction == TransactionDirection::Incoming
-                    && tx.timestamp >= 100
-                    && tx.timestamp <= 300
+                    && tx.tstamp >= 100
+                    && tx.tstamp <= 300
             })
             .collect();
 
@@ -2622,7 +2513,7 @@ mod tests {
 
         assert_eq!(tx_ids(&txs), tx_ids(&expected));
         assert!(next_cursor.is_none());
-        assert!(txs.iter().any(|tx| tx.timestamp == 300));
+        assert!(txs.iter().any(|tx| tx.tstamp == 300));
     }
 
     #[tokio::test]
@@ -2679,7 +2570,7 @@ mod tests {
         let cursor = TransactionCursor::from_tx(&cursor_tx, TransactionSort::TimeDesc);
 
         let mut txs_without_cursor = txs.clone();
-        txs_without_cursor.retain(|tx| tx.id() != cursor_tx.id());
+        txs_without_cursor.retain(|tx| tx.id != cursor_tx.id);
 
         let expected_after_cursor: Vec<_> =
             sort_expected(txs_without_cursor.clone(), TransactionSort::TimeDesc)
@@ -3175,7 +3066,7 @@ mod tests {
     async fn test_mark_payment_request_as_paid_sets_paid_state() {
         let mut ctx = wallet_ctx();
         let req_id = Uuid::new_v4();
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
         let req = payment_request_with(
             req_id,
             PaymentRequestDirection::Incoming,
@@ -3212,7 +3103,7 @@ mod tests {
     async fn test_mark_payment_request_as_paid_errors_if_not_found() {
         let mut ctx = wallet_ctx();
         let req_id = Uuid::new_v4();
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
 
         ctx.payment_request_repo
             .expect_get_payment_request()
@@ -3434,7 +3325,7 @@ mod tests {
     #[tokio::test]
     async fn test_receive_proofs_stores_incoming_tx_for_wallet_mint() {
         let mut ctx = wallet_ctx();
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
         let ys = vec![test_cashu_pubkey(10)];
 
         ctx.client
@@ -3459,18 +3350,12 @@ mod tests {
             },
         );
 
-        ctx.tx_repo.expect_load_tx().times(1).returning(|_| {
-            Err(bcr_wallet_persistence::error::Error::TransactionNotFound(
-                TransactionId::new(vec![]),
-            ))
-        });
-
         ctx.tx_repo.expect_store_tx().times(1).returning(move |tx| {
             assert_eq!(tx.direction, TransactionDirection::Incoming);
             assert_eq!(tx.amount, Amount::ZERO);
-            assert_eq!(tx.fee, Amount::ZERO);
+            assert_eq!(tx.fees, Amount::ZERO);
             assert_eq!(tx.unit, CurrencyUnit::Sat);
-            assert_eq!(tx.timestamp, 123);
+            assert_eq!(tx.tstamp, 123);
             assert_eq!(tx.memo, Some("memo".to_string()));
             Ok(tx_id)
         });
@@ -3486,10 +3371,11 @@ mod tests {
                 url::Url::from_str("https://mint.example").unwrap(),
                 123,
                 Some("memo".to_string()),
-                HashMap::from([(
-                    String::from(PAYMENT_TYPE_METADATA_KEY),
-                    PaymentType::Token.to_string(),
-                )]),
+                PaymentType::Token,
+                TransactionStatus::Settled,
+                None,
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -3537,7 +3423,7 @@ mod tests {
     async fn test_start_nostr_event_listener_contact_payment() {
         let mut ctx = wallet_ctx();
         let req_id = Uuid::new_v4();
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
         let sender = node_id(NODE_ID_1);
         let sender_for_tx = sender.clone();
         let tx_id_for_store = tx_id;
@@ -3565,11 +3451,6 @@ mod tests {
                 Ok((Amount::ZERO, ys.clone()))
             },
         );
-        ctx.tx_repo.expect_load_tx().times(1).returning(|_| {
-            Err(bcr_wallet_persistence::error::Error::TransactionNotFound(
-                TransactionId::new(vec![]),
-            ))
-        });
         ctx.tx_repo
             .expect_store_tx()
             .times(1)
@@ -3578,23 +3459,10 @@ mod tests {
                 assert_eq!(tx.amount, Amount::ZERO);
                 assert_eq!(tx.unit, CurrencyUnit::Sat);
                 assert_eq!(tx.memo, Some("payment request memo".to_string()));
-                assert_eq!(
-                    tx.metadata.get(PAYMENT_TYPE_METADATA_KEY),
-                    Some(&PaymentType::Contact.to_string())
-                );
-                assert_eq!(
-                    tx.metadata.get(TRANSACTION_STATUS_METADATA_KEY),
-                    Some(&TransactionStatus::Settled.to_string())
-                );
-                assert_eq!(
-                    tx.metadata.get(PAYMENT_REQUEST_ID_METADATA_KEY),
-                    Some(&req_id.to_string())
-                );
-                assert_eq!(
-                    tx.metadata.get(CONTACT_NODE_ID_METADATA_KEY),
-                    Some(&sender_for_tx.to_string())
-                );
-
+                assert_eq!(tx.payment_type, PaymentType::Contact);
+                assert_eq!(tx.status, TransactionStatus::Settled);
+                assert_eq!(tx.payment_request_id, Some(req_id));
+                assert_eq!(tx.contact_node_id, Some(sender_for_tx));
                 processed_tx.send(()).expect("test receiver still alive");
                 Ok(tx_id_for_store)
             });
@@ -3790,7 +3658,7 @@ mod tests {
     async fn test_receive_token_same_mint_success() {
         let mut ctx = wallet_ctx();
 
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
         let mint_url = url::Url::from_str("https://mint.example").unwrap();
 
         let (info, _keyset, proofs) = test_keyset_and_proofs(&[Amount::from(8), Amount::from(16)]);
@@ -3824,31 +3692,18 @@ mod tests {
                 Ok((Amount::from(24), expected_ys))
             },
         );
-
-        ctx.tx_repo.expect_load_tx().times(1).returning(|_| {
-            Err(bcr_wallet_persistence::error::Error::TransactionNotFound(
-                TransactionId::new(vec![]),
-            ))
-        });
-
         ctx.tx_repo
             .expect_store_tx()
             .times(1)
             .return_once(move |tx| {
                 assert_eq!(tx.direction, TransactionDirection::Incoming);
                 assert_eq!(tx.amount, Amount::from(24));
-                assert_eq!(tx.fee, Amount::ZERO);
+                assert_eq!(tx.fees, Amount::ZERO);
                 assert_eq!(tx.unit, CurrencyUnit::Sat);
-                assert_eq!(tx.timestamp, 123);
+                assert_eq!(tx.tstamp, 123);
                 assert_eq!(tx.memo, Some("token memo".to_string()));
-                assert_eq!(
-                    tx.metadata.get(PAYMENT_TYPE_METADATA_KEY),
-                    Some(&PaymentType::Token.to_string())
-                );
-                assert_eq!(
-                    tx.metadata.get(TRANSACTION_STATUS_METADATA_KEY),
-                    Some(&TransactionStatus::Settled.to_string())
-                );
+                assert_eq!(tx.payment_type, PaymentType::Token);
+                assert_eq!(tx.status, TransactionStatus::Settled);
                 Ok(tx_id)
             });
 

--- a/crates/bcr-wallet-api/src/wallet/util.rs
+++ b/crates/bcr-wallet-api/src/wallet/util.rs
@@ -12,6 +12,7 @@ use bcr_common::{
     core::swap::wallet::prepare_swap,
     wire::keys::ProofFingerprint,
 };
+use bcr_wallet_core::types::Transaction;
 use bitcoin::{hashes::sha256::Hash as Sha256, secp256k1};
 use secp256k1::schnorr::Signature;
 
@@ -159,7 +160,7 @@ pub async fn htlc_lock(
     Ok(result_proofs)
 }
 
-pub fn tx_can_be_refreshed(tx: &cdk_common::wallet::Transaction) -> bool {
+pub fn tx_can_be_refreshed(tx: &Transaction) -> bool {
     // Only refresh outgoing transactions
     if matches!(
         tx.direction,
@@ -169,8 +170,7 @@ pub fn tx_can_be_refreshed(tx: &cdk_common::wallet::Transaction) -> bool {
     }
 
     // Only refresh pending transactions
-    let p_status = crate::types::get_transaction_status(&tx.metadata);
-    if !matches!(p_status, crate::types::TransactionStatus::Pending) {
+    if !matches!(tx.status, crate::types::TransactionStatus::Pending) {
         return false;
     }
     true
@@ -184,10 +184,11 @@ mod tests {
         core_tests,
     };
     use bcr_wallet_core::{
-        types::{TRANSACTION_STATUS_METADATA_KEY, TransactionStatus},
+        types::{PaymentType, TransactionStatus},
         util::to_mint_url,
     };
     use std::str::FromStr;
+    use uuid::Uuid;
 
     fn add_test_dleqs(proofs: &mut [cashu::Proof]) {
         for proof in proofs {
@@ -317,25 +318,25 @@ mod tests {
     fn test_tx(
         direction: cdk_common::wallet::TransactionDirection,
         status: TransactionStatus,
-    ) -> cdk_common::wallet::Transaction {
-        cdk_common::wallet::Transaction {
+    ) -> Transaction {
+        Transaction {
+            id: Uuid::new_v4(),
             mint_url: to_mint_url(&url::Url::from_str("https://mint.example").unwrap()),
-            fee: cashu::Amount::from(0),
+            fees: cashu::Amount::from(0),
             direction,
             memo: None,
-            timestamp: 5,
+            tstamp: 5,
             unit: cashu::CurrencyUnit::Sat,
             ys: vec![],
             amount: cashu::Amount::from(42),
-            metadata: HashMap::from([(
-                TRANSACTION_STATUS_METADATA_KEY.to_owned(),
-                status.to_string(),
-            )]),
+            status,
+            payment_type: PaymentType::Token,
             quote_id: None,
-            payment_request: None,
-            payment_proof: None,
-            payment_method: None,
-            saga_id: None,
+            payment_request_id: None,
+            btc_tx_id: None,
+            nostr_event_id: None,
+            contact_node_id: None,
+            linked_txs: vec![],
         }
     }
 }

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -1,12 +1,10 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use bcr_common::cdk_common::wallet::TransactionId;
 use bcr_wallet_api::{AppState, config::CreateWalletConfig};
 use bcr_wallet_core::types::{
     PaymentRequestDirection, PaymentResultCallback, PendingPaymentSubscriptionCallback,
-    TransactionFilters, TransactionSort, get_btc_tx_id, get_contact_node_id,
-    get_payment_request_id, get_payment_type, get_transaction_status,
+    TransactionFilters, TransactionSort,
 };
 use chrono::{DateTime, Utc};
 use tokio::sync::oneshot;
@@ -90,19 +88,20 @@ pub async fn cmd_info(app_state: &AppState) -> Result<String> {
             push_break(&mut res);
 
             for tx in transactions.iter() {
-                let status = get_transaction_status(&tx.metadata);
-                let ptype = get_payment_type(&tx.metadata);
-                let btc_tx_id = get_btc_tx_id(&tx.metadata);
-                let contact = get_contact_node_id(&tx.metadata);
-                let payment_req_id = get_payment_request_id(&tx.metadata);
-                let quote_or_btc_tx_id = match (btc_tx_id, &tx.quote_id) {
+                let quote_or_btc_tx_id = match (tx.btc_tx_id, &tx.quote_id) {
                     (Some(txid), _) => txid.to_string(),
                     (None, Some(quote_id)) => quote_id.to_string(),
                     (None, None) => String::default(),
                 };
+                let tx_links = tx
+                    .linked_txs
+                    .iter()
+                    .map(|lnk| format!("{} - {}", lnk.reason, lnk.tx_id))
+                    .collect::<Vec<_>>()
+                    .join(", ");
                 res.push_str(&format!(
-                    "\t\tId: {} \t Amount: {:8} {} \t Fees: {}  \t Status: {:?} \t {} \tType: {:<10} \t {:?} \t Memo: {} \t BTC TxID/Quote ID: {} \t Contact: {} \t Payment Request ID: {}",
-                    tx.id(), tx.amount, tx.unit, tx.fee,  status, format_timestamp(tx.timestamp), format!("{:?}", ptype), tx.direction, tx.memo.clone().unwrap_or_default(), quote_or_btc_tx_id, contact.map(|n| n.to_string()).unwrap_or_default(), payment_req_id.map(|id| id.to_string()).unwrap_or_default()
+                    "\t\tId: {} \t Amount: {:8} {} \t Fees: {}  \t Status: {:?} \t {} \tType: {:<10} \t {:?} \t Memo: {} \t BTC TxID/Quote ID: {} \t Contact: {} \t Payment Request ID: {} \t Links: {}",
+                    tx.id, tx.amount, tx.unit, tx.fees,  tx.status, format_timestamp(tx.tstamp), format!("{:?}", tx.payment_type), tx.direction, tx.memo.clone().unwrap_or_default(), quote_or_btc_tx_id, tx.contact_node_id.as_ref().map(|n| n.to_string()).unwrap_or_default(), tx.payment_request_id.map(|id| id.to_string()).unwrap_or_default(), tx_links
                 ));
                 push_break(&mut res);
             }
@@ -217,7 +216,7 @@ pub async fn cmd_request_payment(
     //     tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     //     cancel_token_clone.cancel();
     // });
-    let (tx, rx) = oneshot::channel::<Option<TransactionId>>();
+    let (tx, rx) = oneshot::channel::<Option<Uuid>>();
 
     let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
 

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -1,14 +1,13 @@
 use bcr_common::{
-    cashu::{self, Amount, CurrencyUnit, KeySetInfo},
-    cdk_common::wallet::{Transaction, TransactionDirection, TransactionId},
+    cashu::{self, Amount, CurrencyUnit, KeySetInfo, MintUrl},
+    cdk_common::wallet::TransactionDirection,
     core::NodeId,
 };
 use bitcoin::{address::NetworkUnchecked, secp256k1};
 use chrono::{DateTime, Datelike, Utc};
-use nostr::RelayUrl;
+use nostr::{RelayUrl, event::EventId};
 use std::{
     collections::{BTreeMap, HashMap},
-    str::FromStr,
     sync::Arc,
 };
 use uuid::Uuid;
@@ -17,7 +16,7 @@ use crate::event::ContactPaymentRequestPayload;
 
 pub type Seed = [u8; 64];
 
-pub type PaymentResultCallback = Arc<dyn Fn(Option<TransactionId>) + Send + Sync + 'static>;
+pub type PaymentResultCallback = Arc<dyn Fn(Option<Uuid>) + Send + Sync + 'static>;
 pub type PendingPaymentSubscriptionCallback = Arc<dyn Fn(Uuid) + Send + Sync + 'static>;
 
 #[derive(Default, Debug, Clone)]
@@ -82,7 +81,7 @@ pub struct MintSummary {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PaymentRequestState {
     Pending,
-    Paid { tx_id: TransactionId },
+    Paid { tx_id: Uuid },
     Canceled,
     Rejected,
 }
@@ -164,6 +163,40 @@ impl From<ContactPaymentRequestPayload> for PaymentRequest {
     }
 }
 
+/// A transaction in our wallet
+#[derive(Debug, Clone)]
+pub struct Transaction {
+    pub id: Uuid,
+    pub mint_url: MintUrl,
+    pub ys: Vec<cashu::PublicKey>,
+    pub amount: cashu::Amount,
+    pub fees: cashu::Amount,
+    pub unit: CurrencyUnit,
+    pub tstamp: u64,
+    pub direction: TransactionDirection,
+    pub memo: Option<String>,
+    pub payment_type: PaymentType,
+    pub status: TransactionStatus,
+    pub btc_tx_id: Option<bitcoin::Txid>,
+    pub quote_id: Option<Uuid>,
+    pub nostr_event_id: Option<EventId>,
+    pub contact_node_id: Option<NodeId>,
+    pub payment_request_id: Option<Uuid>,
+    pub linked_txs: Vec<TransactionLink>,
+}
+
+/// A link to another transaction with a reason, e.g. linking a payment transaction with a reclaim of the payment
+#[derive(Debug, Clone)]
+pub struct TransactionLink {
+    pub tx_id: Uuid,
+    pub reason: TransactionLinkReason,
+}
+
+#[derive(strum::EnumString, strum::Display, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionLinkReason {
+    Reclaim,
+}
+
 #[derive(strum::EnumString, strum::Display, Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum PaymentType {
     #[default]
@@ -193,40 +226,6 @@ pub enum TransactionStatus {
     Pending,
     Settled,
     Canceled,
-}
-
-pub const TRANSACTION_STATUS_METADATA_KEY: &str = "transaction_status";
-pub fn get_transaction_status(metas: &HashMap<String, String>) -> TransactionStatus {
-    let Some(status) = metas.get(TRANSACTION_STATUS_METADATA_KEY) else {
-        return TransactionStatus::default();
-    };
-    TransactionStatus::from_str(status).unwrap_or_default()
-}
-
-pub const PAYMENT_TYPE_METADATA_KEY: &str = "payment_type";
-pub fn get_payment_type(metas: &HashMap<String, String>) -> PaymentType {
-    let Some(ptype) = metas.get(PAYMENT_TYPE_METADATA_KEY) else {
-        return PaymentType::NotApplicable;
-    };
-    PaymentType::from_str(ptype).unwrap_or(PaymentType::NotApplicable)
-}
-
-pub const BTC_TX_ID_TYPE_METADATA_KEY: &str = "btc_tx_id";
-pub fn get_btc_tx_id(metas: &HashMap<String, String>) -> Option<bitcoin::Txid> {
-    let tx_id = metas.get(BTC_TX_ID_TYPE_METADATA_KEY)?;
-    bitcoin::Txid::from_str(tx_id).ok()
-}
-
-pub const CONTACT_NODE_ID_METADATA_KEY: &str = "contact_node_id";
-pub fn get_contact_node_id(metas: &HashMap<String, String>) -> Option<NodeId> {
-    let node_id = metas.get(CONTACT_NODE_ID_METADATA_KEY)?;
-    NodeId::from_str(node_id).ok()
-}
-
-pub const PAYMENT_REQUEST_ID_METADATA_KEY: &str = "payment_request_id";
-pub fn get_payment_request_id(metas: &HashMap<String, String>) -> Option<Uuid> {
-    let id = metas.get(PAYMENT_REQUEST_ID_METADATA_KEY)?;
-    Uuid::from_str(id).ok()
 }
 
 impl std::convert::From<SendSummary> for PaymentSummary {
@@ -269,13 +268,13 @@ impl TransactionFilters {
     pub fn matches_tx(&self, tx: &Transaction) -> bool {
         if let Some(range) = self.time_range {
             if let Some(from) = range.from
-                && tx.timestamp < from
+                && tx.tstamp < from
             {
                 return false;
             }
 
             if let Some(to) = range.to
-                && tx.timestamp > to
+                && tx.tstamp > to
             {
                 return false;
             }
@@ -287,13 +286,11 @@ impl TransactionFilters {
             return false;
         }
 
-        let payment_type = get_payment_type(&tx.metadata);
-        if !self.payment_types.is_empty() && !self.payment_types.contains(&payment_type) {
+        if !self.payment_types.is_empty() && !self.payment_types.contains(&tx.payment_type) {
             return false;
         }
 
-        let status = get_transaction_status(&tx.metadata);
-        if !self.statuses.is_empty() && !self.statuses.contains(&status) {
+        if !self.statuses.is_empty() && !self.statuses.contains(&tx.status) {
             return false;
         }
 
@@ -315,22 +312,22 @@ pub struct TimeRange {
 pub enum TransactionCursor {
     TimeAsc {
         tstamp: u64,
-        id: TransactionId,
+        id: Uuid,
     },
 
     #[strum_discriminants(default)]
     TimeDesc {
         tstamp: u64,
-        id: TransactionId,
+        id: Uuid,
     },
 
     AmountAsc {
         amount: Amount,
-        id: TransactionId,
+        id: Uuid,
     },
     AmountDesc {
         amount: Amount,
-        id: TransactionId,
+        id: Uuid,
     },
 }
 
@@ -342,20 +339,20 @@ impl TransactionCursor {
     pub fn from_tx(tx: &Transaction, sort: TransactionSort) -> Self {
         match sort {
             TransactionSort::TimeAsc => Self::TimeAsc {
-                tstamp: tx.timestamp,
-                id: tx.id(),
+                tstamp: tx.tstamp,
+                id: tx.id,
             },
             TransactionSort::TimeDesc => Self::TimeDesc {
-                tstamp: tx.timestamp,
-                id: tx.id(),
+                tstamp: tx.tstamp,
+                id: tx.id,
             },
             TransactionSort::AmountAsc => Self::AmountAsc {
                 amount: tx.amount,
-                id: tx.id(),
+                id: tx.id,
             },
             TransactionSort::AmountDesc => Self::AmountDesc {
                 amount: tx.amount,
-                id: tx.id(),
+                id: tx.id,
             },
         }
     }
@@ -364,16 +361,16 @@ impl TransactionCursor {
     pub fn tx_is_after(&self, tx: &Transaction) -> bool {
         match self {
             Self::TimeAsc { tstamp, id } => {
-                tx.timestamp > *tstamp || (tx.timestamp == *tstamp && tx.id() > *id)
+                tx.tstamp > *tstamp || (tx.tstamp == *tstamp && tx.id > *id)
             }
             Self::TimeDesc { tstamp, id } => {
-                tx.timestamp < *tstamp || (tx.timestamp == *tstamp && tx.id() < *id)
+                tx.tstamp < *tstamp || (tx.tstamp == *tstamp && tx.id < *id)
             }
             Self::AmountAsc { amount, id } => {
-                tx.amount > *amount || (tx.amount == *amount && tx.id() > *id)
+                tx.amount > *amount || (tx.amount == *amount && tx.id > *id)
             }
             Self::AmountDesc { amount, id } => {
-                tx.amount < *amount || (tx.amount == *amount && tx.id() < *id)
+                tx.amount < *amount || (tx.amount == *amount && tx.id < *id)
             }
         }
     }
@@ -398,7 +395,7 @@ pub fn extract_fees_per_month(transactions: &[Transaction]) -> Vec<FeesByMonth> 
     let mut fees_by_month: BTreeMap<(i32, u32), Amount> = BTreeMap::new();
 
     for tx in transactions {
-        let Some(dt) = DateTime::<Utc>::from_timestamp(tx.timestamp as i64, 0) else {
+        let Some(dt) = DateTime::<Utc>::from_timestamp(tx.tstamp as i64, 0) else {
             continue;
         };
 
@@ -407,8 +404,8 @@ pub fn extract_fees_per_month(transactions: &[Transaction]) -> Vec<FeesByMonth> 
 
         fees_by_month
             .entry((year, month))
-            .and_modify(|fees| *fees += tx.fee)
-            .or_insert(tx.fee);
+            .and_modify(|fees| *fees += tx.fees)
+            .or_insert(tx.fees);
     }
 
     fees_by_month
@@ -420,6 +417,8 @@ pub fn extract_fees_per_month(transactions: &[Transaction]) -> Vec<FeesByMonth> 
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use chrono::{TimeZone, Utc};
 
@@ -431,20 +430,23 @@ mod tests {
 
     fn tx(timestamp: u64, fee: Amount) -> Transaction {
         Transaction {
+            id: Uuid::new_v4(),
             mint_url: cashu::MintUrl::from_str("https://mint.example").unwrap(),
             direction: TransactionDirection::Incoming,
             amount: Amount::from(0),
-            fee,
+            fees: fee,
             unit: CurrencyUnit::Sat,
             ys: vec![],
-            timestamp,
+            tstamp: timestamp,
             memo: None,
-            metadata: HashMap::new(),
             quote_id: None,
-            payment_request: None,
-            payment_proof: None,
-            payment_method: None,
-            saga_id: None,
+            payment_type: PaymentType::Token,
+            status: TransactionStatus::Pending,
+            payment_request_id: None,
+            btc_tx_id: None,
+            nostr_event_id: None,
+            contact_node_id: None,
+            linked_txs: vec![],
         }
     }
 

--- a/crates/bcr-wallet-ffi/Cargo.toml
+++ b/crates/bcr-wallet-ffi/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = {version = "1.21"}
 tokio = {workspace = true}
 tokio-util = {workspace = true}
 url = {workspace = true}
+uuid = {workspace = true}
 
 [lints.rust]
 unexpected_cfgs = {level = "warn", check-cfg = ['cfg(frb_expand)']}

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -1,17 +1,17 @@
 use bcr_wallet_core::types::{
     ListTransactionsResult, PaymentResultCallback, PendingPaymentSubscriptionCallback,
-    get_btc_tx_id, get_contact_node_id, get_payment_type, get_transaction_status,
 };
 use nostr::RelayUrl;
 use once_cell::sync::Lazy;
 use std::{collections::HashMap, panic, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
 
 #[cfg(target_os = "android")]
 use android_logger::FilterBuilder;
 use bcr_common::{
     cashu::{self},
-    cdk_common::{self, wallet::TransactionId},
+    cdk_common::{self},
 };
 use bcr_wallet_api::{
     AppState,
@@ -1298,7 +1298,7 @@ impl From<bcr_common::wire::common::ProtestStatus> for ProtestStatus {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PaymentRequestState {
     Pending,
-    Paid { tx_id: TransactionId },
+    Paid { tx_id: Uuid },
     Canceled,
     Rejected,
 }
@@ -1344,7 +1344,7 @@ impl From<PaymentRequestListState> for bcr_wallet_core::types::PaymentRequestSta
                 bcr_wallet_core::types::PaymentRequestState::Pending
             }
             PaymentRequestListState::Paid => bcr_wallet_core::types::PaymentRequestState::Paid {
-                tx_id: TransactionId::new(vec![]), // use default transactionid, since we're only interested in the type for listing
+                tx_id: Uuid::default(), // use default transactionid, since we're only interested in the type for listing
             },
             PaymentRequestListState::Canceled => {
                 bcr_wallet_core::types::PaymentRequestState::Canceled
@@ -1439,9 +1439,41 @@ pub struct Transaction {
     pub memo: Option<String>,
     pub ptype: PaymentType,
     pub status: TransactionStatus,
-    pub tx_id: Option<String>,
+    pub btc_tx_id: Option<String>,
     pub quote_id: Option<String>,
-    pub contact: Option<String>,
+    pub contact_node_id: Option<String>,
+    pub payment_request_id: Option<String>,
+    pub linked_txs: Vec<TransactionLink>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransactionLink {
+    pub tx_id: String,
+    pub reason: TransactionLinkReason,
+}
+
+impl From<bcr_wallet_core::types::TransactionLink> for TransactionLink {
+    fn from(value: bcr_wallet_core::types::TransactionLink) -> Self {
+        Self {
+            tx_id: value.tx_id.to_string(),
+            reason: value.reason.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionLinkReason {
+    Reclaim,
+}
+
+impl From<bcr_wallet_core::types::TransactionLinkReason> for TransactionLinkReason {
+    fn from(value: bcr_wallet_core::types::TransactionLinkReason) -> Self {
+        match value {
+            bcr_wallet_core::types::TransactionLinkReason::Reclaim => {
+                TransactionLinkReason::Reclaim
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1523,23 +1555,19 @@ impl TryFrom<TransactionCursor> for bcr_wallet_core::types::TransactionCursor {
         Ok(match value.sort {
             TransactionSort::TimeDesc => bcr_wallet_core::types::TransactionCursor::TimeDesc {
                 tstamp: value.tstamp.ok_or(BcrWalletError::InvalidCursor)?,
-                id: TransactionId::from_str(&value.id)
-                    .map_err(|_| BcrWalletError::InvalidTransactionId)?,
+                id: Uuid::from_str(&value.id).map_err(|_| BcrWalletError::InvalidTransactionId)?,
             },
             TransactionSort::TimeAsc => bcr_wallet_core::types::TransactionCursor::TimeAsc {
                 tstamp: value.tstamp.ok_or(BcrWalletError::InvalidCursor)?,
-                id: TransactionId::from_str(&value.id)
-                    .map_err(|_| BcrWalletError::InvalidTransactionId)?,
+                id: Uuid::from_str(&value.id).map_err(|_| BcrWalletError::InvalidTransactionId)?,
             },
             TransactionSort::AmountDesc => bcr_wallet_core::types::TransactionCursor::AmountDesc {
                 amount: cashu::Amount::from(value.amount.ok_or(BcrWalletError::InvalidCursor)?),
-                id: TransactionId::from_str(&value.id)
-                    .map_err(|_| BcrWalletError::InvalidTransactionId)?,
+                id: Uuid::from_str(&value.id).map_err(|_| BcrWalletError::InvalidTransactionId)?,
             },
             TransactionSort::AmountAsc => bcr_wallet_core::types::TransactionCursor::AmountAsc {
                 amount: cashu::Amount::from(value.amount.ok_or(BcrWalletError::InvalidCursor)?),
-                id: TransactionId::from_str(&value.id)
-                    .map_err(|_| BcrWalletError::InvalidTransactionId)?,
+                id: Uuid::from_str(&value.id).map_err(|_| BcrWalletError::InvalidTransactionId)?,
             },
         })
     }
@@ -1601,25 +1629,27 @@ impl From<bcr_wallet_core::types::FeesByMonth> for FeesByMonth {
     }
 }
 
-impl std::convert::From<cdk_common::wallet::Transaction> for Transaction {
-    fn from(tx: cdk_common::wallet::Transaction) -> Self {
-        let status = get_transaction_status(&tx.metadata);
-        let ptype = get_payment_type(&tx.metadata);
-        let tx_id = get_btc_tx_id(&tx.metadata).map(|txid| txid.to_string());
-        let contact = get_contact_node_id(&tx.metadata).map(|node_id| node_id.to_string());
+impl From<bcr_wallet_core::types::Transaction> for Transaction {
+    fn from(value: bcr_wallet_core::types::Transaction) -> Self {
         Self {
-            id: tx.id().to_string(),
-            amount: u64::from(tx.amount),
-            fees: u64::from(tx.fee),
-            unit: tx.unit.to_string(),
-            direction: TransactionDirection::from(tx.direction),
-            tstamp: tx.timestamp,
-            memo: tx.memo,
-            ptype: ptype.into(),
-            status: status.into(),
-            tx_id,
-            quote_id: tx.quote_id,
-            contact,
+            id: value.id.to_string(),
+            amount: u64::from(value.amount),
+            fees: u64::from(value.fees),
+            unit: value.unit.to_string(),
+            tstamp: value.tstamp,
+            direction: TransactionDirection::from(value.direction),
+            memo: value.memo,
+            ptype: value.payment_type.into(),
+            status: value.status.into(),
+            btc_tx_id: value.btc_tx_id.map(|tx_id| tx_id.to_string()),
+            quote_id: value.quote_id.map(|q_id| q_id.to_string()),
+            contact_node_id: value.contact_node_id.map(|node_id| node_id.to_string()),
+            payment_request_id: value.payment_request_id.map(|pr_id| pr_id.to_string()),
+            linked_txs: value
+                .linked_txs
+                .into_iter()
+                .map(|linked_tx| linked_tx.into())
+                .collect(),
         }
     }
 }

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -2832,6 +2832,18 @@ impl SseDecode for Vec<crate::api::Transaction> {
     }
 }
 
+impl SseDecode for Vec<crate::api::TransactionLink> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::TransactionLink>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::api::TransactionStatus> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3149,9 +3161,11 @@ impl SseDecode for crate::api::Transaction {
         let mut var_memo = <Option<String>>::sse_decode(deserializer);
         let mut var_ptype = <crate::api::PaymentType>::sse_decode(deserializer);
         let mut var_status = <crate::api::TransactionStatus>::sse_decode(deserializer);
-        let mut var_txId = <Option<String>>::sse_decode(deserializer);
+        let mut var_btcTxId = <Option<String>>::sse_decode(deserializer);
         let mut var_quoteId = <Option<String>>::sse_decode(deserializer);
-        let mut var_contact = <Option<String>>::sse_decode(deserializer);
+        let mut var_contactNodeId = <Option<String>>::sse_decode(deserializer);
+        let mut var_paymentRequestId = <Option<String>>::sse_decode(deserializer);
+        let mut var_linkedTxs = <Vec<crate::api::TransactionLink>>::sse_decode(deserializer);
         return crate::api::Transaction {
             id: var_id,
             amount: var_amount,
@@ -3162,9 +3176,11 @@ impl SseDecode for crate::api::Transaction {
             memo: var_memo,
             ptype: var_ptype,
             status: var_status,
-            tx_id: var_txId,
+            btc_tx_id: var_btcTxId,
             quote_id: var_quoteId,
-            contact: var_contact,
+            contact_node_id: var_contactNodeId,
+            payment_request_id: var_paymentRequestId,
+            linked_txs: var_linkedTxs,
         };
     }
 }
@@ -3210,6 +3226,29 @@ impl SseDecode for crate::api::TransactionFilters {
             statuses: var_statuses,
             direction: var_direction,
             time_range: var_timeRange,
+        };
+    }
+}
+
+impl SseDecode for crate::api::TransactionLink {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_txId = <String>::sse_decode(deserializer);
+        let mut var_reason = <crate::api::TransactionLinkReason>::sse_decode(deserializer);
+        return crate::api::TransactionLink {
+            tx_id: var_txId,
+            reason: var_reason,
+        };
+    }
+}
+
+impl SseDecode for crate::api::TransactionLinkReason {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => crate::api::TransactionLinkReason::Reclaim,
+            _ => unreachable!("Invalid variant for TransactionLinkReason: {}", inner),
         };
     }
 }
@@ -4796,9 +4835,11 @@ impl flutter_rust_bridge::IntoDart for crate::api::Transaction {
             self.memo.into_into_dart().into_dart(),
             self.ptype.into_into_dart().into_dart(),
             self.status.into_into_dart().into_dart(),
-            self.tx_id.into_into_dart().into_dart(),
+            self.btc_tx_id.into_into_dart().into_dart(),
             self.quote_id.into_into_dart().into_dart(),
-            self.contact.into_into_dart().into_dart(),
+            self.contact_node_id.into_into_dart().into_dart(),
+            self.payment_request_id.into_into_dart().into_dart(),
+            self.linked_txs.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -4870,6 +4911,44 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::TransactionFilters>
     for crate::api::TransactionFilters
 {
     fn into_into_dart(self) -> crate::api::TransactionFilters {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::TransactionLink {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.tx_id.into_into_dart().into_dart(),
+            self.reason.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::TransactionLink {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::TransactionLink>
+    for crate::api::TransactionLink
+{
+    fn into_into_dart(self) -> crate::api::TransactionLink {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::TransactionLinkReason {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::Reclaim => 0.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::TransactionLinkReason
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::TransactionLinkReason>
+    for crate::api::TransactionLinkReason
+{
+    fn into_into_dart(self) -> crate::api::TransactionLinkReason {
         self
     }
 }
@@ -6645,6 +6724,16 @@ impl SseEncode for Vec<crate::api::Transaction> {
     }
 }
 
+impl SseEncode for Vec<crate::api::TransactionLink> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::TransactionLink>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::api::TransactionStatus> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -6914,9 +7003,11 @@ impl SseEncode for crate::api::Transaction {
         <Option<String>>::sse_encode(self.memo, serializer);
         <crate::api::PaymentType>::sse_encode(self.ptype, serializer);
         <crate::api::TransactionStatus>::sse_encode(self.status, serializer);
-        <Option<String>>::sse_encode(self.tx_id, serializer);
+        <Option<String>>::sse_encode(self.btc_tx_id, serializer);
         <Option<String>>::sse_encode(self.quote_id, serializer);
-        <Option<String>>::sse_encode(self.contact, serializer);
+        <Option<String>>::sse_encode(self.contact_node_id, serializer);
+        <Option<String>>::sse_encode(self.payment_request_id, serializer);
+        <Vec<crate::api::TransactionLink>>::sse_encode(self.linked_txs, serializer);
     }
 }
 
@@ -6953,6 +7044,29 @@ impl SseEncode for crate::api::TransactionFilters {
         <Vec<crate::api::TransactionStatus>>::sse_encode(self.statuses, serializer);
         <Option<crate::api::TransactionDirection>>::sse_encode(self.direction, serializer);
         <Option<crate::api::TimeRange>>::sse_encode(self.time_range, serializer);
+    }
+}
+
+impl SseEncode for crate::api::TransactionLink {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.tx_id, serializer);
+        <crate::api::TransactionLinkReason>::sse_encode(self.reason, serializer);
+    }
+}
+
+impl SseEncode for crate::api::TransactionLinkReason {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                crate::api::TransactionLinkReason::Reclaim => 0,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
     }
 }
 

--- a/crates/bcr-wallet-persistence/src/error.rs
+++ b/crates/bcr-wallet-persistence/src/error.rs
@@ -3,6 +3,7 @@ use bcr_common::{
     cdk_common,
 };
 use thiserror::Error;
+use uuid::Uuid;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -37,7 +38,9 @@ pub enum Error {
     #[error("wallet id {0} not found")]
     WalletIdNotFound(String),
     #[error("transaction not found {0}")]
-    TransactionNotFound(cdk_common::wallet::TransactionId),
+    TransactionNotFound(Uuid),
+    #[error("transaction not found for ys {0}")]
+    TransactionNotFoundForYs(cdk_common::wallet::TransactionId),
     #[error("proof not in desired state: {0}")]
     InvalidProofState(cashu::PublicKey),
     #[error("proof in local DB not found: {0}")]
@@ -64,4 +67,12 @@ pub enum Error {
     PaymentRequestNotFound(String),
     #[error("Counter Exhausted")]
     CounterExhausted,
+    #[error("Invalid Btc Tx Id {0}")]
+    InvalidBtcTxId(String),
+    #[error("Invalid Nostr Event Id {0}")]
+    InvalidNostrEventId(String),
+    #[error("Invalid Transaction Id {0}")]
+    InvalidTransactionId(String),
+    #[error("Invalid Quote Id {0}")]
+    InvalidQuoteId(String),
 }

--- a/crates/bcr-wallet-persistence/src/lib.rs
+++ b/crates/bcr-wallet-persistence/src/lib.rs
@@ -7,11 +7,13 @@ pub mod test_utils;
 use crate::error::Result;
 use async_trait::async_trait;
 use bcr_common::cashu::{self, nut00 as cdk00, nut01 as cdk01, nut07 as cdk07};
-use bcr_common::cdk_common::wallet::{Transaction, TransactionId};
 use bcr_common::core::NodeId;
 use bcr_wallet_core::contact::Contact;
 use bcr_wallet_core::name::Name;
-use bcr_wallet_core::types::{PaymentRequestDirection, PaymentRequestState};
+use bcr_wallet_core::types::{
+    PaymentRequestDirection, PaymentRequestState, Transaction, TransactionLinkReason,
+    TransactionStatus,
+};
 use bcr_wallet_core::{
     SendSync,
     types::{PaymentRequest, WalletConfig},
@@ -95,24 +97,22 @@ pub trait PurseRepository: SendSync {
 #[cfg_attr(any(test, feature = "test-utils"), mockall::automock)]
 #[async_trait]
 pub trait TransactionRepository: SendSync {
-    async fn store_tx(&self, tx: Transaction) -> Result<TransactionId>;
-    async fn load_tx(&self, tx_id: TransactionId) -> Result<Transaction>;
-    #[allow(dead_code)]
-    async fn delete_tx(&self, tx_id: TransactionId) -> Result<()>;
-    async fn list_tx_ids(&self) -> Result<Vec<TransactionId>>;
+    async fn store_tx(&self, tx: Transaction) -> Result<Uuid>;
+    async fn load_tx(&self, tx_id: Uuid) -> Result<Transaction>;
+    async fn list_tx_ids(&self) -> Result<Vec<Uuid>>;
     async fn list_txs(&self) -> Result<Vec<Transaction>>;
-    async fn update_metadata(
+    async fn update_status(
         &self,
-        tx_id: TransactionId,
-        key: String,
-        value: String,
-    ) -> Result<Option<String>>;
-    async fn update_memo(
+        tx_id: Uuid,
+        status: TransactionStatus,
+    ) -> Result<Option<TransactionStatus>>;
+    async fn update_memo(&self, tx_id: Uuid, new_memo: Option<String>) -> Result<Option<String>>;
+    async fn link_txs(
         &self,
-        tx_id: TransactionId,
-        new_memo: Option<String>,
-    ) -> Result<Option<String>>;
-    async fn update_fee(&self, tx_id: TransactionId, fee_to_add: cashu::Amount) -> Result<()>;
+        tx_id_1: Uuid,
+        tx_id_2: Uuid,
+        reason: TransactionLinkReason,
+    ) -> Result<()>;
     async fn delete_repo(&self) -> Result<()>;
 }
 

--- a/crates/bcr-wallet-persistence/src/redb/migration/migration_0003.rs
+++ b/crates/bcr-wallet-persistence/src/redb/migration/migration_0003.rs
@@ -1,0 +1,436 @@
+use crate::{
+    error::{Error, Result},
+    redb::{migration::WalletStorageNamespace, transaction::StoredTransaction},
+};
+use bcr_common::{
+    cashu::{CurrencyUnit, MintUrl, nut01 as cdk01},
+    cdk_common::wallet::TransactionDirection,
+    core::NodeId,
+};
+use bcr_wallet_core::types::{PaymentType, Transaction, TransactionStatus};
+use nostr::event::EventId;
+use redb::{ReadableTable, TableDefinition};
+use std::{collections::HashMap, str::FromStr};
+use uuid::Uuid;
+
+///////////////////////////////////////////////////////////////// MIGRATION 0003
+const MIGRATION_0003_TX_REWORK: &str = "0003_tx_rework";
+
+pub(super) fn migration_name_for_wallet(wallet_id: &str) -> String {
+    format!("{}_{}", MIGRATION_0003_TX_REWORK, wallet_id)
+}
+
+pub(super) fn migration_0003_tx_rework(
+    txn: &redb::WriteTransaction,
+    namespace: &WalletStorageNamespace,
+) -> Result<()> {
+    tracing::info!("Migrating transactions..");
+    migrate_transactions_to_envelope_and_new_data_model(txn, &namespace.transaction_table)?;
+    tracing::info!("Migrated transactions.");
+
+    Ok(())
+}
+
+// Fetch old transactions
+// put in V1 envelope and new data model
+// Delete old transactions because of the id change
+// Store new transactions
+fn migrate_transactions_to_envelope_and_new_data_model(
+    txn: &redb::WriteTransaction,
+    table_name: &str,
+) -> Result<()> {
+    let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+
+    let mut table = match txn.open_table(table_def) {
+        Ok(table) => table,
+        Err(redb::TableError::TableDoesNotExist(_)) => {
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut old_keys = Vec::new();
+    let mut migrated_transactions: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    for item in table.iter()? {
+        // discard old ID
+        let (k, v) = item?;
+        let old_key = k.value().to_vec();
+
+        let old_tx: TransactionEntry = ciborium::from_reader(v.value().as_slice())?;
+        let new_tx: Transaction = old_tx.try_into()?;
+        let new_tx_id = new_tx.id;
+        let stored_tx_v1 = StoredTransaction::V1(new_tx.into());
+
+        let migrated_tx_bytes =
+            borsh::to_vec(&stored_tx_v1).map_err(|e| Error::BorshSerialization(e.to_string()))?;
+
+        old_keys.push(old_key);
+        migrated_transactions.push((new_tx_id.as_bytes().to_vec(), migrated_tx_bytes));
+    }
+
+    // Remove legacy entries before adding new ones
+    for old_key in &old_keys {
+        table.remove(old_key.as_slice())?;
+    }
+
+    // Add new entries
+    for (id, new_transaction) in migrated_transactions.iter() {
+        table.insert(id.as_slice(), new_transaction)?;
+    }
+
+    Ok(())
+}
+
+///////////////////////////////////////////// TransactionEntry
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+struct TransactionEntry {
+    pub tx_id: String,
+    pub mint_url: MintUrl,
+    pub direction: TransactionDirection,
+    pub amount: bcr_common::cashu::Amount,
+    pub fee: bcr_common::cashu::Amount,
+    pub unit: CurrencyUnit,
+    pub ys: Vec<cdk01::PublicKey>,
+    pub timestamp: u64,
+    pub memo: Option<String>,
+    pub metadata: HashMap<String, String>,
+    pub quote_id: Option<String>,
+}
+
+impl TryFrom<TransactionEntry> for Transaction {
+    type Error = Error;
+
+    fn try_from(entry: TransactionEntry) -> Result<Self> {
+        Ok(Transaction {
+            id: Uuid::new_v4(),
+            mint_url: entry.mint_url,
+            direction: entry.direction,
+            amount: entry.amount,
+            fees: entry.fee,
+            unit: entry.unit,
+            ys: entry.ys,
+            tstamp: entry.timestamp,
+            memo: entry.memo,
+            status: get_transaction_status(&entry.metadata),
+            payment_type: get_payment_type(&entry.metadata),
+            quote_id: entry
+                .quote_id
+                .map(|qid| Uuid::from_str(&qid))
+                .transpose()
+                .map_err(|e| Error::InvalidQuoteId(e.to_string()))?,
+            payment_request_id: get_payment_request_id(&entry.metadata),
+            nostr_event_id: get_nostr_event_id(&entry.metadata),
+            contact_node_id: get_contact_node_id(&entry.metadata),
+            btc_tx_id: get_btc_tx_id(&entry.metadata),
+            linked_txs: vec![],
+        })
+    }
+}
+
+pub const TRANSACTION_STATUS_METADATA_KEY: &str = "transaction_status";
+pub fn get_transaction_status(metas: &HashMap<String, String>) -> TransactionStatus {
+    let Some(status) = metas.get(TRANSACTION_STATUS_METADATA_KEY) else {
+        return TransactionStatus::default();
+    };
+    TransactionStatus::from_str(status).unwrap_or_default()
+}
+
+pub const PAYMENT_TYPE_METADATA_KEY: &str = "payment_type";
+pub fn get_payment_type(metas: &HashMap<String, String>) -> PaymentType {
+    let Some(ptype) = metas.get(PAYMENT_TYPE_METADATA_KEY) else {
+        return PaymentType::NotApplicable;
+    };
+    PaymentType::from_str(ptype).unwrap_or(PaymentType::NotApplicable)
+}
+
+pub const BTC_TX_ID_TYPE_METADATA_KEY: &str = "btc_tx_id";
+pub fn get_btc_tx_id(metas: &HashMap<String, String>) -> Option<bitcoin::Txid> {
+    let tx_id = metas.get(BTC_TX_ID_TYPE_METADATA_KEY)?;
+    bitcoin::Txid::from_str(tx_id).ok()
+}
+
+pub const CONTACT_NODE_ID_METADATA_KEY: &str = "contact_node_id";
+pub fn get_contact_node_id(metas: &HashMap<String, String>) -> Option<NodeId> {
+    let node_id = metas.get(CONTACT_NODE_ID_METADATA_KEY)?;
+    NodeId::from_str(node_id).ok()
+}
+
+pub const PAYMENT_REQUEST_ID_METADATA_KEY: &str = "payment_request_id";
+pub fn get_payment_request_id(metas: &HashMap<String, String>) -> Option<Uuid> {
+    let id = metas.get(PAYMENT_REQUEST_ID_METADATA_KEY)?;
+    Uuid::from_str(id).ok()
+}
+
+pub const NOSTR_EVENT_ID_METADATA_KEY: &str = "nostr_event_id";
+pub fn get_nostr_event_id(metas: &HashMap<String, String>) -> Option<EventId> {
+    let id = metas
+        .get(NOSTR_EVENT_ID_METADATA_KEY)
+        .or_else(|| metas.get("nostr::event_id"))?;
+    EventId::from_str(id).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{redb::transaction::StoredTransactionPayloadV1, test_utils::tests::test_pub_key};
+    use bcr_common::cashu::Amount;
+    use redb::{
+        Builder, Database, ReadableDatabase, ReadableTable, TableDefinition,
+        backends::InMemoryBackend,
+    };
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    };
+
+    fn test_database() -> Arc<Database> {
+        let backend = InMemoryBackend::new();
+        Arc::new(
+            Builder::new()
+                .create_with_backend(backend)
+                .expect("create in-memory database"),
+        )
+    }
+
+    fn legacy_transaction(
+        metadata: HashMap<String, String>,
+        quote_id: Option<String>,
+    ) -> TransactionEntry {
+        TransactionEntry {
+            tx_id: "legacy-id-that-is-discarded".to_string(),
+            mint_url: MintUrl::from_str("https://example.com").expect("valid mint URL"),
+            direction: TransactionDirection::Outgoing,
+            amount: Amount::from(42_u64),
+            fee: Amount::from(2_u64),
+            unit: CurrencyUnit::Sat,
+            ys: vec![cdk01::PublicKey::from(test_pub_key())],
+            timestamp: 1_750_000_000,
+            memo: Some("legacy transaction".to_string()),
+            metadata,
+            quote_id,
+        }
+    }
+
+    fn insert_legacy_transaction(
+        db: &Arc<Database>,
+        table_name: &str,
+        database_key: &[u8],
+        transaction: &TransactionEntry,
+    ) {
+        let mut encoded = Vec::new();
+        ciborium::into_writer(transaction, &mut encoded).expect("serialize legacy transaction");
+        let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+        let write_txn = db.begin_write().expect("begin write transaction");
+
+        {
+            let mut table = write_txn
+                .open_table(table_def)
+                .expect("open legacy transaction table");
+            table
+                .insert(database_key, encoded)
+                .expect("insert legacy transaction");
+        }
+        write_txn.commit().expect("commit legacy transaction");
+    }
+
+    fn run_migration(db: &Arc<Database>, table_name: &str) {
+        let write_txn = db.begin_write().expect("begin write transaction");
+        migrate_transactions_to_envelope_and_new_data_model(&write_txn, table_name)
+            .expect("migrate transactions");
+        write_txn.commit().expect("commit migration");
+    }
+
+    fn load_migrated_transactions(
+        db: &Arc<Database>,
+        table_name: &str,
+    ) -> Vec<(Vec<u8>, StoredTransactionPayloadV1)> {
+        let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+        let read_txn = db.begin_read().expect("begin read transaction");
+        let table = read_txn
+            .open_table(table_def)
+            .expect("open migrated transaction table");
+        let mut transactions = Vec::new();
+        for item in table.iter().expect("iterate transaction table") {
+            let (key, value) = item.expect("read transaction entry");
+            let envelope: StoredTransaction = borsh::from_slice(value.value().as_slice())
+                .expect("deserialize transaction envelope");
+            let StoredTransaction::V1(payload) = envelope;
+            transactions.push((key.value().to_vec(), payload));
+        }
+        transactions
+    }
+
+    fn assert_key_matches_payload_id(database_key: &[u8], payload: &StoredTransactionPayloadV1) {
+        let key_id = Uuid::from_slice(database_key).expect("database key is a UUID");
+        assert_eq!(key_id, payload.id);
+        assert_eq!(database_key, payload.id.as_bytes());
+    }
+
+    fn assert_key_is_missing(db: &Arc<Database>, table_name: &str, database_key: &[u8]) {
+        let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+        let read_txn = db.begin_read().expect("begin read transaction");
+        let table = read_txn
+            .open_table(table_def)
+            .expect("open transaction table");
+        assert!(
+            table
+                .get(database_key)
+                .expect("read transaction table")
+                .is_none(),
+            "legacy database key should have been removed"
+        );
+    }
+
+    #[test]
+    fn migration_succeeds_when_transaction_table_does_not_exist() {
+        let db = test_database();
+        let write_txn = db.begin_write().expect("begin write transaction");
+        migrate_transactions_to_envelope_and_new_data_model(&write_txn, "missing-transactions")
+            .expect("migration succeeds for missing table");
+        write_txn.commit().expect("commit migration");
+    }
+
+    #[test]
+    fn migration_replaces_legacy_key_with_new_transaction_id() {
+        let db = test_database();
+        let table_name = "transactions-key-replacement";
+        let legacy_key = b"legacy-database-key";
+
+        let legacy = legacy_transaction(HashMap::new(), None);
+        insert_legacy_transaction(&db, table_name, legacy_key, &legacy);
+
+        run_migration(&db, table_name);
+        assert_key_is_missing(&db, table_name, legacy_key);
+
+        let migrated = load_migrated_transactions(&db, table_name);
+        assert_eq!(migrated.len(), 1);
+
+        let (new_key, payload) = &migrated[0];
+        assert_ne!(new_key.as_slice(), legacy_key);
+        assert_key_matches_payload_id(new_key, payload);
+
+        assert_ne!(
+            payload.id.to_string(),
+            legacy.tx_id,
+            "legacy transaction ID must be discarded"
+        );
+    }
+
+    #[test]
+    fn migration_converts_legacy_transaction_to_v1_envelope() {
+        let db = test_database();
+        let table_name = "transactions-field-conversion";
+        let legacy_key = b"legacy-transaction-key";
+
+        let quote_id = Uuid::new_v4();
+        let payment_request_id = Uuid::new_v4();
+
+        let btc_tx_id = "11".repeat(32);
+        let nostr_event_id = "22".repeat(32);
+
+        let metadata = HashMap::from([
+            (
+                TRANSACTION_STATUS_METADATA_KEY.to_string(),
+                TransactionStatus::Settled.to_string(),
+            ),
+            (
+                PAYMENT_TYPE_METADATA_KEY.to_string(),
+                PaymentType::Token.to_string(),
+            ),
+            (BTC_TX_ID_TYPE_METADATA_KEY.to_string(), btc_tx_id.clone()),
+            (
+                PAYMENT_REQUEST_ID_METADATA_KEY.to_string(),
+                payment_request_id.to_string(),
+            ),
+            (
+                NOSTR_EVENT_ID_METADATA_KEY.to_string(),
+                nostr_event_id.clone(),
+            ),
+        ]);
+
+        let legacy = legacy_transaction(metadata, Some(quote_id.to_string()));
+
+        insert_legacy_transaction(&db, table_name, legacy_key, &legacy);
+        run_migration(&db, table_name);
+        assert_key_is_missing(&db, table_name, legacy_key);
+
+        let migrated = load_migrated_transactions(&db, table_name);
+        assert_eq!(migrated.len(), 1);
+
+        let (new_key, payload) = &migrated[0];
+        assert_key_matches_payload_id(new_key, payload);
+        assert_eq!(payload.mint_url, legacy.mint_url);
+        assert_eq!(payload.direction, legacy.direction);
+        assert_eq!(payload.amount, legacy.amount);
+        assert_eq!(payload.fees, legacy.fee);
+        assert_eq!(payload.unit, legacy.unit);
+        assert_eq!(payload.ys, legacy.ys);
+        assert_eq!(payload.tstamp, legacy.timestamp);
+        assert_eq!(payload.memo, legacy.memo);
+        assert_eq!(payload.status, TransactionStatus::Settled);
+        assert_eq!(payload.payment_type, PaymentType::Token);
+        assert_eq!(payload.quote_id, Some(quote_id));
+        assert_eq!(payload.payment_request_id, Some(payment_request_id));
+        assert_eq!(payload.btc_tx_id.as_deref(), Some(btc_tx_id.as_str()));
+        assert_eq!(
+            payload.nostr_event_id.as_deref(),
+            Some(nostr_event_id.as_str())
+        );
+        assert_eq!(payload.contact_node_id, None);
+        assert!(payload.linked_txs.is_empty());
+    }
+
+    #[test]
+    fn migration_replaces_multiple_legacy_entries() {
+        let db = test_database();
+        let table_name = "multiple-transactions";
+
+        let first_key = b"first-legacy-key";
+        let second_key = b"second-legacy-key";
+        let third_key = b"third-legacy-key";
+
+        let mut first = legacy_transaction(HashMap::new(), None);
+        first.amount = Amount::from(1_u64);
+        first.memo = Some("first".to_string());
+
+        let mut second = legacy_transaction(HashMap::new(), None);
+        second.amount = Amount::from(20_u64);
+        second.memo = Some("second".to_string());
+
+        let mut third = legacy_transaction(HashMap::new(), None);
+        third.amount = Amount::from(u64::MAX);
+        third.memo = Some("third".to_string());
+
+        insert_legacy_transaction(&db, table_name, first_key, &first);
+        insert_legacy_transaction(&db, table_name, second_key, &second);
+        insert_legacy_transaction(&db, table_name, third_key, &third);
+
+        run_migration(&db, table_name);
+
+        assert_key_is_missing(&db, table_name, first_key);
+        assert_key_is_missing(&db, table_name, second_key);
+        assert_key_is_missing(&db, table_name, third_key);
+
+        let migrated = load_migrated_transactions(&db, table_name);
+        assert_eq!(migrated.len(), 3);
+
+        let mut migrated_ids = HashSet::new();
+        let mut migrated_memos = HashSet::new();
+        for (database_key, payload) in &migrated {
+            assert_key_matches_payload_id(database_key, payload);
+            assert!(
+                migrated_ids.insert(payload.id),
+                "each migrated transaction must receive a unique ID"
+            );
+            migrated_memos.insert(payload.memo.clone());
+        }
+        assert_eq!(
+            migrated_memos,
+            HashSet::from([
+                Some("first".to_string()),
+                Some("second".to_string()),
+                Some("third".to_string()),
+            ])
+        );
+    }
+}

--- a/crates/bcr-wallet-persistence/src/redb/migration/mod.rs
+++ b/crates/bcr-wallet-persistence/src/redb/migration/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{Error, Result},
-    redb::pocket::PocketDB,
+    redb::{pocket::PocketDB, transaction::TransactionDB},
 };
 use bcr_common::cashu::CurrencyUnit;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 mod migration_0001;
 mod migration_0002;
+mod migration_0003;
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct AppliedMigration {
@@ -71,6 +72,18 @@ fn migrate_wallet_sync(db: Arc<Database>, namespace: WalletStorageNamespace) -> 
         tracing::info!("Applied Migration 0001 for wallet {}", &namespace.wallet_id);
     }
 
+    let migration_0003_id_for_wallet =
+        migration_0003::migration_name_for_wallet(&namespace.wallet_id);
+    if !applied.contains(&migration_0003_id_for_wallet) {
+        tracing::info!(
+            "Applying Migration 0003 for wallet {}",
+            &namespace.wallet_id
+        );
+        migration_0003::migration_0003_tx_rework(&write_txn, &namespace)?;
+        mark_migration_applied(&write_txn, &migration_0003_id_for_wallet)?;
+        tracing::info!("Applied Migration 0003 for wallet {}", &namespace.wallet_id);
+    }
+
     write_txn.commit()?;
     tracing::info!(
         "Finished DB migrations for wallet {}.",
@@ -86,6 +99,7 @@ pub struct WalletStorageNamespace {
     proof_table: String,
     counter_table: String,
     commitment_table: String,
+    transaction_table: String,
     keys: bitcoin::secp256k1::Keypair,
 }
 
@@ -99,6 +113,7 @@ pub fn collect_wallet_namespace(
         proof_table: PocketDB::proof_table_name(&wallet_id, &unit),
         counter_table: PocketDB::counter_table_name(&wallet_id, &unit),
         commitment_table: PocketDB::commitment_table_name(&wallet_id, &unit),
+        transaction_table: TransactionDB::transaction_table_name(&wallet_id),
         keys,
     }
 }

--- a/crates/bcr-wallet-persistence/src/redb/payment_request.rs
+++ b/crates/bcr-wallet-persistence/src/redb/payment_request.rs
@@ -5,7 +5,6 @@ use crate::{
 use async_trait::async_trait;
 use bcr_common::{
     cashu::{Amount, CurrencyUnit},
-    cdk_common::wallet::TransactionId,
     core::NodeId,
 };
 use bcr_wallet_core::types::{PaymentRequest, PaymentRequestDirection, PaymentRequestState};
@@ -41,7 +40,7 @@ impl From<PaymentRequestEntryDirection> for PaymentRequestDirection {
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum PaymentRequestEntryState {
     Pending,
-    Paid { tx_id: TransactionId },
+    Paid { tx_id: Uuid },
     Canceled,
     Rejected,
 }
@@ -332,10 +331,7 @@ mod tests {
     use crate::{PaymentRequestStoreApi, error::Error, test_utils::tests::wallet_id};
 
     use super::*;
-    use bcr_common::{
-        cashu::{Amount, CurrencyUnit},
-        cdk_common::wallet::TransactionId,
-    };
+    use bcr_common::cashu::{Amount, CurrencyUnit};
     use bcr_wallet_core::types::{PaymentRequest, PaymentRequestDirection, PaymentRequestState};
     use chrono::Utc;
     use redb::{Builder, backends::InMemoryBackend};
@@ -536,7 +532,7 @@ mod tests {
 
         repo.add_payment_request(payment_request).await.unwrap();
 
-        let tx_id = TransactionId::new(vec![]);
+        let tx_id = Uuid::new_v4();
         repo.set_payment_request_state(id, PaymentRequestState::Paid { tx_id })
             .await
             .expect("set_payment_request_state works");

--- a/crates/bcr-wallet-persistence/src/redb/transaction.rs
+++ b/crates/bcr-wallet-persistence/src/redb/transaction.rs
@@ -1,63 +1,182 @@
 use crate::error::Error;
 use crate::{TransactionRepository, error::Result};
 use async_trait::async_trait;
-use bcr_common::cashu::{CurrencyUnit, MintUrl, nut01 as cdk01};
-use bcr_common::cdk_common::wallet::{Transaction, TransactionDirection, TransactionId};
+use bcr_common::cashu::{self, CurrencyUnit, MintUrl};
+use bcr_common::cdk_common::wallet::TransactionDirection;
+use bcr_common::core::NodeId;
+use bcr_common::wire::borsh::{
+    deserialize_cashu_amount, deserialize_from_str, deserialize_vec_of_strs, serialize_as_str,
+    serialize_cashu_amount, serialize_vec_of_strs,
+};
+use bcr_wallet_core::types::{PaymentType, Transaction, TransactionStatus};
+use borsh::{BorshDeserialize, BorshSerialize};
+use nostr::event::EventId;
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, TableError};
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 use tokio::task::spawn_blocking;
+use uuid::Uuid;
 
-///////////////////////////////////////////// TransactionEntry
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
-struct TransactionEntry {
-    pub tx_id: String,
-    pub mint_url: MintUrl,
-    pub direction: TransactionDirection,
-    pub amount: bcr_common::cashu::Amount,
-    pub fee: bcr_common::cashu::Amount,
-    pub unit: CurrencyUnit,
-    pub ys: Vec<cdk01::PublicKey>,
-    pub timestamp: u64,
-    pub memo: Option<String>,
-    pub metadata: HashMap<String, String>,
-    pub quote_id: Option<String>,
+/// StoredTransaction is a versioned, borsh-serialized transaction
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) enum StoredTransaction {
+    V1(StoredTransactionPayloadV1),
 }
 
-impl std::convert::From<Transaction> for TransactionEntry {
-    fn from(tx: Transaction) -> Self {
-        let tx_id = TransactionId::new(tx.ys.clone());
-        TransactionEntry {
-            tx_id: tx_id.to_string(),
-            mint_url: tx.mint_url,
-            direction: tx.direction,
-            amount: tx.amount,
-            fee: tx.fee,
-            unit: tx.unit,
-            ys: tx.ys,
-            timestamp: tx.timestamp,
-            memo: tx.memo,
-            metadata: tx.metadata,
-            quote_id: tx.quote_id,
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct StoredTransactionPayloadV1 {
+    pub id: Uuid,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub mint_url: MintUrl,
+    #[borsh(
+        serialize_with = "serialize_vec_of_strs",
+        deserialize_with = "deserialize_vec_of_strs"
+    )]
+    pub ys: Vec<cashu::PublicKey>,
+    #[borsh(
+        serialize_with = "serialize_cashu_amount",
+        deserialize_with = "deserialize_cashu_amount"
+    )]
+    pub amount: cashu::Amount,
+    #[borsh(
+        serialize_with = "serialize_cashu_amount",
+        deserialize_with = "deserialize_cashu_amount"
+    )]
+    pub fees: cashu::Amount,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub unit: CurrencyUnit,
+    pub tstamp: u64,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub direction: TransactionDirection,
+    pub memo: Option<String>,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub payment_type: PaymentType,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub status: TransactionStatus,
+    pub btc_tx_id: Option<String>,
+    pub quote_id: Option<Uuid>,
+    pub nostr_event_id: Option<String>,
+    pub contact_node_id: Option<NodeId>,
+    pub payment_request_id: Option<Uuid>,
+    pub linked_txs: Vec<TransactionLink>,
+}
+
+impl From<bcr_wallet_core::types::Transaction> for StoredTransactionPayloadV1 {
+    fn from(value: bcr_wallet_core::types::Transaction) -> Self {
+        Self {
+            id: value.id,
+            mint_url: value.mint_url,
+            ys: value.ys,
+            amount: value.amount,
+            fees: value.fees,
+            unit: value.unit,
+            tstamp: value.tstamp,
+            direction: value.direction,
+            memo: value.memo,
+            payment_type: value.payment_type,
+            status: value.status,
+            btc_tx_id: value.btc_tx_id.map(|bid| bid.to_string()),
+            quote_id: value.quote_id,
+            nostr_event_id: value.nostr_event_id.map(|nei| nei.to_string()),
+            contact_node_id: value.contact_node_id,
+            payment_request_id: value.payment_request_id,
+            linked_txs: value.linked_txs.into_iter().map(|ltx| ltx.into()).collect(),
         }
     }
 }
-impl std::convert::From<TransactionEntry> for Transaction {
-    fn from(entry: TransactionEntry) -> Self {
-        Transaction {
-            mint_url: entry.mint_url,
-            direction: entry.direction,
-            amount: entry.amount,
-            fee: entry.fee,
-            unit: entry.unit,
-            ys: entry.ys,
-            timestamp: entry.timestamp,
-            memo: entry.memo,
-            metadata: entry.metadata,
-            quote_id: entry.quote_id,
-            payment_request: None,
-            payment_proof: None,
-            payment_method: None,
-            saga_id: None,
+
+impl TryFrom<StoredTransactionPayloadV1> for bcr_wallet_core::types::Transaction {
+    type Error = Error;
+    fn try_from(value: StoredTransactionPayloadV1) -> Result<Self> {
+        Ok(Self {
+            id: value.id,
+            mint_url: value.mint_url,
+            ys: value.ys,
+            amount: value.amount,
+            fees: value.fees,
+            unit: value.unit,
+            tstamp: value.tstamp,
+            direction: value.direction,
+            memo: value.memo,
+            payment_type: value.payment_type,
+            status: value.status,
+            btc_tx_id: value
+                .btc_tx_id
+                .map(|bid| bitcoin::Txid::from_str(&bid))
+                .transpose()
+                .map_err(|e| Error::InvalidBtcTxId(e.to_string()))?,
+            quote_id: value.quote_id,
+            nostr_event_id: value
+                .nostr_event_id
+                .map(|nei| EventId::from_str(&nei))
+                .transpose()
+                .map_err(|e| Error::InvalidNostrEventId(e.to_string()))?,
+            contact_node_id: value.contact_node_id,
+            payment_request_id: value.payment_request_id,
+            linked_txs: value.linked_txs.into_iter().map(|ltx| ltx.into()).collect(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct TransactionLink {
+    pub tx_id: Uuid,
+    pub reason: TransactionLinkReason,
+}
+
+impl From<bcr_wallet_core::types::TransactionLink> for TransactionLink {
+    fn from(value: bcr_wallet_core::types::TransactionLink) -> Self {
+        Self {
+            tx_id: value.tx_id,
+            reason: value.reason.into(),
+        }
+    }
+}
+
+impl From<TransactionLink> for bcr_wallet_core::types::TransactionLink {
+    fn from(value: TransactionLink) -> Self {
+        Self {
+            tx_id: value.tx_id,
+            reason: value.reason.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub enum TransactionLinkReason {
+    Reclaim,
+}
+
+impl From<bcr_wallet_core::types::TransactionLinkReason> for TransactionLinkReason {
+    fn from(value: bcr_wallet_core::types::TransactionLinkReason) -> Self {
+        match value {
+            bcr_wallet_core::types::TransactionLinkReason::Reclaim => {
+                TransactionLinkReason::Reclaim
+            }
+        }
+    }
+}
+
+impl From<TransactionLinkReason> for bcr_wallet_core::types::TransactionLinkReason {
+    fn from(value: TransactionLinkReason) -> Self {
+        match value {
+            TransactionLinkReason::Reclaim => {
+                bcr_wallet_core::types::TransactionLinkReason::Reclaim
+            }
         }
     }
 }
@@ -71,10 +190,14 @@ pub struct TransactionDB {
 impl TransactionDB {
     const TRANSACTION_BASE_DB_NAME: &'static str = "transactions";
 
+    pub fn transaction_table_name(wallet_id: &str) -> String {
+        format!("{wallet_id}_{}", Self::TRANSACTION_BASE_DB_NAME)
+    }
+
     pub fn new(db: Arc<Database>, wallet_id: &str) -> Result<Self> {
         // Leak once to get static string, because of dynamically generated table names
         let transaction_name: &'static str =
-            Box::leak(format!("{wallet_id}_{}", Self::TRANSACTION_BASE_DB_NAME).into_boxed_str());
+            Box::leak(Self::transaction_table_name(wallet_id).into_boxed_str());
         let transaction_table = TableDefinition::new(transaction_name);
         Ok(Self {
             db,
@@ -86,16 +209,16 @@ impl TransactionDB {
         db: Arc<Database>,
         tx_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
         tx: Transaction,
-    ) -> Result<TransactionId> {
-        let id = tx.id();
-        let entry: TransactionEntry = tx.into();
+    ) -> Result<Uuid> {
+        let id = tx.id;
+        let entry = StoredTransaction::V1(tx.into());
         let write_txn = db.begin_write()?;
 
         {
             let mut table = write_txn.open_table(tx_table)?;
+            let serialized =
+                borsh::to_vec(&entry).map_err(|e| Error::BorshSerialization(e.to_string()))?;
 
-            let mut serialized = Vec::new();
-            ciborium::into_writer(&entry, &mut serialized)?;
             table.insert(id.as_bytes().as_slice(), serialized)?;
         }
 
@@ -106,8 +229,8 @@ impl TransactionDB {
     fn load_tx_sync(
         db: Arc<Database>,
         tx_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-        tx_id: TransactionId,
-    ) -> Result<Option<TransactionEntry>> {
+        tx_id: Uuid,
+    ) -> Result<Option<Transaction>> {
         let read_txn = db.begin_read()?;
 
         match read_txn.open_table(tx_table) {
@@ -115,8 +238,11 @@ impl TransactionDB {
                 let entry = table.get(tx_id.as_bytes().as_slice())?;
                 match entry {
                     Some(e) => {
-                        let tx: TransactionEntry = ciborium::from_reader(e.value().as_slice())?;
-                        Ok(Some(tx))
+                        let deserialized: StoredTransaction =
+                            borsh::from_slice(e.value().as_slice())
+                                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                        let StoredTransaction::V1(tx) = deserialized;
+                        Ok(Some(tx.try_into()?))
                     }
                     None => Ok(None),
                 }
@@ -126,34 +252,20 @@ impl TransactionDB {
         }
     }
 
-    fn delete_tx_sync(
-        db: Arc<Database>,
-        tx_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-        tx_id: TransactionId,
-    ) -> Result<()> {
-        let write_txn = db.begin_write()?;
-
-        {
-            let mut table = write_txn.open_table(tx_table)?;
-            table.remove(tx_id.as_bytes().as_slice())?;
-        }
-
-        write_txn.commit()?;
-        Ok(())
-    }
-
     fn list_tx_ids_sync(
         db: Arc<Database>,
         tx_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-    ) -> Result<Vec<TransactionId>> {
+    ) -> Result<Vec<Uuid>> {
         let read_txn = db.begin_read()?;
 
         match read_txn.open_table(tx_table) {
             Ok(table) => {
                 let mut res = Vec::new();
-                for (_, v) in table.range::<&[u8]>(..)?.flatten() {
-                    let tx: TransactionEntry = ciborium::from_reader(v.value().as_slice())?;
-                    res.push(TransactionId::from_str(&tx.tx_id)?);
+                for item in table.range::<&[u8]>(..)? {
+                    let (k, _) = item?;
+                    let tx_id = Uuid::from_slice(k.value().to_vec().as_slice())
+                        .map_err(|e| Error::InvalidTransactionId(e.to_string()))?;
+                    res.push(tx_id);
                 }
                 Ok(res)
             }
@@ -165,15 +277,18 @@ impl TransactionDB {
     fn list_txs_sync(
         db: Arc<Database>,
         tx_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-    ) -> Result<Vec<TransactionEntry>> {
+    ) -> Result<Vec<Transaction>> {
         let read_txn = db.begin_read()?;
 
         match read_txn.open_table(tx_table) {
             Ok(table) => {
                 let mut res = Vec::new();
                 for (_, v) in table.range::<&[u8]>(..)?.flatten() {
-                    let tx: TransactionEntry = ciborium::from_reader(v.value().as_slice())?;
-                    res.push(tx);
+                    let deserialized: StoredTransaction =
+                        borsh::from_slice(v.value().as_slice())
+                            .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                    let StoredTransaction::V1(tx) = deserialized;
+                    res.push(tx.try_into()?);
                 }
                 Ok(res)
             }
@@ -182,26 +297,28 @@ impl TransactionDB {
         }
     }
 
-    fn update_meta_sync(
+    fn update_status_sync(
         db: Arc<Database>,
         tx_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-        tx_id: TransactionId,
-        k: String,
-        v: String,
-    ) -> Result<Option<String>> {
+        tx_id: Uuid,
+        status: TransactionStatus,
+    ) -> Result<Option<TransactionStatus>> {
         let write_txn = db.begin_write()?;
         let old_v = {
             let mut table = write_txn.open_table(tx_table)?;
             let old_value = table.get(tx_id.as_bytes().as_slice())?.map(|v| v.value());
 
             if let Some(old_value) = old_value {
-                let mut tx: TransactionEntry = ciborium::from_reader(old_value.as_slice())?;
-                let old = tx.metadata.insert(k, v);
+                let deserialized: StoredTransaction = borsh::from_slice(&old_value)
+                    .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                let StoredTransaction::V1(mut tx) = deserialized;
+                let old = tx.status;
+                tx.status = status;
 
-                let mut serialized = Vec::new();
-                ciborium::into_writer(&tx, &mut serialized)?;
+                let serialized = borsh::to_vec(&StoredTransaction::V1(tx))
+                    .map_err(|e| Error::BorshSerialization(e.to_string()))?;
                 table.insert(tx_id.as_bytes().as_slice(), serialized)?;
-                old
+                Some(old)
             } else {
                 None
             }
@@ -214,7 +331,7 @@ impl TransactionDB {
     fn update_memo_sync(
         db: Arc<Database>,
         tx_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-        tx_id: TransactionId,
+        tx_id: Uuid,
         new_memo: Option<String>,
     ) -> Result<Option<String>> {
         let write_txn = db.begin_write()?;
@@ -223,12 +340,15 @@ impl TransactionDB {
             let old_value = table.get(tx_id.as_bytes().as_slice())?.map(|v| v.value());
 
             if let Some(old_value) = old_value {
-                let mut tx: TransactionEntry = ciborium::from_reader(old_value.as_slice())?;
+                let deserialized: StoredTransaction = borsh::from_slice(&old_value)
+                    .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                let StoredTransaction::V1(mut tx) = deserialized;
+
                 let old = tx.memo.clone();
                 tx.memo = new_memo;
 
-                let mut serialized = Vec::new();
-                ciborium::into_writer(&tx, &mut serialized)?;
+                let serialized = borsh::to_vec(&StoredTransaction::V1(tx))
+                    .map_err(|e| Error::BorshSerialization(e.to_string()))?;
                 table.insert(tx_id.as_bytes().as_slice(), serialized)?;
                 old
             } else {
@@ -240,26 +360,54 @@ impl TransactionDB {
         Ok(old_v)
     }
 
-    fn update_fee_sync(
+    fn link_txs_sync(
         db: Arc<Database>,
         tx_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-        tx_id: TransactionId,
-        fee_to_add: bcr_common::cashu::Amount,
+        tx_id_1: Uuid,
+        tx_id_2: Uuid,
+        reason: TransactionLinkReason,
     ) -> Result<()> {
         let write_txn = db.begin_write()?;
 
         {
             let mut table = write_txn.open_table(tx_table)?;
-            let old_value = table.get(tx_id.as_bytes().as_slice())?.map(|v| v.value());
+            let entry_1 = table
+                .get(tx_id_1.as_bytes().as_slice())?
+                .map(|v| v.value())
+                .ok_or(Error::TransactionNotFound(tx_id_1))?;
+            let entry_2 = table
+                .get(tx_id_2.as_bytes().as_slice())?
+                .map(|v| v.value())
+                .ok_or(Error::TransactionNotFound(tx_id_2))?;
 
-            if let Some(old_value) = old_value {
-                let mut tx: TransactionEntry = ciborium::from_reader(old_value.as_slice())?;
-                tx.fee += fee_to_add;
+            let deserialized_1: StoredTransaction = borsh::from_slice(&entry_1)
+                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+            let StoredTransaction::V1(mut tx_1) = deserialized_1;
 
-                let mut serialized = Vec::new();
-                ciborium::into_writer(&tx, &mut serialized)?;
-                table.insert(tx_id.as_bytes().as_slice(), serialized)?;
-            }
+            let deserialized_2: StoredTransaction = borsh::from_slice(&entry_2)
+                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+            let StoredTransaction::V1(mut tx_2) = deserialized_2;
+
+            let link_1_to_2 = TransactionLink {
+                tx_id: tx_id_2,
+                reason,
+            };
+
+            let link_2_to_1 = TransactionLink {
+                tx_id: tx_id_1,
+                reason,
+            };
+
+            tx_1.linked_txs.push(link_1_to_2);
+            tx_2.linked_txs.push(link_2_to_1);
+
+            let serialized_1 = borsh::to_vec(&StoredTransaction::V1(tx_1))
+                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+            table.insert(tx_id_1.as_bytes().as_slice(), serialized_1)?;
+
+            let serialized_2 = borsh::to_vec(&StoredTransaction::V1(tx_2))
+                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+            table.insert(tx_id_2.as_bytes().as_slice(), serialized_2)?;
         }
 
         write_txn.commit()?;
@@ -285,28 +433,21 @@ impl TransactionDB {
 
 #[async_trait]
 impl TransactionRepository for TransactionDB {
-    async fn store_tx(&self, tx: Transaction) -> Result<TransactionId> {
+    async fn store_tx(&self, tx: Transaction) -> Result<Uuid> {
         let db_clone = self.db.clone();
         let table = self.transaction_table;
         spawn_blocking(move || Self::store_tx_sync(db_clone, table, tx)).await?
     }
 
-    async fn load_tx(&self, tx_id: TransactionId) -> Result<Transaction> {
+    async fn load_tx(&self, tx_id: Uuid) -> Result<Transaction> {
         let db_clone = self.db.clone();
         let table = self.transaction_table;
         let res = spawn_blocking(move || Self::load_tx_sync(db_clone, table, tx_id)).await??;
         let entry = res.ok_or(Error::TransactionNotFound(tx_id))?;
-        Ok(entry.into())
+        Ok(entry)
     }
 
-    async fn delete_tx(&self, tx_id: TransactionId) -> Result<()> {
-        let db_clone = self.db.clone();
-        let table = self.transaction_table;
-        spawn_blocking(move || Self::delete_tx_sync(db_clone, table, tx_id)).await??;
-        Ok(())
-    }
-
-    async fn list_tx_ids(&self) -> Result<Vec<TransactionId>> {
+    async fn list_tx_ids(&self) -> Result<Vec<Uuid>> {
         let db_clone = self.db.clone();
         let table = self.transaction_table;
         spawn_blocking(move || Self::list_tx_ids_sync(db_clone, table)).await?
@@ -316,38 +457,37 @@ impl TransactionRepository for TransactionDB {
         let db_clone = self.db.clone();
         let table = self.transaction_table;
         let res = spawn_blocking(move || Self::list_txs_sync(db_clone, table)).await??;
-        Ok(res.into_iter().map(|entry| entry.into()).collect())
+        Ok(res)
     }
 
-    async fn update_metadata(
+    async fn update_status(
         &self,
-        tx_id: TransactionId,
-        k: String,
-        v: String,
-    ) -> Result<Option<String>> {
+        tx_id: Uuid,
+        status: TransactionStatus,
+    ) -> Result<Option<TransactionStatus>> {
         let db_clone = self.db.clone();
         let table = self.transaction_table;
-        spawn_blocking(move || Self::update_meta_sync(db_clone, table, tx_id, k, v)).await?
+        spawn_blocking(move || Self::update_status_sync(db_clone, table, tx_id, status)).await?
     }
 
-    async fn update_memo(
-        &self,
-        tx_id: TransactionId,
-        new_memo: Option<String>,
-    ) -> Result<Option<String>> {
+    async fn update_memo(&self, tx_id: Uuid, new_memo: Option<String>) -> Result<Option<String>> {
         let db_clone = self.db.clone();
         let table = self.transaction_table;
         spawn_blocking(move || Self::update_memo_sync(db_clone, table, tx_id, new_memo)).await?
     }
 
-    async fn update_fee(
+    async fn link_txs(
         &self,
-        tx_id: TransactionId,
-        fee_to_add: bcr_common::cashu::Amount,
+        tx_id_1: Uuid,
+        tx_id_2: Uuid,
+        reason: bcr_wallet_core::types::TransactionLinkReason,
     ) -> Result<()> {
         let db_clone = self.db.clone();
         let table = self.transaction_table;
-        spawn_blocking(move || Self::update_fee_sync(db_clone, table, tx_id, fee_to_add)).await?
+        spawn_blocking(move || {
+            Self::link_txs_sync(db_clone, table, tx_id_1, tx_id_2, reason.into())
+        })
+        .await?
     }
 
     async fn delete_repo(&self) -> Result<()> {
@@ -363,7 +503,7 @@ mod tests {
         error::Error,
         test_utils::tests::{test_other_pub_key, test_pub_key, wallet_id},
     };
-    use bcr_wallet_core::types::{PAYMENT_TYPE_METADATA_KEY, PaymentType};
+    use bcr_wallet_core::types::PaymentType;
 
     use super::*;
     use bcr_common::cashu::Amount;
@@ -382,29 +522,24 @@ mod tests {
 
     fn test_tx() -> Transaction {
         let mint_url = MintUrl::from_str("https://example.com").expect("valid mint url");
-        let mut metadata = HashMap::new();
-        metadata.insert(
-            PAYMENT_TYPE_METADATA_KEY.to_string(),
-            PaymentType::Token.to_string(),
-        );
-
         Transaction {
+            id: Uuid::new_v4(),
             mint_url,
             direction: TransactionDirection::Outgoing,
             amount: Amount::from(42u64),
-            fee: Amount::ZERO,
+            fees: Amount::ZERO,
             unit: CurrencyUnit::Sat,
-
-            ys: vec![cdk01::PublicKey::from(test_pub_key())],
-
-            timestamp: Utc::now().timestamp() as u64,
+            ys: vec![cashu::PublicKey::from(test_pub_key())],
+            tstamp: Utc::now().timestamp() as u64,
             memo: Some("some memo".to_string()),
-            metadata,
+            payment_type: PaymentType::Token,
+            status: TransactionStatus::Pending,
             quote_id: None,
-            payment_request: None,
-            payment_proof: None,
-            payment_method: None,
-            saga_id: None,
+            btc_tx_id: None,
+            nostr_event_id: None,
+            contact_node_id: None,
+            payment_request_id: None,
+            linked_txs: vec![],
         }
     }
 
@@ -420,7 +555,7 @@ mod tests {
         let repo = get_db(&wallet_id());
 
         let tx = test_tx();
-        let tx_id = tx.id();
+        let tx_id = tx.id;
 
         let err = repo.load_tx(tx_id).await.unwrap_err();
         match err {
@@ -438,7 +573,7 @@ mod tests {
 
         let loaded = repo.load_tx(tx_id).await.expect("load_tx works");
 
-        assert_eq!(loaded, tx);
+        assert_eq!(loaded.id, tx.id);
     }
 
     #[tokio::test]
@@ -446,10 +581,10 @@ mod tests {
         let repo = get_db(&wallet_id());
 
         let mut tx1 = test_tx();
-        tx1.ys = vec![cdk01::PublicKey::from(test_pub_key())];
+        tx1.ys = vec![cashu::PublicKey::from(test_pub_key())];
 
         let mut tx2 = test_tx();
-        tx2.ys = vec![cdk01::PublicKey::from(test_other_pub_key())];
+        tx2.ys = vec![cashu::PublicKey::from(test_other_pub_key())];
 
         let id1 = repo.store_tx(tx1.clone()).await.unwrap();
         let id2 = repo.store_tx(tx2.clone()).await.unwrap();
@@ -471,7 +606,7 @@ mod tests {
         let repo = get_db(&wallet_id());
 
         let tx = test_tx();
-        let tx_id = tx.id();
+        let tx_id = tx.id;
 
         let old = repo
             .update_memo(tx_id, None)
@@ -506,21 +641,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_update_metadata_missing_returns_none() {
+    async fn test_update_status_missing_returns_none() {
         let repo = get_db(&wallet_id());
 
         let tx = test_tx();
-        let tx_id = tx.id();
+        let tx_id = tx.id;
 
         let old = repo
-            .update_metadata(tx_id, "new".to_string(), "value".to_string())
+            .update_status(tx_id, TransactionStatus::Settled)
             .await
-            .expect("update_metadata works");
+            .expect("update_status works");
         assert_eq!(old, None);
     }
 
     #[tokio::test]
-    async fn test_update_metadata_insert_and_overwrite() {
+    async fn test_update_status_insert_and_overwrite() {
         let repo = get_db(&wallet_id());
 
         let tx = test_tx();
@@ -528,53 +663,19 @@ mod tests {
 
         // no value for key before - returns None
         let old = repo
-            .update_metadata(tx_id, "tag".to_string(), "first".to_string())
+            .update_status(tx_id, TransactionStatus::Settled)
             .await
             .unwrap();
-        assert_eq!(old, None);
+        assert_eq!(old, Some(TransactionStatus::Pending));
 
         // overwrite value for key - returns old key
         let old = repo
-            .update_metadata(tx_id, "tag".to_string(), "second".to_string())
+            .update_status(tx_id, TransactionStatus::Pending)
             .await
             .unwrap();
-        assert_eq!(old, Some("first".to_string()));
+        assert_eq!(old, Some(TransactionStatus::Settled));
 
         let loaded = repo.load_tx(tx_id).await.unwrap();
-        assert_eq!(
-            loaded.metadata.get("tag").cloned(),
-            Some("second".to_string())
-        );
-    }
-
-    #[tokio::test]
-    async fn test_update_fee() {
-        let repo = get_db(&wallet_id());
-
-        let tx = test_tx();
-        let tx_id = repo.store_tx(tx).await.unwrap();
-
-        repo.update_fee(tx_id, bcr_common::cashu::Amount::ONE)
-            .await
-            .unwrap();
-
-        let loaded = repo.load_tx(tx_id).await.unwrap();
-        assert_eq!(loaded.fee, bcr_common::cashu::Amount::ONE,);
-    }
-
-    #[tokio::test]
-    async fn test_delete_removes() {
-        let repo = get_db(&wallet_id());
-
-        let tx = test_tx();
-        let tx_id = repo.store_tx(tx).await.unwrap();
-
-        repo.delete_tx(tx_id).await.unwrap();
-
-        let err = repo.load_tx(tx_id).await.unwrap_err();
-        match err {
-            Error::TransactionNotFound(id) => assert_eq!(id, tx_id),
-            other => panic!("expected TransactionNotFound, got: {other:?}"),
-        }
+        assert_eq!(loaded.status, TransactionStatus::Pending);
     }
 }

--- a/crates/bcr-wallet-transport/src/nostr.rs
+++ b/crates/bcr-wallet-transport/src/nostr.rs
@@ -96,12 +96,35 @@ impl Client {
         Ok(signer)
     }
 
+    async fn update_relays(&self, target_relays: HashSet<RelayUrl>) -> Result<()> {
+        let client = &self.client;
+
+        // Get current relays
+        let current_relays: HashSet<RelayUrl> = client.relays().await.keys().cloned().collect();
+
+        // Add new relays
+        for relay in target_relays.iter() {
+            if !current_relays.contains(relay) {
+                match client.add_relay(relay).await {
+                    Ok(_) => tracing::debug!("Added relay: {}", relay),
+                    Err(e) => tracing::warn!("Failed to add relay {}: {}", relay, e),
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     async fn fetch_events(
         &self,
         filter: Filter,
         order: Option<SortOrder>,
         relays: Option<Vec<RelayUrl>>,
     ) -> Result<Vec<Event>> {
+        if let Some(ref r) = relays {
+            // refresh relays to match target set
+            self.update_relays(r.iter().cloned().collect()).await?;
+        }
         let events = self
             .client()
             .await?
@@ -230,15 +253,30 @@ impl TransportApi for Transport {
         let signer = self.client.client.signer().await?;
         let event: Event =
             EventBuilder::private_msg(&signer, receiver.public_key, payload, []).await?;
-        let _ = self
-            .client
-            .client
-            .send_event_to(receiver.relays, &event)
-            .await
-            .map_err(|e| {
+        let relays = receiver.relays;
+
+        if !relays.is_empty() {
+            // refresh relays to match target set
+            self.client
+                .update_relays(relays.iter().cloned().collect())
+                .await?;
+            let output = self
+                .client
+                .client
+                .send_event_to(relays, &event)
+                .await
+                .map_err(|e| {
+                    tracing::error!("send_private_msg failed: {e}");
+                    Error::NostrSendPrivateMsg(event.id)
+                })?;
+            check_send_output(output, "send_private_msg")?;
+        } else {
+            let output = self.client.client.send_event(&event).await.map_err(|e| {
                 tracing::error!("send_private_msg failed: {e}");
                 Error::NostrSendPrivateMsg(event.id)
             })?;
+            check_send_output(output, "send_private_msg")?;
+        }
         Ok(event.id)
     }
 
@@ -309,12 +347,24 @@ impl TransportApi for Transport {
         {
             let result: Result<()> = match &queued_message.recipient {
                 Some(target) => {
-                    if let Err(e) = serde_json::from_str::<cdk18::PaymentRequestPayload>(
-                        &queued_message.payload,
-                    ) {
-                        tracing::error!("Failed to parse private retry payload: {e}");
-                        failed_ids.push(queued_message.id.clone());
-                        continue;
+                    // first, see if it's a cdk18 payload
+                    if serde_json::from_str::<cdk18::PaymentRequestPayload>(&queued_message.payload)
+                        .is_err()
+                    {
+                        match base58::decode(&queued_message.payload) {
+                            Ok(decoded) => {
+                                if let Err(e) = borsh::from_slice::<EventEnvelope>(&decoded) {
+                                    tracing::error!("Failed to parse private retry payload: {e}");
+                                    failed_ids.push(queued_message.id.clone());
+                                    continue;
+                                }
+                            }
+                            Err(e) => {
+                                tracing::error!("Failed to parse private retry payload: {e}");
+                                failed_ids.push(queued_message.id.clone());
+                                continue;
+                            }
+                        }
                     };
 
                     match self

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `get_app_state`, `init_logging`, `init_panic_hook`, `new`, `reset_runtime`, `start_jobs`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `PaymentRequestState`, `WalletCleanLocalDbResponse`, `WalletRuntime`, `WalletsNamesResponse`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
 
 Future<void> initWalletFfi({required WalletFfiConfig conf}) =>
     RustLib.instance.api.crateApiInitWalletFfi(conf: conf);
@@ -682,9 +682,11 @@ class Transaction {
   final String? memo;
   final PaymentType ptype;
   final TransactionStatus status;
-  final String? txId;
+  final String? btcTxId;
   final String? quoteId;
-  final String? contact;
+  final String? contactNodeId;
+  final String? paymentRequestId;
+  final List<TransactionLink> linkedTxs;
 
   const Transaction({
     required this.id,
@@ -696,9 +698,11 @@ class Transaction {
     this.memo,
     required this.ptype,
     required this.status,
-    this.txId,
+    this.btcTxId,
     this.quoteId,
-    this.contact,
+    this.contactNodeId,
+    this.paymentRequestId,
+    required this.linkedTxs,
   });
 
   @override
@@ -712,9 +716,11 @@ class Transaction {
       memo.hashCode ^
       ptype.hashCode ^
       status.hashCode ^
-      txId.hashCode ^
+      btcTxId.hashCode ^
       quoteId.hashCode ^
-      contact.hashCode;
+      contactNodeId.hashCode ^
+      paymentRequestId.hashCode ^
+      linkedTxs.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -730,9 +736,11 @@ class Transaction {
           memo == other.memo &&
           ptype == other.ptype &&
           status == other.status &&
-          txId == other.txId &&
+          btcTxId == other.btcTxId &&
           quoteId == other.quoteId &&
-          contact == other.contact;
+          contactNodeId == other.contactNodeId &&
+          paymentRequestId == other.paymentRequestId &&
+          linkedTxs == other.linkedTxs;
 }
 
 class TransactionCursor {
@@ -811,6 +819,26 @@ class TransactionFilters {
           direction == other.direction &&
           timeRange == other.timeRange;
 }
+
+class TransactionLink {
+  final String txId;
+  final TransactionLinkReason reason;
+
+  const TransactionLink({required this.txId, required this.reason});
+
+  @override
+  int get hashCode => txId.hashCode ^ reason.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TransactionLink &&
+          runtimeType == other.runtimeType &&
+          txId == other.txId &&
+          reason == other.reason;
+}
+
+enum TransactionLinkReason { reclaim }
 
 enum TransactionSort {
   timeAsc,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -3160,6 +3160,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<TransactionLink> dco_decode_list_transaction_link(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_transaction_link).toList();
+  }
+
+  @protected
   List<TransactionStatus> dco_decode_list_transaction_status(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_transaction_status).toList();
@@ -3394,8 +3400,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Transaction dco_decode_transaction(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 12)
-      throw Exception('unexpected arr length: expect 12 but see ${arr.length}');
+    if (arr.length != 14)
+      throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return Transaction(
       id: dco_decode_String(arr[0]),
       amount: dco_decode_u_64(arr[1]),
@@ -3406,9 +3412,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       memo: dco_decode_opt_String(arr[6]),
       ptype: dco_decode_payment_type(arr[7]),
       status: dco_decode_transaction_status(arr[8]),
-      txId: dco_decode_opt_String(arr[9]),
+      btcTxId: dco_decode_opt_String(arr[9]),
       quoteId: dco_decode_opt_String(arr[10]),
-      contact: dco_decode_opt_String(arr[11]),
+      contactNodeId: dco_decode_opt_String(arr[11]),
+      paymentRequestId: dco_decode_opt_String(arr[12]),
+      linkedTxs: dco_decode_list_transaction_link(arr[13]),
     );
   }
 
@@ -3444,6 +3452,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       direction: dco_decode_opt_box_autoadd_transaction_direction(arr[2]),
       timeRange: dco_decode_opt_box_autoadd_time_range(arr[3]),
     );
+  }
+
+  @protected
+  TransactionLink dco_decode_transaction_link(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return TransactionLink(
+      txId: dco_decode_String(arr[0]),
+      reason: dco_decode_transaction_link_reason(arr[1]),
+    );
+  }
+
+  @protected
+  TransactionLinkReason dco_decode_transaction_link_reason(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return TransactionLinkReason.values[raw as int];
   }
 
   @protected
@@ -5043,6 +5069,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<TransactionLink> sse_decode_list_transaction_link(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <TransactionLink>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_transaction_link(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<TransactionStatus> sse_decode_list_transaction_status(
     SseDeserializer deserializer,
   ) {
@@ -5328,9 +5368,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_memo = sse_decode_opt_String(deserializer);
     var var_ptype = sse_decode_payment_type(deserializer);
     var var_status = sse_decode_transaction_status(deserializer);
-    var var_txId = sse_decode_opt_String(deserializer);
+    var var_btcTxId = sse_decode_opt_String(deserializer);
     var var_quoteId = sse_decode_opt_String(deserializer);
-    var var_contact = sse_decode_opt_String(deserializer);
+    var var_contactNodeId = sse_decode_opt_String(deserializer);
+    var var_paymentRequestId = sse_decode_opt_String(deserializer);
+    var var_linkedTxs = sse_decode_list_transaction_link(deserializer);
     return Transaction(
       id: var_id,
       amount: var_amount,
@@ -5341,9 +5383,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       memo: var_memo,
       ptype: var_ptype,
       status: var_status,
-      txId: var_txId,
+      btcTxId: var_btcTxId,
       quoteId: var_quoteId,
-      contact: var_contact,
+      contactNodeId: var_contactNodeId,
+      paymentRequestId: var_paymentRequestId,
+      linkedTxs: var_linkedTxs,
     );
   }
 
@@ -5390,6 +5434,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       direction: var_direction,
       timeRange: var_timeRange,
     );
+  }
+
+  @protected
+  TransactionLink sse_decode_transaction_link(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_txId = sse_decode_String(deserializer);
+    var var_reason = sse_decode_transaction_link_reason(deserializer);
+    return TransactionLink(txId: var_txId, reason: var_reason);
+  }
+
+  @protected
+  TransactionLinkReason sse_decode_transaction_link_reason(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return TransactionLinkReason.values[inner];
   }
 
   @protected
@@ -6987,6 +7048,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_transaction_link(
+    List<TransactionLink> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_transaction_link(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_transaction_status(
     List<TransactionStatus> self,
     SseSerializer serializer,
@@ -7252,9 +7325,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_String(self.memo, serializer);
     sse_encode_payment_type(self.ptype, serializer);
     sse_encode_transaction_status(self.status, serializer);
-    sse_encode_opt_String(self.txId, serializer);
+    sse_encode_opt_String(self.btcTxId, serializer);
     sse_encode_opt_String(self.quoteId, serializer);
-    sse_encode_opt_String(self.contact, serializer);
+    sse_encode_opt_String(self.contactNodeId, serializer);
+    sse_encode_opt_String(self.paymentRequestId, serializer);
+    sse_encode_list_transaction_link(self.linkedTxs, serializer);
   }
 
   @protected
@@ -7291,6 +7366,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       serializer,
     );
     sse_encode_opt_box_autoadd_time_range(self.timeRange, serializer);
+  }
+
+  @protected
+  void sse_encode_transaction_link(
+    TransactionLink self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.txId, serializer);
+    sse_encode_transaction_link_reason(self.reason, serializer);
+  }
+
+  @protected
+  void sse_encode_transaction_link_reason(
+    TransactionLinkReason self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -300,6 +300,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<Transaction> dco_decode_list_transaction(dynamic raw);
 
   @protected
+  List<TransactionLink> dco_decode_list_transaction_link(dynamic raw);
+
+  @protected
   List<TransactionStatus> dco_decode_list_transaction_status(dynamic raw);
 
   @protected
@@ -388,6 +391,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   TransactionFilters dco_decode_transaction_filters(dynamic raw);
+
+  @protected
+  TransactionLink dco_decode_transaction_link(dynamic raw);
+
+  @protected
+  TransactionLinkReason dco_decode_transaction_link_reason(dynamic raw);
 
   @protected
   TransactionSort dco_decode_transaction_sort(dynamic raw);
@@ -1033,6 +1042,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<Transaction> sse_decode_list_transaction(SseDeserializer deserializer);
 
   @protected
+  List<TransactionLink> sse_decode_list_transaction_link(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<TransactionStatus> sse_decode_list_transaction_status(
     SseDeserializer deserializer,
   );
@@ -1149,6 +1163,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   TransactionFilters sse_decode_transaction_filters(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  TransactionLink sse_decode_transaction_link(SseDeserializer deserializer);
+
+  @protected
+  TransactionLinkReason sse_decode_transaction_link_reason(
     SseDeserializer deserializer,
   );
 
@@ -1936,6 +1958,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_transaction_link(
+    List<TransactionLink> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_transaction_status(
     List<TransactionStatus> self,
     SseSerializer serializer,
@@ -2088,6 +2116,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_transaction_filters(
     TransactionFilters self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_transaction_link(
+    TransactionLink self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_transaction_link_reason(
+    TransactionLinkReason self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -302,6 +302,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<Transaction> dco_decode_list_transaction(dynamic raw);
 
   @protected
+  List<TransactionLink> dco_decode_list_transaction_link(dynamic raw);
+
+  @protected
   List<TransactionStatus> dco_decode_list_transaction_status(dynamic raw);
 
   @protected
@@ -390,6 +393,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   TransactionFilters dco_decode_transaction_filters(dynamic raw);
+
+  @protected
+  TransactionLink dco_decode_transaction_link(dynamic raw);
+
+  @protected
+  TransactionLinkReason dco_decode_transaction_link_reason(dynamic raw);
 
   @protected
   TransactionSort dco_decode_transaction_sort(dynamic raw);
@@ -1035,6 +1044,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<Transaction> sse_decode_list_transaction(SseDeserializer deserializer);
 
   @protected
+  List<TransactionLink> sse_decode_list_transaction_link(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<TransactionStatus> sse_decode_list_transaction_status(
     SseDeserializer deserializer,
   );
@@ -1151,6 +1165,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   TransactionFilters sse_decode_transaction_filters(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  TransactionLink sse_decode_transaction_link(SseDeserializer deserializer);
+
+  @protected
+  TransactionLinkReason sse_decode_transaction_link_reason(
     SseDeserializer deserializer,
   );
 
@@ -1938,6 +1960,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_transaction_link(
+    List<TransactionLink> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_transaction_status(
     List<TransactionStatus> self,
     SseSerializer serializer,
@@ -2090,6 +2118,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_transaction_filters(
     TransactionFilters self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_transaction_link(
+    TransactionLink self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_transaction_link_reason(
+    TransactionLinkReason self,
     SseSerializer serializer,
   );
 


### PR DESCRIPTION
* Rework Transactions Data Model
* Implement Data Migration to new Transactions Data Model
* Fix some bugs with payment requests and relays
* Rework reclaim to create two linked transactions - one `Settled` and one `Canceled`