### PR TITLE
Rework Contacts and Payment Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# 0.9.8
+
+* Rework Contacts
+    * Fields
+        * id is now a `Uuid`
+        * node_id is an `Option<NodeId>`
+        * add email as an `Option<Email>`
+        * name is an `Option<Name>`
+        * add company as an `Option<Name>`
+        * Either company, or name have to be set
+        * Either node_id, or email have to be set
+        * For `edit_contact`
+            * All fields have to be provided
+            * To delete a field, send it as `None`
+            * To set a field, send it as `Some(new_value)`
+    * Contacts are now on `purse` level instead of on `wallet` level and are persisted per `btc_network`
+        * there is a contact book for each btc network
+    * DB migration & versioning for contacts
+    * It would be good to add all clowder-relays (wildcat0-n) to the wallet config
+* Payment Request functions and pay by contact take a `Uuid` (the contact id) now
+    * Contacts have to have a `node_id` to be eligible for `pay_to_contact` or `request_payment_from_contact`
+* Expose functionality to send a private, encrypted payment to an existing contact via Nostr
+    * `wallet_prepare_pay_to_contact` - taking a contact_id, amount and description
+    * `wallet_pay_to_contact` - taking a payment request id
+
 # 0.9.7
 
 * Wallet name is now only unique per btc network

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-api"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "async-trait",
  "bcr-common",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-cli"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "bcr-common",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-core"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "ammonia",
  "bcr-common",
@@ -422,6 +422,7 @@ dependencies = [
  "borsh",
  "chrono",
  "ecies",
+ "email_address",
  "nostr",
  "serde",
  "strum",
@@ -432,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-persistence"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "async-trait",
  "bcr-common",
@@ -454,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-transport"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "async-trait",
  "bcr-common",
@@ -1368,6 +1369,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 
 [[package]]
 name = "encoding_rs"
@@ -4314,7 +4321,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wallet_ffi"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "android_logger",
  "bcr-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 license = "MIT"
 

--- a/crates/bcr-wallet-api/src/error.rs
+++ b/crates/bcr-wallet-api/src/error.rs
@@ -1,7 +1,6 @@
 use bcr_common::{
     cashu::{self},
     cdk_common,
-    core::NodeId,
 };
 use thiserror::Error;
 use uuid::Uuid;
@@ -91,6 +90,12 @@ pub enum Error {
     InvalidName,
     #[error("empty name")]
     EmptyName,
+    #[error("invalid email")]
+    InvalidEmail,
+    #[error("empty email")]
+    EmptyEmail,
+    #[error("invalid contact - need one of name/company and one of node_id/email")]
+    InvalidContact,
     #[error("invalid node id")]
     InvalidNodeId,
     #[error("invalid bill id")]
@@ -124,9 +129,11 @@ pub enum Error {
     #[error("Invalid Clowder Path for foreign eCash")]
     InvalidClowderPath,
     #[error("No contact found for {0}")]
-    ContactNotFound(NodeId),
+    ContactNotFound(String),
+    #[error("Contact must have node id for payment request for contact {0}")]
+    ContactMustHaveNodeId(String),
     #[error("Contact {0} already exists")]
-    ContactAlreadyExists(NodeId),
+    ContactAlreadyExists(Uuid),
     #[error("Beta not found")]
     BetaNotFound(url::Url),
     #[error("No Substitute could be determined")]
@@ -305,6 +312,9 @@ impl From<bcr_wallet_core::ValidationError> for Error {
         match err {
             bcr_wallet_core::ValidationError::EmptyName => Error::EmptyName,
             bcr_wallet_core::ValidationError::InvalidName => Error::InvalidName,
+            bcr_wallet_core::ValidationError::EmptyEmail => Error::EmptyEmail,
+            bcr_wallet_core::ValidationError::InvalidEmail => Error::InvalidEmail,
+            bcr_wallet_core::ValidationError::InvalidContact(_) => Error::InvalidContact,
         }
     }
 }

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -10,6 +10,7 @@ use bcr_common::{
     wallet::Token,
 };
 use bcr_wallet_core::contact::Contact;
+use bcr_wallet_core::email::Email;
 use bcr_wallet_core::name::Name;
 use bcr_wallet_core::types::{
     self, BtcTxStatus, ListTransactionsResult, MeltEstimation, MintSummary, PaymentRequest,
@@ -20,7 +21,8 @@ use bcr_wallet_core::types::{
 use bcr_wallet_core::util::{
     build_wallet_id, keypair_from_mnemonic, keypair_from_seed, seed_from_mnemonic,
 };
-use bcr_wallet_persistence::redb::{Database, build_pursedb, build_wallet_dbs, create_db};
+use bcr_wallet_persistence::ContactStoreApi;
+use bcr_wallet_persistence::redb::{Database, build_pursedbs, build_wallet_dbs, create_db};
 use bcr_wallet_transport::NostrEventChannel;
 use bcr_wallet_transport::nostr;
 use error::{Error, Result};
@@ -59,10 +61,15 @@ impl AppState {
 
         // Open Database file - only allowed to do once!
         let db = Arc::new(create_db(&cfg.db_path)?);
-        let pursedb = build_pursedb(AppState::DB_VERSION, db.clone()).await?;
+
+        let (pursedb, contactdbs) = build_pursedbs(AppState::DB_VERSION, db.clone()).await?;
+        let contact_repos: HashMap<bitcoin::Network, Arc<dyn ContactStoreApi>> = contactdbs
+            .into_iter()
+            .map(|(network, db)| (network, db as Arc<dyn ContactStoreApi>))
+            .collect();
 
         let http_cl = Arc::new(reqwest::Client::new());
-        let purse = purse::Purse::new(pursedb).await?;
+        let purse = purse::Purse::new(pursedb, contact_repos).await?;
         let btc_cl = Arc::new(external::bitcoin::BitcoinClient::new(
             cfg.esplora_base_urls.clone(),
         ));
@@ -135,12 +142,14 @@ impl AppState {
                 }
             };
 
+            let network = w_cfg.network;
             let wallet = build_wallet(
                 w_cfg,
                 client,
                 Self::DB_VERSION,
                 self.cfg.swap_expiry,
                 db.clone(),
+                purse.get_contact_repo(network),
                 seed,
                 nostr_cl,
             )
@@ -188,11 +197,13 @@ impl AppState {
         let purse = self.get_purse();
 
         self.validate_add_wallet(&cfg).await?;
+        let network = cfg.network;
         let wallet = create_new_wallet(
             cfg,
             AppState::DB_VERSION,
             self.cfg.swap_expiry,
             self.get_db(),
+            purse.get_contact_repo(network),
         )
         .await?;
 
@@ -209,12 +220,14 @@ impl AppState {
         );
         let purse = self.get_purse();
 
+        let network = cfg.network;
         self.validate_add_wallet(&cfg).await?;
         let wallet = create_new_wallet(
             cfg,
             AppState::DB_VERSION,
             self.cfg.swap_expiry,
             self.get_db(),
+            purse.get_contact_repo(network),
         )
         .await?;
         wallet.read().await.restore_local_proofs().await?;
@@ -258,6 +271,94 @@ impl AppState {
         let migrated = purse.migrate_rabid_wallets().await?;
 
         Ok(migrated)
+    }
+
+    pub async fn purse_add_contact(
+        &self,
+        bitcoin_network: String,
+        node_id: Option<String>,
+        email: Option<String>,
+        name: Option<String>,
+        company: Option<String>,
+    ) -> Result<Uuid> {
+        let parsed_network = bitcoin::Network::from_str(&bitcoin_network)
+            .map_err(|_| Error::InvalidBitcoinNetwork(bitcoin_network))?;
+        let node_id = node_id.map(|n| NodeId::from_str(&n)).transpose()?;
+        let name = name.map(|n| Name::from_str(&n)).transpose()?;
+        let company = company.map(|c| Name::from_str(&c)).transpose()?;
+        let email = email.map(|e| Email::from_str(&e)).transpose()?;
+        let purse = self.get_purse();
+        let id = purse
+            .add_contact(parsed_network, node_id, email, name, company)
+            .await?;
+        Ok(id)
+    }
+
+    pub async fn purse_edit_contact(
+        &self,
+        bitcoin_network: String,
+        contact_id: String,
+        node_id: Option<String>,
+        email: Option<String>,
+        name: Option<String>,
+        company: Option<String>,
+    ) -> Result<()> {
+        let parsed_network = bitcoin::Network::from_str(&bitcoin_network)
+            .map_err(|_| Error::InvalidBitcoinNetwork(bitcoin_network))?;
+        let contact_id = Uuid::from_str(&contact_id)?;
+        let node_id = node_id
+            .map(|node_id| NodeId::from_str(&node_id))
+            .transpose()?;
+        let email = email.map(|email| Email::from_str(&email)).transpose()?;
+        let name = name.map(|name| Name::from_str(&name)).transpose()?;
+        let company = company
+            .map(|company| Name::from_str(&company))
+            .transpose()?;
+        let purse = self.get_purse();
+        purse
+            .edit_contact(parsed_network, contact_id, node_id, email, name, company)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn purse_delete_contact(
+        &self,
+        bitcoin_network: String,
+        contact_id: String,
+    ) -> Result<()> {
+        let parsed_network = bitcoin::Network::from_str(&bitcoin_network)
+            .map_err(|_| Error::InvalidBitcoinNetwork(bitcoin_network))?;
+        let contact_id = Uuid::from_str(&contact_id)?;
+        let purse = self.get_purse();
+        purse.delete_contact(parsed_network, contact_id).await?;
+        Ok(())
+    }
+
+    pub async fn purse_get_contact(
+        &self,
+        bitcoin_network: String,
+        contact_id: String,
+    ) -> Result<Contact> {
+        let parsed_network = bitcoin::Network::from_str(&bitcoin_network)
+            .map_err(|_| Error::InvalidBitcoinNetwork(bitcoin_network))?;
+        let contact_id = Uuid::from_str(&contact_id)?;
+        let purse = self.get_purse();
+        match purse.get_contact(parsed_network, contact_id).await? {
+            Some(c) => Ok(c),
+            None => Err(Error::ContactNotFound(contact_id.to_string())),
+        }
+    }
+
+    pub async fn purse_list_contacts(
+        &self,
+        bitcoin_network: String,
+        search_term: Option<String>,
+    ) -> Result<Vec<Contact>> {
+        let parsed_network = bitcoin::Network::from_str(&bitcoin_network)
+            .map_err(|_| Error::InvalidBitcoinNetwork(bitcoin_network))?;
+        let purse = self.get_purse();
+        let contacts = purse.list_contacts(parsed_network, search_term).await?;
+        Ok(contacts)
     }
 
     ////////////////////////////////////////////////////  Wallet-Level API methods
@@ -368,26 +469,22 @@ impl AppState {
     pub async fn wallet_prepare_pay_to_contact(
         &self,
         wallet_id: String,
-        node_id: String,
+        contact_id: String,
         amount: u64,
         description: Option<String>,
     ) -> Result<PaymentSummary> {
         tracing::debug!(
-            "wallet_prepare_pay_to_contact({wallet_id}, {node_id}, {amount}, {description:?})"
+            "wallet_prepare_pay_to_contact({wallet_id}, {contact_id}, {amount}, {description:?})"
         );
         let amount = cashu::Amount::from(amount);
         let wallet = self.get_wallet(&wallet_id).await?;
         let unit = wallet.read().await.debit_unit();
-        let node_id = NodeId::from_str(&node_id)?;
-        let wallet_network = wallet.read().await.network();
-        if node_id.network() != wallet_network {
-            return Err(Error::InvalidNetwork(wallet_network, node_id.network()));
-        }
+        let contact_id = Uuid::from_str(&contact_id)?;
 
         let summary = wallet
             .read()
             .await
-            .prepare_pay_to_contact(node_id, amount, unit, description)
+            .prepare_pay_to_contact(contact_id, amount, unit, description)
             .await?;
 
         Ok(summary)
@@ -407,26 +504,22 @@ impl AppState {
     pub async fn wallet_request_payment_from_contact(
         &self,
         wallet_id: String,
-        node_id: String,
+        contact_id: String,
         amount: u64,
         description: Option<String>,
         deadline: Option<u64>,
     ) -> Result<Uuid> {
         tracing::debug!(
-            "wallet_request_payment_from_contact({wallet_id}, {node_id}, {amount}, {description:?}, {deadline:?})"
+            "wallet_request_payment_from_contact({wallet_id}, {contact_id}, {amount}, {description:?}, {deadline:?})"
         );
-        let node_id = NodeId::from_str(&node_id)?;
+        let contact_id = Uuid::from_str(&contact_id)?;
         let amount = cashu::Amount::from(amount);
         let wallet = self.get_wallet(&wallet_id).await?;
-        let wallet_network = wallet.read().await.network();
-        if node_id.network() != wallet_network {
-            return Err(Error::InvalidNetwork(wallet_network, node_id.network()));
-        }
         let unit = wallet.read().await.debit_unit();
         let payment_req_id = wallet
             .read()
             .await
-            .request_payment_from_contact(node_id, amount, unit, description, deadline)
+            .request_payment_from_contact(contact_id, amount, unit, description, deadline)
             .await?;
         Ok(payment_req_id)
     }
@@ -815,74 +908,6 @@ impl AppState {
         Ok(amount)
     }
 
-    pub async fn wallet_add_contact(
-        &self,
-        wallet_id: String,
-        node_id: String,
-        name: String,
-    ) -> Result<()> {
-        let node_id = NodeId::from_str(&node_id)?;
-        let name = Name::from_str(&name)?;
-        let wallet = self.get_wallet(&wallet_id).await?;
-        let wallet_network = wallet.read().await.network();
-        if node_id.network() != wallet_network {
-            return Err(Error::InvalidNetwork(wallet_network, node_id.network()));
-        }
-        wallet.read().await.add_contact(node_id, name).await?;
-        Ok(())
-    }
-
-    pub async fn wallet_edit_contact(
-        &self,
-        wallet_id: String,
-        node_id: String,
-        name: String,
-    ) -> Result<()> {
-        let node_id = NodeId::from_str(&node_id)?;
-        let name = Name::from_str(&name)?;
-        let wallet = self.get_wallet(&wallet_id).await?;
-        let wallet_network = wallet.read().await.network();
-        if node_id.network() != wallet_network {
-            return Err(Error::InvalidNetwork(wallet_network, node_id.network()));
-        }
-        wallet.read().await.edit_contact(node_id, name).await?;
-        Ok(())
-    }
-
-    pub async fn wallet_delete_contact(&self, wallet_id: String, node_id: String) -> Result<()> {
-        let node_id = NodeId::from_str(&node_id)?;
-        let wallet = self.get_wallet(&wallet_id).await?;
-        let wallet_network = wallet.read().await.network();
-        if node_id.network() != wallet_network {
-            return Err(Error::InvalidNetwork(wallet_network, node_id.network()));
-        }
-        wallet.read().await.delete_contact(node_id).await?;
-        Ok(())
-    }
-
-    pub async fn wallet_get_contact(&self, wallet_id: String, node_id: String) -> Result<Contact> {
-        let node_id = NodeId::from_str(&node_id)?;
-        let wallet = self.get_wallet(&wallet_id).await?;
-        let wallet_network = wallet.read().await.network();
-        if node_id.network() != wallet_network {
-            return Err(Error::InvalidNetwork(wallet_network, node_id.network()));
-        }
-        match wallet.read().await.get_contact(node_id.clone()).await? {
-            Some(c) => Ok(c),
-            None => Err(Error::ContactNotFound(node_id)),
-        }
-    }
-
-    pub async fn wallet_list_contacts(
-        &self,
-        wallet_id: String,
-        search_term: Option<String>,
-    ) -> Result<Vec<Contact>> {
-        let wallet = self.get_wallet(&wallet_id).await?;
-        let contacts = wallet.read().await.list_contacts(search_term).await?;
-        Ok(contacts)
-    }
-
     // Recover pending stale proofs
     pub async fn wallet_recover_pending_stale_proofs(
         &self,
@@ -1149,6 +1174,7 @@ async fn create_new_wallet(
     db_version: u32,
     swap_expiry: chrono::TimeDelta,
     db: Arc<Database>,
+    contact_repo: Arc<dyn ContactStoreApi>,
 ) -> Result<Arc<RwLock<wallet::Wallet>>> {
     let seed = seed_from_mnemonic(&cfg.mnemonic);
     let keypair = keypair_from_mnemonic(&cfg.mnemonic);
@@ -1197,7 +1223,17 @@ async fn create_new_wallet(
         betas,
         nostr_relays: cfg.nostr_relays,
     };
-    build_wallet(w_cfg, client, db_version, swap_expiry, db, seed, nostr_cl).await
+    build_wallet(
+        w_cfg,
+        client,
+        db_version,
+        swap_expiry,
+        db,
+        contact_repo,
+        seed,
+        nostr_cl,
+    )
+    .await
 }
 
 async fn build_wallet(
@@ -1206,11 +1242,12 @@ async fn build_wallet(
     db_version: u32,
     swap_expiry: chrono::TimeDelta,
     db: Arc<Database>,
+    contactdb: Arc<dyn ContactStoreApi>,
     seed: Seed,
     nostr_cl: Arc<nostr::Client>,
 ) -> Result<Arc<RwLock<wallet::Wallet>>> {
     // building wallet dbs
-    let (tx_repo, debitdb, mintmeltdb, nostrdb, contactdb, pending_incoming_payment_request_db) =
+    let (tx_repo, debitdb, mintmeltdb, nostrdb, pending_incoming_payment_request_db) =
         build_wallet_dbs(db_version, &w_cfg.wallet_id, &w_cfg.debit, db, seed).await?;
 
     let nostr_repo = Arc::new(nostrdb);
@@ -1252,7 +1289,7 @@ async fn build_wallet(
         client,
         w_cfg.mint_keyset_infos,
         Box::new(tx_repo),
-        Box::new(contactdb),
+        contactdb,
         Box::new(pending_incoming_payment_request_db),
         debit_pocket,
         w_cfg.name,

--- a/crates/bcr-wallet-api/src/purse/mod.rs
+++ b/crates/bcr-wallet-api/src/purse/mod.rs
@@ -1,23 +1,41 @@
 use crate::{
     error::{Error, Result},
-    wallet::api::WalletApi,
+    wallet::{api::WalletApi, util::update_optional_field},
 };
-use bcr_wallet_core::types::WalletConfig;
-use bcr_wallet_persistence::{PurseRepository, redb::purse::PurseDB};
-use std::{collections::HashMap, sync::Arc};
+use bcr_common::core::NodeId;
+use bcr_wallet_core::{contact::Contact, email::Email, name::Name, types::WalletConfig};
+use bcr_wallet_persistence::{ContactStoreApi, PurseRepository, redb::purse::PurseDB};
+use nostr::types::RelayUrl;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 use tokio::sync::RwLock;
+use uuid::Uuid;
 
 pub struct Purse<Wlt> {
     pub repo: Box<dyn PurseRepository>,
+    pub contact_repos: HashMap<bitcoin::Network, Arc<dyn ContactStoreApi>>,
     pub wallets: Arc<RwLock<HashMap<String, Arc<RwLock<Wlt>>>>>,
 }
 
 impl<Wlt> Purse<Wlt> {
-    pub async fn new(repo: PurseDB) -> Result<Self> {
+    pub async fn new(
+        repo: PurseDB,
+        contact_repos: HashMap<bitcoin::Network, Arc<dyn ContactStoreApi>>,
+    ) -> Result<Self> {
         Ok(Self {
             repo: Box::new(repo),
+            contact_repos,
             wallets: Arc::new(RwLock::new(HashMap::default())),
         })
+    }
+
+    pub fn get_contact_repo(&self, network: bitcoin::Network) -> Arc<dyn ContactStoreApi> {
+        self.contact_repos
+            .get(&network)
+            .expect("there is a contact repo for each network")
+            .clone()
     }
 
     pub async fn load_wallet_config(&self, wallet_id: &str) -> Result<WalletConfig> {
@@ -128,6 +146,179 @@ where
         }
         res
     }
+
+    async fn first_wallet_for_network(&self, network: bitcoin::Network) -> Option<String> {
+        let wallets: HashMap<_, _> = {
+            let wlts = self.wallets.read().await;
+            wlts.clone()
+        };
+        for (wallet_id, wlt) in wallets.iter() {
+            let info = wlt.read().await.info();
+            if info.network == network {
+                return Some(wallet_id.to_string());
+            }
+        }
+        None
+    }
+
+    // collect nostr relays of all wallets of this network
+    async fn nostr_relays(&self, network: bitcoin::Network) -> Vec<RelayUrl> {
+        let mut res = HashSet::new();
+        let wallets: HashMap<_, _> = {
+            let wlts = self.wallets.read().await;
+            wlts.clone()
+        };
+        for wlt in wallets.values() {
+            let info = wlt.read().await.info();
+            if info.network == network {
+                res.extend(info.nostr_relays);
+            }
+        }
+        res.into_iter().collect()
+    }
+
+    async fn relay_list_for_node_id(
+        &self,
+        node_id: Option<NodeId>,
+        network: bitcoin::Network,
+    ) -> Vec<RelayUrl> {
+        // fetch relay list for the contact from nostr if node id is set, falling back to our relays
+        let my_relays = self.nostr_relays(network).await;
+
+        if let Some(ref node_id) = node_id
+            && let Some(first_wallet_for_network) = self.first_wallet_for_network(network).await
+            && let Some(wlt) = self.get_wallet(&first_wallet_for_network).await
+        {
+            let mut fetched_relay_list = wlt
+                .read()
+                .await
+                .fetch_nostr_relays(node_id.npub(), my_relays.clone())
+                .await
+                .unwrap_or(my_relays.clone());
+
+            if fetched_relay_list.is_empty() {
+                fetched_relay_list = my_relays;
+            }
+            fetched_relay_list
+        } else {
+            my_relays
+        }
+    }
+
+    pub async fn add_contact(
+        &self,
+        network: bitcoin::Network,
+        node_id: Option<NodeId>,
+        email: Option<Email>,
+        name: Option<Name>,
+        company: Option<Name>,
+    ) -> Result<Uuid> {
+        let relay_list_for_node_id = self.relay_list_for_node_id(node_id.clone(), network).await;
+        if let Some(ref node_id) = node_id
+            && node_id.network() != network
+        {
+            return Err(Error::InvalidNetwork(network, node_id.network()));
+        }
+        let contact = Contact::new(node_id, email, name, company, relay_list_for_node_id)?;
+        match self.get_contact_repo(network).add_contact(contact).await {
+            Ok(id) => Ok(id),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub async fn edit_contact(
+        &self,
+        network: bitcoin::Network,
+        contact_id: Uuid,
+        node_id: Option<NodeId>,
+        email: Option<Email>,
+        name: Option<Name>,
+        company: Option<Name>,
+    ) -> Result<()> {
+        let Some(mut contact_to_update) = self
+            .get_contact_repo(network)
+            .get_contact(contact_id)
+            .await?
+        else {
+            return Err(Error::ContactNotFound(contact_id.to_string()));
+        };
+        if let Some(ref node_id) = node_id
+            && node_id.network() != network
+        {
+            return Err(Error::InvalidNetwork(network, node_id.network()));
+        }
+
+        let mut changed = false;
+
+        update_optional_field(&mut contact_to_update.node_id, &node_id, &mut changed);
+        // if node id is set/changed, fetch and set/update relays
+        if changed && node_id.is_some() {
+            let relay_list_for_node_id =
+                self.relay_list_for_node_id(node_id.clone(), network).await;
+            contact_to_update.nostr_relays = relay_list_for_node_id;
+        }
+        update_optional_field(&mut contact_to_update.email, &email, &mut changed);
+        update_optional_field(&mut contact_to_update.name, &name, &mut changed);
+        update_optional_field(&mut contact_to_update.company, &company, &mut changed);
+
+        if !changed {
+            return Ok(());
+        }
+
+        contact_to_update.validate()?;
+
+        match self
+            .get_contact_repo(network)
+            .edit_contact(contact_id, contact_to_update)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(bcr_wallet_persistence::error::Error::ContactNotFound(_)) => {
+                Err(Error::ContactNotFound(contact_id.to_string()))
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub async fn delete_contact(&self, network: bitcoin::Network, contact_id: Uuid) -> Result<()> {
+        if self
+            .get_contact_repo(network)
+            .get_contact(contact_id)
+            .await?
+            .is_some()
+        {
+            self.get_contact_repo(network)
+                .delete_contact(contact_id)
+                .await?;
+        } else {
+            return Err(Error::ContactNotFound(contact_id.to_string()));
+        }
+        Ok(())
+    }
+
+    pub async fn get_contact(
+        &self,
+        network: bitcoin::Network,
+        contact_id: Uuid,
+    ) -> Result<Option<Contact>> {
+        let contact = self
+            .get_contact_repo(network)
+            .get_contact(contact_id)
+            .await?;
+        Ok(contact)
+    }
+
+    pub async fn list_contacts(
+        &self,
+        network: bitcoin::Network,
+        search_term: Option<String>,
+    ) -> Result<Vec<Contact>> {
+        let contacts = self
+            .get_contact_repo(network)
+            .list_contacts(search_term)
+            .await?;
+        Ok(contacts)
+    }
 }
 
 #[cfg(test)]
@@ -135,14 +326,42 @@ mod tests {
     use std::str::FromStr;
 
     use bcr_common::cashu::CurrencyUnit;
-    use bcr_wallet_persistence::{MockPurseRepository, test_utils::tests::test_pub_key};
+    use bcr_wallet_persistence::{
+        MockContactStoreApi, MockPurseRepository, test_utils::tests::test_pub_key,
+    };
 
     use super::*;
     use crate::wallet::api::MockWalletApi;
 
     fn purse(db: Box<dyn PurseRepository>) -> super::Purse<MockWalletApi> {
+        let mut contact_dbs = HashMap::new();
+        contact_dbs.insert(
+            bitcoin::Network::Testnet,
+            Arc::new(MockContactStoreApi::new()),
+        );
+        contact_dbs.insert(
+            bitcoin::Network::Testnet4,
+            Arc::new(MockContactStoreApi::new()),
+        );
+        contact_dbs.insert(
+            bitcoin::Network::Regtest,
+            Arc::new(MockContactStoreApi::new()),
+        );
+        contact_dbs.insert(
+            bitcoin::Network::Signet,
+            Arc::new(MockContactStoreApi::new()),
+        );
+        contact_dbs.insert(
+            bitcoin::Network::Bitcoin,
+            Arc::new(MockContactStoreApi::new()),
+        );
+        let contact_repos: HashMap<bitcoin::Network, Arc<dyn ContactStoreApi>> = contact_dbs
+            .into_iter()
+            .map(|(network, db)| (network, db as Arc<dyn ContactStoreApi>))
+            .collect();
         Purse {
             repo: db,
+            contact_repos,
             wallets: Arc::new(RwLock::new(HashMap::default())),
         }
     }
@@ -227,5 +446,83 @@ mod tests {
             .await
             .expect("migrate rabid wallets works");
         assert!(!migrated.is_empty());
+    }
+
+    const NODE_ID_1: &str =
+        "bitcrt03205b8dec12bc9e879f5b517aa32192a2550e88adcee3e54ec2c7294802568fef";
+
+    fn test_contact(id: Uuid) -> Contact {
+        Contact {
+            id,
+            node_id: Some(NodeId::from_str(NODE_ID_1).unwrap()),
+            email: None,
+            name: Some(Name::from_str("Minka").unwrap()),
+            company: None,
+            nostr_relays: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_contacts() {
+        let network = bitcoin::Network::Testnet;
+        let db = MockPurseRepository::new();
+        let mut contact_repo = MockContactStoreApi::new();
+        let ct_id = Uuid::new_v4();
+        contact_repo
+            .expect_add_contact()
+            .times(1)
+            .returning(move |_| Ok(ct_id));
+        contact_repo
+            .expect_edit_contact()
+            .times(1)
+            .returning(|_, _| Ok(()));
+        contact_repo
+            .expect_delete_contact()
+            .times(1)
+            .returning(|_| Ok(()));
+        // one for edit, one for get
+        contact_repo
+            .expect_get_contact()
+            .times(2)
+            .returning(move |_| Ok(Some(test_contact(ct_id))));
+        contact_repo
+            .expect_list_contacts()
+            .times(1)
+            .returning(move |_| Ok(vec![test_contact(ct_id)]));
+        let mut purse = purse(Box::new(db));
+        *purse.contact_repos.get_mut(&network).unwrap() = Arc::new(contact_repo);
+
+        purse
+            .add_contact(
+                network,
+                Some(NodeId::from_str(NODE_ID_1).unwrap()),
+                None,
+                Some(Name::from_str("Minka").unwrap()),
+                None,
+            )
+            .await
+            .expect("create contact works");
+
+        purse
+            .edit_contact(
+                network,
+                ct_id,
+                Some(NodeId::from_str(NODE_ID_1).unwrap()),
+                None,
+                Some(Name::from_str("Nala").unwrap()),
+                None,
+            )
+            .await
+            .expect("edit contact works");
+
+        purse
+            .delete_contact(network, ct_id)
+            .await
+            .expect("delete contact works");
+        let cts = purse
+            .list_contacts(network, None)
+            .await
+            .expect("list contacts works");
+        assert!(cts.len() == 1);
     }
 }

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -21,9 +21,7 @@ use bcr_common::{
 };
 use bcr_wallet_core::{
     SendSync,
-    contact::Contact,
     event::{ContactPaymentRequestPayload, EventEnvelope},
-    name::Name,
     types::{
         MeltEstimation, PaymentRequest, PaymentRequestDirection, PaymentRequestState,
         PaymentResultCallback, PaymentType, PendingPaymentSubscriptionCallback, Transaction,
@@ -54,7 +52,6 @@ pub trait WalletApi: SendSync {
     fn node_id(&self) -> NodeId;
     fn id(&self) -> String;
     fn mint_url(&self) -> url::Url;
-    fn nostr_relays(&self) -> Vec<RelayUrl>;
     fn betas(&self) -> Vec<url::Url>;
     #[allow(dead_code)]
     fn clowder_id(&self) -> secp256k1::PublicKey;
@@ -126,7 +123,7 @@ pub trait WalletApi: SendSync {
     ) -> Result<PaymentSummary>;
     async fn prepare_pay_to_contact(
         &self,
-        node_id: NodeId,
+        contact_id: Uuid,
         amount: Amount,
         unit: CurrencyUnit,
         description: Option<String>,
@@ -140,17 +137,16 @@ pub trait WalletApi: SendSync {
         now: u64,
     ) -> Result<(Uuid, Option<Token>)>;
     async fn is_nostr_connected(&self) -> bool;
+    async fn fetch_nostr_relays(
+        &self,
+        npub: nostr::PublicKey,
+        relays: Vec<RelayUrl>,
+    ) -> Result<Vec<RelayUrl>>;
     async fn delete(&self) -> Result<()>;
-    // contacts
-    async fn add_contact(&self, node_id: NodeId, name: Name) -> Result<()>;
-    async fn edit_contact(&self, node_id: NodeId, name: Name) -> Result<()>;
-    async fn delete_contact(&self, node_id: NodeId) -> Result<()>;
-    async fn get_contact(&self, node_id: NodeId) -> Result<Option<Contact>>;
-    async fn list_contacts(&self, search_term: Option<String>) -> Result<Vec<Contact>>;
     // pending payment requests
     async fn request_payment_from_contact(
         &self,
-        node_id: NodeId,
+        contact_id: Uuid,
         amount: Amount,
         unit: CurrencyUnit,
         description: Option<String>,
@@ -218,10 +214,6 @@ impl WalletApi for super::Wallet {
 
     fn mint_url(&self) -> url::Url {
         self.client.mint_url().to_owned()
-    }
-
-    fn nostr_relays(&self) -> Vec<RelayUrl> {
-        self.nostr_transport.relays().to_owned()
     }
 
     async fn estimate_melt(&self, amount: bitcoin::Amount) -> Result<MeltEstimation> {
@@ -577,13 +569,17 @@ impl WalletApi for super::Wallet {
                 Ok((tx_id, None))
             }
             WalletPaymentType::Contact {
-                node_id,
+                contact_id,
                 payment_request_id,
             } => {
-                self.refresh_contact_relays(&node_id).await;
-                let Ok(Some(contact)) = self.contact_repo.get_contact(node_id.clone()).await else {
-                    return Err(Error::ContactNotFound(node_id));
+                self.refresh_contact_relays(&contact_id).await;
+                let Ok(Some(contact)) = self.contact_repo.get_contact(contact_id).await
+                else {
+                    return Err(Error::ContactNotFound(contact_id.to_string()));
                 };
+                if contact.node_id.is_none() {
+                    return Err(Error::ContactMustHaveNodeId(contact.id.to_string()));
+                }
 
                 let proofs = self
                     .debit
@@ -609,7 +605,7 @@ impl WalletApi for super::Wallet {
                     btc_tx_id: None,
                     quote_id: None,
                     nostr_event_id: None,
-                    contact_node_id: Some(node_id),
+                    contact_node_id: contact.node_id.clone(),
                     linked_txs: vec![],
                 };
                 let tx_id = self
@@ -1066,7 +1062,7 @@ impl WalletApi for super::Wallet {
 
     async fn prepare_pay_to_contact(
         &self,
-        node_id: NodeId,
+        contact_id: Uuid,
         amount: Amount,
         unit: CurrencyUnit,
         description: Option<String>,
@@ -1075,15 +1071,13 @@ impl WalletApi for super::Wallet {
             return Err(Error::InvalidCurrencyUnit(unit.to_string()));
         }
 
-        if self
-            .contact_repo
-            .get_contact(node_id.clone())
-            .await?
-            .is_none()
-        {
-            return Err(Error::ContactNotFound(node_id));
+        let Some(contact) = self.contact_repo.get_contact(contact_id).await? else {
+            return Err(Error::ContactNotFound(contact_id.to_string()));
+        };
+        if contact.node_id.is_none() {
+            return Err(Error::ContactMustHaveNodeId(contact.id.to_string()));
         }
-        self.refresh_contact_relays(&node_id).await;
+        self.refresh_contact_relays(&contact.id).await;
 
         let infos = self.get_wallet_mint_keyset_infos().await?;
 
@@ -1095,7 +1089,7 @@ impl WalletApi for super::Wallet {
             unit: summary.unit.clone(),
             fees: summary.fees,
             ptype: WalletPaymentType::Contact {
-                node_id,
+                contact_id,
                 payment_request_id: None,
             },
             memo: description,
@@ -1247,6 +1241,15 @@ impl WalletApi for super::Wallet {
             && *self.nostr_consumer_running.lock().await
     }
 
+    async fn fetch_nostr_relays(
+        &self,
+        npub: nostr::PublicKey,
+        relays: Vec<RelayUrl>,
+    ) -> Result<Vec<RelayUrl>> {
+        let res = self.nostr_transport.fetch_relay_list(npub, relays).await?;
+        Ok(res)
+    }
+
     async fn delete(&self) -> Result<()> {
         // shut down nostr client
         self.nostr_transport.shutdown().await;
@@ -1286,78 +1289,20 @@ impl WalletApi for super::Wallet {
         Ok(())
     }
 
-    async fn add_contact(&self, node_id: NodeId, name: Name) -> Result<()> {
-        let my_relays = self.nostr_relays();
-        // fetch relay list for the contact from nostr, falling back to our relays
-        let mut fetched_relay_list = self
-            .nostr_transport
-            .fetch_relay_list(node_id.npub(), my_relays.clone())
-            .await
-            .unwrap_or(my_relays.clone());
-
-        if fetched_relay_list.is_empty() {
-            fetched_relay_list = my_relays;
-        }
-
-        let contact = Contact {
-            node_id: node_id.clone(),
-            name,
-            nostr_relays: fetched_relay_list,
-        };
-        match self.contact_repo.add_contact(contact).await {
-            Ok(()) => Ok(()),
-            Err(bcr_wallet_persistence::error::Error::ContactAlreadyExists(_)) => {
-                Err(Error::ContactAlreadyExists(node_id))
-            }
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    async fn edit_contact(&self, node_id: NodeId, name: Name) -> Result<()> {
-        match self.contact_repo.edit_contact(node_id.clone(), name).await {
-            Ok(()) => Ok(()),
-            Err(bcr_wallet_persistence::error::Error::ContactNotFound(_)) => {
-                Err(Error::ContactNotFound(node_id))
-            }
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    async fn delete_contact(&self, node_id: NodeId) -> Result<()> {
-        if self
-            .contact_repo
-            .get_contact(node_id.clone())
-            .await?
-            .is_some()
-        {
-            self.contact_repo.delete_contact(node_id).await?;
-        } else {
-            return Err(Error::ContactNotFound(node_id));
-        }
-        Ok(())
-    }
-
-    async fn get_contact(&self, node_id: NodeId) -> Result<Option<Contact>> {
-        let contact = self.contact_repo.get_contact(node_id).await?;
-        Ok(contact)
-    }
-
-    async fn list_contacts(&self, search_term: Option<String>) -> Result<Vec<Contact>> {
-        let contacts = self.contact_repo.list_contacts(search_term).await?;
-        Ok(contacts)
-    }
-
     async fn request_payment_from_contact(
         &self,
-        node_id: NodeId,
+        contact_id: Uuid,
         amount: Amount,
         unit: CurrencyUnit,
         description: Option<String>,
         deadline: Option<u64>,
     ) -> Result<Uuid> {
-        self.refresh_contact_relays(&node_id).await;
-        let Ok(Some(contact)) = self.contact_repo.get_contact(node_id.clone()).await else {
-            return Err(Error::ContactNotFound(node_id));
+        self.refresh_contact_relays(&contact_id).await;
+        let Ok(Some(contact)) = self.contact_repo.get_contact(contact_id).await else {
+            return Err(Error::ContactNotFound(contact_id.to_string()));
+        };
+        let Some(ref node_id) = contact.node_id else {
+            return Err(Error::ContactMustHaveNodeId(contact.id.to_string()));
         };
         let payload = ContactPaymentRequestPayload::new(
             self.node_id(),
@@ -1373,6 +1318,9 @@ impl WalletApi for super::Wallet {
             bcr_wallet_core::event::Event::new_contact_payment_request(payload).try_into()?;
         let payload = base58::encode(&borsh::to_vec(&event)?);
         let target = self.nostr_transport.nip19_for_contact(&contact).await?;
+        let Some(target) = target else {
+            return Err(Error::ContactMustHaveNodeId(contact.id.to_string()));
+        };
         match self
             .nostr_transport
             .send_private_msg(target.clone(), payload.clone())
@@ -1398,7 +1346,7 @@ impl WalletApi for super::Wallet {
         };
         let outgoing_payment_request = PaymentRequest {
             id: payment_req_id,
-            node_id,
+            node_id: node_id.to_owned(),
             amount,
             unit,
             description,
@@ -1510,14 +1458,13 @@ impl WalletApi for super::Wallet {
             return Err(Error::PaymentRequestInWrongState(payment_req_id));
         }
         // has to be added to contacts to pay the payment request
-        if self
+        let contacts_by_node_id = self
             .contact_repo
-            .get_contact(req.node_id.clone())
-            .await?
-            .is_none()
-        {
-            return Err(Error::ContactNotFound(req.node_id));
-        }
+            .get_contacts_by_node_id(req.node_id.clone())
+            .await?;
+        let Some(first_node_id_contact) = contacts_by_node_id.first() else {
+            return Err(Error::ContactNotFound(req.node_id.to_string()));
+        };
         let infos = self.get_wallet_mint_keyset_infos().await?;
 
         let s_summary = self.debit.prepare_send(req.amount, &infos).await?;
@@ -1528,7 +1475,7 @@ impl WalletApi for super::Wallet {
             unit: summary.unit.clone(),
             fees: summary.fees,
             ptype: WalletPaymentType::Contact {
-                node_id: req.node_id,
+                contact_id: first_node_id_contact.id,
                 payment_request_id: Some(req.id),
             },
             memo: req.description,

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -53,7 +53,7 @@ pub struct Wallet {
     mint_keyset_infos: HashMap<cashu::Id, KeySetInfo>,
     beta_clients: HashMap<url::Url, Arc<dyn ClowderMintConnector>>,
     tx_repo: Box<dyn TransactionRepository>,
-    contact_repo: Box<dyn ContactStoreApi>,
+    contact_repo: Arc<dyn ContactStoreApi>,
     payment_request_repo: Box<dyn PaymentRequestStoreApi>,
     debit: Box<dyn DebitPocketApi>,
     name: String,
@@ -77,7 +77,7 @@ impl Wallet {
         client: Arc<dyn ClowderMintConnector>,
         mint_keyset_infos: HashMap<cashu::Id, KeySetInfo>,
         tx_repo: Box<dyn TransactionRepository>,
-        contact_repo: Box<dyn ContactStoreApi>,
+        contact_repo: Arc<dyn ContactStoreApi>,
         payment_request_repo: Box<dyn PaymentRequestStoreApi>,
         debit: Box<dyn DebitPocketApi>,
         name: String,
@@ -977,6 +977,9 @@ impl Wallet {
             bcr_wallet_core::event::Event::new_contact_payment(payload).try_into()?;
         let payload = base58::encode(&borsh::to_vec(&event)?);
         let target = nostr_cl.nip19_for_contact(&contact).await?;
+        let Some(target) = target else {
+            return Err(Error::ContactMustHaveNodeId(contact.id.to_string()));
+        };
 
         let event_id = match nostr_cl
             .send_private_msg(target.clone(), payload.clone())
@@ -1075,14 +1078,13 @@ impl Wallet {
     }
 
     // refresh relays for a given contact and update if necessary
-    async fn refresh_contact_relays(&self, node_id: &NodeId) {
-        if node_id.network() != self.network() {
-            tracing::warn!("Tried to ensure nostr contact for a different network {node_id}");
-            return;
-        }
-
-        let Ok(Some(existing_contact)) = self.contact_repo.get_contact(node_id.to_owned()).await
+    async fn refresh_contact_relays(&self, contact_id: &Uuid) {
+        let Ok(Some(existing_contact)) = self.contact_repo.get_contact(contact_id.to_owned()).await
         else {
+            return;
+        };
+
+        let Some(node_id) = existing_contact.node_id else {
             return;
         };
 
@@ -1099,7 +1101,7 @@ impl Wallet {
         if !fetched_relays.is_empty()
             && let Err(e) = self
                 .contact_repo
-                .edit_contact_relays(node_id.to_owned(), fetched_relays)
+                .edit_contact_relays(contact_id.to_owned(), fetched_relays)
                 .await
         {
             tracing::warn!("Could not update relays for contact {node_id}: {e}");
@@ -1163,8 +1165,11 @@ mod tests {
 
     fn test_contact() -> Contact {
         Contact {
-            node_id: node_id(NODE_ID_1),
-            name: name("Minka"),
+            id: Uuid::new_v4(),
+            node_id: Some(node_id(NODE_ID_1)),
+            email: None,
+            name: Some(name("Minka")),
+            company: None,
             nostr_relays: vec![],
         }
     }
@@ -1251,7 +1256,7 @@ mod tests {
             arc_client,
             HashMap::new(),
             Box::new(ctx.tx_repo),
-            Box::new(ctx.contact_repo),
+            Arc::new(ctx.contact_repo),
             Box::new(ctx.payment_request_repo),
             Box::new(ctx.debit),
             "wallet-1".to_owned(),
@@ -2096,13 +2101,15 @@ mod tests {
             .expect_nip19_for_contact()
             .times(1)
             .returning(|_| {
-                Ok(Nip19Profile::new(
-                    PublicKey::from_byte_array([0u8; 32]),
-                    vec![RelayUrl::from_str("wss://test.example.com").unwrap()],
-                )
-                .to_bech32()
-                .unwrap()
-                .to_string())
+                Ok(Some(
+                    Nip19Profile::new(
+                        PublicKey::from_byte_array([0u8; 32]),
+                        vec![RelayUrl::from_str("wss://test.example.com").unwrap()],
+                    )
+                    .to_bech32()
+                    .unwrap()
+                    .to_string(),
+                ))
             });
 
         ctx.nostr_transport
@@ -2136,7 +2143,7 @@ mod tests {
             unit: CurrencyUnit::Sat,
             fees: cashu::Amount::ZERO,
             ptype: WalletPaymentType::Contact {
-                node_id: node_id(NODE_ID_1),
+                contact_id: Uuid::new_v4(),
                 payment_request_id: None,
             },
             memo: Some("contact memo".to_string()),
@@ -2602,66 +2609,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_contacts() {
-        let mut ctx = wallet_ctx();
-
-        ctx.nostr_transport
-            .expect_relays()
-            .return_const(vec![RelayUrl::from_str("wss://test.example.com").unwrap()]);
-
-        ctx.nostr_transport
-            .expect_fetch_relay_list()
-            .returning(|_, _| Ok(vec![]));
-
-        ctx.contact_repo
-            .expect_add_contact()
-            .times(1)
-            .returning(|_| Ok(()));
-        ctx.contact_repo
-            .expect_edit_contact()
-            .times(1)
-            .returning(|_, _| Ok(()));
-        ctx.contact_repo
-            .expect_delete_contact()
-            .times(1)
-            .returning(|_| Ok(()));
-        ctx.contact_repo
-            .expect_get_contact()
-            .times(1)
-            .returning(|_| Ok(Some(test_contact())));
-        ctx.contact_repo
-            .expect_list_contacts()
-            .times(1)
-            .returning(|_| Ok(vec![test_contact()]));
-
-        let wlt = wallet(ctx).await;
-        wlt.read()
-            .await
-            .add_contact(node_id(NODE_ID_1), name("Minka"))
-            .await
-            .expect("create contact works");
-
-        wlt.read()
-            .await
-            .edit_contact(node_id(NODE_ID_1), name("Nala"))
-            .await
-            .expect("edit contact works");
-
-        wlt.read()
-            .await
-            .delete_contact(node_id(NODE_ID_1))
-            .await
-            .expect("delete contact works");
-        let cts = wlt
-            .read()
-            .await
-            .list_contacts(None)
-            .await
-            .expect("list contacts works");
-        assert!(cts.len() == 1);
-    }
-
-    #[tokio::test]
     async fn test_req_payment_from_contact() {
         let mut ctx = wallet_ctx();
 
@@ -2677,13 +2624,15 @@ mod tests {
             .expect_nip19_for_contact()
             .times(1)
             .returning(|_| {
-                Ok(Nip19Profile::new(
-                    PublicKey::from_byte_array([0u8; 32]),
-                    vec![RelayUrl::from_str("wss://test.example.com").unwrap()],
-                )
-                .to_bech32()
-                .unwrap()
-                .to_string())
+                Ok(Some(
+                    Nip19Profile::new(
+                        PublicKey::from_byte_array([0u8; 32]),
+                        vec![RelayUrl::from_str("wss://test.example.com").unwrap()],
+                    )
+                    .to_bech32()
+                    .unwrap()
+                    .to_string(),
+                ))
             });
         ctx.contact_repo
             .expect_get_contact()
@@ -2703,7 +2652,7 @@ mod tests {
             .read()
             .await
             .request_payment_from_contact(
-                node_id(NODE_ID_1),
+                Uuid::new_v4(),
                 Amount::from(100),
                 CurrencyUnit::Sat,
                 None,
@@ -2751,23 +2700,6 @@ mod tests {
         assert_eq!(
             wlt.read().await.node_id(),
             NodeId::new(test_pub_key(), bitcoin::Network::Testnet)
-        );
-    }
-
-    #[tokio::test]
-    async fn test_nostr_relays() {
-        let mut ctx = wallet_ctx();
-
-        ctx.nostr_transport
-            .expect_relays()
-            .times(1)
-            .return_const(vec![RelayUrl::from_str("wss://test.example.com").unwrap()]);
-
-        let wlt = wallet(ctx).await;
-
-        assert_eq!(
-            wlt.read().await.nostr_relays(),
-            vec![RelayUrl::from_str("wss://test.example.com").unwrap()]
         );
     }
 
@@ -3203,9 +3135,9 @@ mod tests {
             .returning(move |_| Ok(Some(req.clone())));
 
         ctx.contact_repo
-            .expect_get_contact()
+            .expect_get_contacts_by_node_id()
             .times(1)
-            .returning(|_| Ok(None));
+            .returning(|_| Ok(vec![]));
 
         let wlt = wallet(ctx).await;
 
@@ -3217,7 +3149,7 @@ mod tests {
             .unwrap_err();
 
         match err {
-            Error::ContactNotFound(id) => assert_eq!(id, missing_node_id),
+            Error::ContactNotFound(id) => assert_eq!(id, missing_node_id.to_string()),
             other => panic!("unexpected error: {other:?}"),
         }
     }
@@ -3225,6 +3157,7 @@ mod tests {
     #[tokio::test]
     async fn test_prepare_pay_to_contact_errors_if_contact_missing() {
         let mut ctx = wallet_ctx();
+        let contact_id = Uuid::new_v4();
 
         ctx.debit
             .expect_unit()
@@ -3241,17 +3174,12 @@ mod tests {
         let err = wlt
             .read()
             .await
-            .prepare_pay_to_contact(
-                node_id(NODE_ID_1),
-                Amount::from(321),
-                CurrencyUnit::Sat,
-                None,
-            )
+            .prepare_pay_to_contact(contact_id, Amount::from(321), CurrencyUnit::Sat, None)
             .await
             .unwrap_err();
 
         match err {
-            Error::ContactNotFound(id) => assert_eq!(id, node_id(NODE_ID_1)),
+            Error::ContactNotFound(id) => assert_eq!(id, contact_id.to_string()),
             other => panic!("unexpected error: {other:?}"),
         }
     }
@@ -3260,6 +3188,7 @@ mod tests {
     async fn test_prepare_pay_payment_request_success_sets_contact_payment_reference() {
         let mut ctx = wallet_ctx();
         let req_id = Uuid::new_v4();
+        let test_contact = test_contact();
 
         let req = payment_request_with(
             req_id,
@@ -3275,10 +3204,11 @@ mod tests {
                 Ok(Some(req.clone()))
             });
 
+        let tc_clone = test_contact.clone();
         ctx.contact_repo
-            .expect_get_contact()
+            .expect_get_contacts_by_node_id()
             .times(1)
-            .returning(|_| Ok(Some(test_contact())));
+            .returning(move |_| Ok(vec![tc_clone.clone()]));
 
         ctx.client
             .expect_get_mint_keysets()
@@ -3310,10 +3240,10 @@ mod tests {
 
         match &p.ptype {
             WalletPaymentType::Contact {
-                node_id,
+                contact_id,
                 payment_request_id,
             } => {
-                assert_eq!(node_id, &self::node_id(NODE_ID_1));
+                assert_eq!(contact_id, &test_contact.id);
                 assert_eq!(payment_request_id, &Some(req_id));
             }
             _ => panic!("unexpected payment type"),

--- a/crates/bcr-wallet-api/src/wallet/test_utils.rs
+++ b/crates/bcr-wallet-api/src/wallet/test_utils.rs
@@ -12,7 +12,7 @@ pub mod tests {
         impl TransportApi for Transport {
             async fn send_private_msg(&self, target: String, payload: String) -> Result<EventId>;
             async fn cdk18_transport(&self) -> Result<cdk18::Transport>;
-            async fn nip19_for_contact(&self, contact: &Contact) -> Result<String>;
+            async fn nip19_for_contact(&self, contact: &Contact) -> Result<Option<String>>;
             async fn shutdown(&self);
             fn relays(&self) -> &[RelayUrl];
             async fn has_connected_relays(&self) -> bool;

--- a/crates/bcr-wallet-api/src/wallet/types.rs
+++ b/crates/bcr-wallet-api/src/wallet/types.rs
@@ -21,7 +21,7 @@ pub enum WalletPaymentType {
     OnChain,
     Token,
     Contact {
-        node_id: NodeId,
+        contact_id: Uuid,
         payment_request_id: Option<Uuid>,
     },
 }

--- a/crates/bcr-wallet-api/src/wallet/util.rs
+++ b/crates/bcr-wallet-api/src/wallet/util.rs
@@ -176,6 +176,17 @@ pub fn tx_can_be_refreshed(tx: &Transaction) -> bool {
     true
 }
 
+pub fn update_optional_field<T: Clone + PartialEq>(
+    field_to_update: &mut Option<T>,
+    field: &Option<T>,
+    changed: &mut bool,
+) {
+    if field_to_update != field {
+        *field_to_update = field.clone();
+        *changed = true;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,6 +195,7 @@ mod tests {
         core_tests,
     };
     use bcr_wallet_core::{
+        name::Name,
         types::{PaymentType, TransactionStatus},
         util::to_mint_url,
     };
@@ -338,5 +350,49 @@ mod tests {
             contact_node_id: None,
             linked_txs: vec![],
         }
+    }
+
+    #[test]
+    fn update_optional_field_baseline() {
+        let mut field_to_update = Some(String::from("hi"));
+        let mut changed = false;
+        update_optional_field(
+            &mut field_to_update,
+            &Some(String::from("hello")),
+            &mut changed,
+        );
+        assert!(changed);
+        assert_eq!(Some(String::from("hello")), field_to_update);
+    }
+
+    #[test]
+    fn update_optional_field_same() {
+        let mut field_to_update = Some(String::from("hello"));
+        let mut changed = false;
+        update_optional_field(
+            &mut field_to_update,
+            &Some(String::from("hello")),
+            &mut changed,
+        );
+        assert!(!changed);
+        assert_eq!(Some(String::from("hello")), field_to_update);
+    }
+
+    #[test]
+    fn update_optional_field_none() {
+        let mut field_to_update: Option<Name> = None;
+        let mut changed = false;
+        update_optional_field(&mut field_to_update, &None, &mut changed);
+        assert!(!changed);
+        assert_eq!(None, field_to_update);
+    }
+
+    #[test]
+    fn update_optional_field_some_none() {
+        let mut field_to_update = Some(String::from("hi"));
+        let mut changed = false;
+        update_optional_field(&mut field_to_update, &None, &mut changed);
+        assert!(changed);
+        assert_eq!(None, field_to_update);
     }
 }

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -291,13 +291,13 @@ pub async fn cmd_pay_to_contact(
     app_state: &AppState,
     name: &str,
     id: &str,
-    node_id: &str,
+    contact_id: &str,
     amount: u64,
     description: Option<String>,
 ) -> Result<String> {
     let mut res = String::new();
     let payment_summary = app_state
-        .wallet_prepare_pay_to_contact(id.to_owned(), node_id.to_owned(), amount, description)
+        .wallet_prepare_pay_to_contact(id.to_owned(), contact_id.to_owned(), amount, description)
         .await?;
 
     info!(
@@ -311,7 +311,7 @@ pub async fn cmd_pay_to_contact(
     push_break(&mut res);
     push_break(&mut res);
     res.push_str(&format!(
-        "Pay to Contact {node_id} for {name}, Wallet ID: {id}.\n"
+        "Pay to Contact {contact_id} for {name}, Wallet ID: {id}.\n"
     ));
     push_break(&mut res);
     res.push_str(&format!("Payment Summary: {}", payment_summary.request_id));
@@ -620,17 +620,23 @@ pub async fn cmd_edit_tx_memo(
 pub async fn cmd_add_contact(
     app_state: &AppState,
     name: &str,
-    id: &str,
-    node_id: &str,
+    network: bitcoin::Network,
     contact_name: &str,
+    contact_node_id: &str,
 ) -> Result<String> {
     let mut res = String::new();
-    app_state
-        .wallet_add_contact(id.to_owned(), node_id.to_owned(), contact_name.to_owned())
+    let contact_id = app_state
+        .purse_add_contact(
+            network.to_string(),
+            Some(contact_node_id.to_owned()),
+            None,
+            Some(contact_name.to_owned()),
+            None,
+        )
         .await?;
     push_break(&mut res);
     push_break(&mut res);
-    res.push_str(&format!("Added Contact for {node_id} for {name}:\n"));
+    res.push_str(&format!("Added Contact for {contact_id} for {name}:\n"));
     push_break(&mut res);
     Ok(res)
 }
@@ -638,17 +644,43 @@ pub async fn cmd_add_contact(
 pub async fn cmd_edit_contact(
     app_state: &AppState,
     name: &str,
-    id: &str,
-    node_id: &str,
+    network: bitcoin::Network,
+    contact_id: &str,
+    contact_node_id: &str,
+    contact_email: &str,
     contact_name: &str,
+    contact_company: &str,
 ) -> Result<String> {
     let mut res = String::new();
     app_state
-        .wallet_edit_contact(id.to_owned(), node_id.to_owned(), contact_name.to_owned())
+        .purse_edit_contact(
+            network.to_string(),
+            contact_id.to_owned(),
+            if contact_node_id == "None" {
+                None
+            } else {
+                Some(contact_node_id.to_owned())
+            },
+            if contact_email == "None" {
+                None
+            } else {
+                Some(contact_email.to_owned())
+            },
+            if contact_name == "None" {
+                None
+            } else {
+                Some(contact_name.to_owned())
+            },
+            if contact_company == "None" {
+                None
+            } else {
+                Some(contact_company.to_owned())
+            },
+        )
         .await?;
     push_break(&mut res);
     push_break(&mut res);
-    res.push_str(&format!("Edited Contact for {node_id} for {name}:\n"));
+    res.push_str(&format!("Edited Contact for {contact_id} for {name}:\n"));
     push_break(&mut res);
     Ok(res)
 }
@@ -656,16 +688,16 @@ pub async fn cmd_edit_contact(
 pub async fn cmd_delete_contact(
     app_state: &AppState,
     name: &str,
-    id: &str,
-    node_id: &str,
+    network: bitcoin::Network,
+    contact_id: &str,
 ) -> Result<String> {
     let mut res = String::new();
     app_state
-        .wallet_delete_contact(id.to_owned(), node_id.to_owned())
+        .purse_delete_contact(network.to_string(), contact_id.to_owned())
         .await?;
     push_break(&mut res);
     push_break(&mut res);
-    res.push_str(&format!("Deleted Contact for {node_id} for {name}:\n"));
+    res.push_str(&format!("Deleted Contact for {contact_id} for {name}:\n"));
     push_break(&mut res);
     Ok(res)
 }
@@ -673,19 +705,25 @@ pub async fn cmd_delete_contact(
 pub async fn cmd_get_contact(
     app_state: &AppState,
     name: &str,
-    id: &str,
-    node_id: &str,
+    network: bitcoin::Network,
+    contact_id: &str,
 ) -> Result<String> {
     let mut res = String::new();
     let contact = app_state
-        .wallet_get_contact(id.to_owned(), node_id.to_owned())
+        .purse_get_contact(network.to_string(), contact_id.to_owned())
         .await?;
     push_break(&mut res);
     push_break(&mut res);
-    res.push_str(&format!("Contact for node_id: {node_id} for {name}:\n"));
     res.push_str(&format!(
-        "NodeId: {} Name: {}\n",
-        contact.node_id, contact.name
+        "Contact for contact_id: {contact_id} for {name}:\n"
+    ));
+    res.push_str(&format!(
+        "ContactId: {} Name: {:?}, Node_id: {}, Email: {:?}, Company: {:?}\n",
+        contact.id,
+        contact.name,
+        contact.node_id.map(|n| n.to_string()).unwrap_or_default(),
+        contact.email,
+        contact.company
     ));
     push_break(&mut res);
     Ok(res)
@@ -694,12 +732,12 @@ pub async fn cmd_get_contact(
 pub async fn cmd_list_contacts(
     app_state: &AppState,
     name: &str,
-    id: &str,
+    network: bitcoin::Network,
     search_term: &Option<String>,
 ) -> Result<String> {
     let mut res = String::new();
     let contacts = app_state
-        .wallet_list_contacts(id.to_owned(), search_term.to_owned())
+        .purse_list_contacts(network.to_string(), search_term.to_owned())
         .await?;
     push_break(&mut res);
     push_break(&mut res);
@@ -708,7 +746,14 @@ pub async fn cmd_list_contacts(
     ));
     push_break(&mut res);
     for c in contacts {
-        res.push_str(&format!("NodeId: {} Name: {}\n", c.node_id, c.name));
+        res.push_str(&format!(
+            "ContactId: {} Name: {:?}, Node_id: {}, Email: {:?}, Company: {:?}\n",
+            c.id,
+            c.name,
+            c.node_id.map(|n| n.to_string()).unwrap_or_default(),
+            c.email,
+            c.company
+        ));
         push_break(&mut res);
     }
     push_break(&mut res);
@@ -719,17 +764,23 @@ pub async fn cmd_request_payment_from_contact(
     app_state: &AppState,
     name: &str,
     id: &str,
-    node_id: &str,
+    contact_id: &str,
     amount: u64,
 ) -> Result<String> {
     let mut res = String::new();
     app_state
-        .wallet_request_payment_from_contact(id.to_owned(), node_id.to_owned(), amount, None, None)
+        .wallet_request_payment_from_contact(
+            id.to_owned(),
+            contact_id.to_owned(),
+            amount,
+            None,
+            None,
+        )
         .await?;
     push_break(&mut res);
     push_break(&mut res);
     res.push_str(&format!(
-        "Request Payment over {amount} from Contact {node_id} for {name}:\n"
+        "Request Payment over {amount} from Contact {contact_id} for {name}:\n"
     ));
     push_break(&mut res);
     Ok(res)

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -74,7 +74,7 @@ enum Commands {
     #[command(name = "pay_to_contact")]
     PayToContact {
         id: String,
-        node_id: String,
+        contact_id: String,
         amount: u64,
         description: Option<String>,
     },
@@ -126,29 +126,38 @@ enum Commands {
     },
     #[command(name = "add_contact")]
     AddContact {
-        id: String,
-        node_id: String,
+        network: bitcoin::Network,
         name: String,
+        node_id: String,
     },
     #[command(name = "edit_contact")]
     EditContact {
-        id: String,
+        network: bitcoin::Network,
+        contact_id: String,
         node_id: String,
+        email: String,
         name: String,
+        company: String,
     },
     #[command(name = "delete_contact")]
-    DeleteContact { id: String, node_id: String },
+    DeleteContact {
+        network: bitcoin::Network,
+        contact_id: String,
+    },
     #[command(name = "get_contact")]
-    GetContact { id: String, node_id: String },
+    GetContact {
+        network: bitcoin::Network,
+        contact_id: String,
+    },
     #[command(name = "list_contacts")]
     ListContacts {
-        id: String,
+        network: bitcoin::Network,
         search_term: Option<String>,
     },
     #[command(name = "req_payment_from_contact")]
     RequestPaymentFromContact {
         id: String,
-        node_id: String,
+        contact_id: String,
         amount: u64,
     },
     #[command(name = "subscribe_to_prs")]
@@ -301,18 +310,18 @@ async fn main() -> Result<()> {
         }
         Commands::PayToContact {
             id,
-            node_id,
+            contact_id,
             amount,
             description,
         } => {
             info!(
-                "Payment to Contact {node_id} for {}: {}, Amount: {amount}, Description: {description:?}",
+                "Payment to Contact {contact_id} for {}: {}, Amount: {amount}, Description: {description:?}",
                 cli.wallet,
                 command::cmd_pay_to_contact(
                     &app_state,
                     &cli.wallet,
                     &id,
-                    &node_id,
+                    &contact_id,
                     amount,
                     description.clone()
                 )
@@ -427,44 +436,74 @@ async fn main() -> Result<()> {
                 command::cmd_edit_tx_memo(&app_state, &cli.wallet, &id, &tx_id, &new_memo).await?
             );
         }
-        Commands::AddContact { id, node_id, name } => {
+        Commands::AddContact {
+            network,
+            name,
+            node_id,
+        } => {
             info!(
                 "Add Contact for {}: {}",
                 cli.wallet,
-                command::cmd_add_contact(&app_state, &cli.wallet, &id, &node_id, &name).await?
+                command::cmd_add_contact(&app_state, &cli.wallet, network, &node_id, &name).await?
             );
         }
-        Commands::EditContact { id, node_id, name } => {
+        Commands::EditContact {
+            network,
+            contact_id,
+            node_id,
+            email,
+            name,
+            company,
+        } => {
             info!(
                 "Edit Contact for {}: {}",
                 cli.wallet,
-                command::cmd_edit_contact(&app_state, &cli.wallet, &id, &node_id, &name).await?
+                command::cmd_edit_contact(
+                    &app_state,
+                    &cli.wallet,
+                    network,
+                    &contact_id,
+                    &node_id,
+                    &email,
+                    &name,
+                    &company
+                )
+                .await?
             );
         }
-        Commands::DeleteContact { id, node_id } => {
+        Commands::DeleteContact {
+            network,
+            contact_id,
+        } => {
             info!(
                 "Delete Contact for {}: {}",
                 cli.wallet,
-                command::cmd_delete_contact(&app_state, &cli.wallet, &id, &node_id).await?
+                command::cmd_delete_contact(&app_state, &cli.wallet, network, &contact_id).await?
             );
         }
-        Commands::GetContact { id, node_id } => {
+        Commands::GetContact {
+            network,
+            contact_id,
+        } => {
             info!(
                 "Get Contact for {}: {}",
                 cli.wallet,
-                command::cmd_get_contact(&app_state, &cli.wallet, &id, &node_id).await?
+                command::cmd_get_contact(&app_state, &cli.wallet, network, &contact_id).await?
             );
         }
-        Commands::ListContacts { id, search_term } => {
+        Commands::ListContacts {
+            network,
+            search_term,
+        } => {
             info!(
                 "List Contacts for {}: {}",
                 cli.wallet,
-                command::cmd_list_contacts(&app_state, &cli.wallet, &id, &search_term).await?
+                command::cmd_list_contacts(&app_state, &cli.wallet, network, &search_term).await?
             );
         }
         Commands::RequestPaymentFromContact {
             id,
-            node_id,
+            contact_id,
             amount,
         } => {
             info!(
@@ -474,7 +513,7 @@ async fn main() -> Result<()> {
                     &app_state,
                     &cli.wallet,
                     &id,
-                    &node_id,
+                    &contact_id,
                     amount
                 )
                 .await?

--- a/crates/bcr-wallet-core/Cargo.toml
+++ b/crates/bcr-wallet-core/Cargo.toml
@@ -12,6 +12,7 @@ bitcoin.workspace = true
 borsh.workspace = true
 chrono = {workspace = true}
 ecies.workspace = true
+email_address = { version = "0.2", default-features = false }
 nostr = {workspace = true}
 serde.workspace = true
 strum = {workspace = true, features = ["derive"]}

--- a/crates/bcr-wallet-core/src/contact.rs
+++ b/crates/bcr-wallet-core/src/contact.rs
@@ -1,10 +1,55 @@
-use crate::name::Name;
+use crate::{ValidationError, email::Email, name::Name};
 use bcr_common::core::NodeId;
 use nostr::types::RelayUrl;
+use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct Contact {
-    pub node_id: NodeId,
-    pub name: Name,
+    pub id: Uuid,
+    pub node_id: Option<NodeId>,
+    pub email: Option<Email>,
+    pub name: Option<Name>,
+    pub company: Option<Name>,
     pub nostr_relays: Vec<RelayUrl>,
+}
+
+impl Contact {
+    /// Creates and validates a new contact
+    pub fn new(
+        node_id: Option<NodeId>,
+        email: Option<Email>,
+        name: Option<Name>,
+        company: Option<Name>,
+        nostr_relays: Vec<RelayUrl>,
+    ) -> Result<Self, ValidationError> {
+        let contact = Self {
+            id: Uuid::new_v4(),
+            node_id,
+            email,
+            name,
+            company,
+            nostr_relays,
+        };
+        contact.validate()?;
+        Ok(contact)
+    }
+
+    /// Validation for a Contact
+    /// Either e-mail or node_id need to be set (or both)
+    /// Either name or company need to be set (or both)
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.email.is_none() && self.node_id.is_none() {
+            return Err(ValidationError::InvalidContact(
+                "Either E-Mail or NodeId have to be set".to_string(),
+            ));
+        }
+
+        if self.name.is_none() && self.company.is_none() {
+            return Err(ValidationError::InvalidContact(
+                "Either Name or Company have to be set".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
 }

--- a/crates/bcr-wallet-core/src/email.rs
+++ b/crates/bcr-wallet-core/src/email.rs
@@ -1,0 +1,94 @@
+use serde::{Deserialize, Serialize};
+use std::{fmt::Display, str::FromStr};
+
+use crate::ValidationError;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, Hash)]
+#[serde(try_from = "String", into = "String")]
+pub struct Email(String);
+
+impl Email {
+    pub fn new(n: impl Into<String>) -> Result<Self, ValidationError> {
+        let s = n.into();
+        if s.trim().is_empty() {
+            return Err(ValidationError::EmptyEmail);
+        }
+
+        if !email_address::EmailAddress::is_valid(&s) {
+            return Err(ValidationError::InvalidEmail);
+        }
+
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for Email {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for Email {
+    type Err = ValidationError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Email::new(s)
+    }
+}
+
+impl TryFrom<String> for Email {
+    type Error = ValidationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl From<Email> for String {
+    fn from(value: Email) -> Self {
+        value.0
+    }
+}
+
+impl borsh::BorshSerialize for Email {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        borsh::BorshSerialize::serialize(&self.0, writer)
+    }
+}
+
+impl borsh::BorshDeserialize for Email {
+    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let email_str: String = borsh::BorshDeserialize::deserialize_reader(reader)?;
+        Email::new(&email_str).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_email() {
+        let n = Email::new("test@example.com").expect("works");
+        let n_owned = Email::new(String::from("test@example.com")).expect("works");
+        assert_eq!(n, n_owned);
+
+        assert!(matches!(
+            Email::new("totally@$$$12312@sdfds.com"),
+            Err(ValidationError::InvalidEmail)
+        ));
+        assert!(matches!(
+            Email::new("12312"),
+            Err(ValidationError::InvalidEmail)
+        ));
+        assert!(matches!(Email::new(""), Err(ValidationError::EmptyEmail)));
+        assert!(matches!(
+            Email::new("            "),
+            Err(ValidationError::EmptyEmail)
+        ));
+    }
+}

--- a/crates/bcr-wallet-core/src/lib.rs
+++ b/crates/bcr-wallet-core/src/lib.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 pub mod borsh;
 pub mod contact;
 pub mod crypto;
+pub mod email;
 pub mod event;
 pub mod name;
 pub mod types;
@@ -18,4 +19,10 @@ pub enum ValidationError {
     EmptyName,
     #[error("Name is invalid")]
     InvalidName,
+    #[error("Email can't be empty")]
+    EmptyEmail,
+    #[error("Email is invalid")]
+    InvalidEmail,
+    #[error("Contact is invalid {0}")]
+    InvalidContact(String),
 }

--- a/crates/bcr-wallet-core/src/name.rs
+++ b/crates/bcr-wallet-core/src/name.rs
@@ -58,6 +58,19 @@ impl From<Name> for String {
     }
 }
 
+impl borsh::BorshSerialize for Name {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        borsh::BorshSerialize::serialize(&self.0, writer)
+    }
+}
+
+impl borsh::BorshDeserialize for Name {
+    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let name_str: String = borsh::BorshDeserialize::deserialize_reader(reader)?;
+        Name::new(&name_str).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -724,67 +724,108 @@ pub async fn wallet_get_ids() -> Result<WalletsIdsResponse, WalletError> {
 }
 
 #[frb]
-pub async fn wallet_add_contact(
-    req: WalletAddContactRequest,
-) -> Result<WalletAddContactResponse, WalletError> {
+pub async fn add_contact(req: AddContactRequest) -> Result<AddContactResponse, WalletError> {
     let app_state = get_app_state().await;
-    app_state
-        .wallet_add_contact(req.wallet_id, req.node_id.clone(), req.name)
+    let res = app_state
+        .purse_add_contact(
+            req.bitcoin_network,
+            req.node_id,
+            req.email,
+            req.name,
+            req.company,
+        )
         .await?;
-    Ok(WalletAddContactResponse {
-        node_id: req.node_id,
+    Ok(AddContactResponse {
+        contact_id: res.to_string(),
     })
 }
 
 #[frb]
-pub async fn wallet_edit_contact(
-    req: WalletEditContactRequest,
-) -> Result<WalletEditContactResponse, WalletError> {
+pub async fn edit_contact(req: EditContactRequest) -> Result<EditContactResponse, WalletError> {
     let app_state = get_app_state().await;
     app_state
-        .wallet_edit_contact(req.wallet_id, req.node_id.clone(), req.name)
+        .purse_edit_contact(
+            req.bitcoin_network,
+            req.contact_id.clone(),
+            req.node_id,
+            req.email,
+            req.name,
+            req.company,
+        )
         .await?;
-    Ok(WalletEditContactResponse {
-        node_id: req.node_id,
+    Ok(EditContactResponse {
+        contact_id: req.contact_id,
     })
 }
 
 #[frb]
-pub async fn wallet_delete_contact(
-    req: WalletDeleteContactRequest,
-) -> Result<WalletDeleteContactResponse, WalletError> {
+pub async fn delete_contact(
+    req: DeleteContactRequest,
+) -> Result<DeleteContactResponse, WalletError> {
     let app_state = get_app_state().await;
     app_state
-        .wallet_delete_contact(req.wallet_id, req.node_id.clone())
+        .purse_delete_contact(req.bitcoin_network, req.contact_id.clone())
         .await?;
-    Ok(WalletDeleteContactResponse {
-        node_id: req.node_id,
+    Ok(DeleteContactResponse {
+        contact_id: req.contact_id,
     })
 }
 
 #[frb]
-pub async fn wallet_get_contact(
-    req: WalletGetContactRequest,
-) -> Result<WalletGetContactResponse, WalletError> {
+pub async fn get_contact(req: GetContactRequest) -> Result<GetContactResponse, WalletError> {
     let app_state = get_app_state().await;
     let contact = app_state
-        .wallet_get_contact(req.wallet_id, req.node_id.clone())
+        .purse_get_contact(req.bitcoin_network, req.contact_id.clone())
         .await?;
-    Ok(WalletGetContactResponse {
+    Ok(GetContactResponse {
         contact: contact.into(),
     })
 }
 
 #[frb]
-pub async fn wallet_list_contacts(
-    req: WalletListContactsRequest,
-) -> Result<WalletListContactsResponse, WalletError> {
+pub async fn list_contacts(req: ListContactsRequest) -> Result<ListContactsResponse, WalletError> {
     let app_state = get_app_state().await;
     let contacts = app_state
-        .wallet_list_contacts(req.wallet_id, req.search_term.clone())
+        .purse_list_contacts(req.bitcoin_network, req.search_term.clone())
         .await?;
-    Ok(WalletListContactsResponse {
+    Ok(ListContactsResponse {
         contacts: contacts.into_iter().map(|c| c.into()).collect(),
+    })
+}
+
+#[frb]
+pub async fn wallet_prepare_pay_to_contact(
+    req: WalletPreparePaymentByContactRequest,
+) -> Result<WalletPreparePaymentResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let payment_summary = app_state
+        .wallet_prepare_pay_to_contact(req.wallet_id, req.contact_id, req.amount, req.description)
+        .await?;
+    Ok(WalletPreparePaymentResponse {
+        payment_summary: PaymentSummary {
+            request_id: payment_summary.request_id.to_string(),
+            unit: payment_summary.unit.to_string(),
+            amount: u64::from(payment_summary.amount),
+            fees: u64::from(payment_summary.fees),
+            reserved_fees: u64::from(payment_summary.reserved_fees),
+            expiry: payment_summary.expiry,
+            ptype: PaymentType::from(bcr_wallet_core::types::PaymentType::from(
+                payment_summary.ptype,
+            )),
+        },
+    })
+}
+
+#[frb]
+pub async fn wallet_pay_to_contact(
+    req: WalletPaymentByContactRequest,
+) -> Result<WalletTransactionIdResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let res = app_state
+        .wallet_pay_to_contact(req.wallet_id, req.rid)
+        .await?;
+    Ok(WalletTransactionIdResponse {
+        tx_id: res.to_string(),
     })
 }
 
@@ -796,7 +837,7 @@ pub async fn wallet_request_payment_from_contact(
     let res = app_state
         .wallet_request_payment_from_contact(
             req.wallet_id,
-            req.node_id,
+            req.contact_id,
             req.amount,
             req.description,
             req.deadline,
@@ -1457,15 +1498,21 @@ impl From<bcr_wallet_core::types::PaymentRequest> for PaymentRequest {
 
 #[derive(Debug, Clone)]
 pub struct Contact {
-    pub node_id: String,
-    pub name: String,
+    pub id: String,
+    pub node_id: Option<String>,
+    pub email: Option<String>,
+    pub name: Option<String>,
+    pub company: Option<String>,
 }
 
 impl From<bcr_wallet_core::contact::Contact> for Contact {
     fn from(v: bcr_wallet_core::contact::Contact) -> Self {
         Self {
-            node_id: v.node_id.to_string(),
-            name: v.name.to_string(),
+            id: v.id.to_string(),
+            node_id: v.node_id.map(|n| n.to_string()),
+            email: v.email.map(|e| e.to_string()),
+            name: v.name.map(|n| n.to_string()),
+            company: v.company.map(|c| c.to_string()),
         }
     }
 }
@@ -1998,6 +2045,20 @@ pub struct WalletPayRequest {
 }
 
 #[derive(Debug, Clone)]
+pub struct WalletPreparePaymentByContactRequest {
+    pub wallet_id: String,
+    pub contact_id: String,
+    pub amount: u64,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletPaymentByContactRequest {
+    pub wallet_id: String,
+    pub rid: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct WalletPreparePaymentByTokenRequest {
     pub wallet_id: String,
     pub amount: u64,
@@ -2017,66 +2078,71 @@ pub struct WalletPaymentByTokenResponse {
 }
 
 #[derive(Debug, Clone)]
-pub struct WalletAddContactRequest {
-    pub wallet_id: String,
-    pub node_id: String,
-    pub name: String,
+pub struct AddContactRequest {
+    pub bitcoin_network: String,
+    pub email: Option<String>,
+    pub node_id: Option<String>,
+    pub name: Option<String>,
+    pub company: Option<String>,
 }
 
 #[derive(Debug, Clone)]
-pub struct WalletAddContactResponse {
-    pub node_id: String,
+pub struct AddContactResponse {
+    pub contact_id: String,
 }
 
 #[derive(Debug, Clone)]
-pub struct WalletEditContactRequest {
-    pub wallet_id: String,
-    pub node_id: String,
-    pub name: String,
+pub struct EditContactRequest {
+    pub bitcoin_network: String,
+    pub contact_id: String,
+    pub node_id: Option<String>,
+    pub email: Option<String>,
+    pub name: Option<String>,
+    pub company: Option<String>,
 }
 
 #[derive(Debug, Clone)]
-pub struct WalletEditContactResponse {
-    pub node_id: String,
+pub struct EditContactResponse {
+    pub contact_id: String,
 }
 
 #[derive(Debug, Clone)]
-pub struct WalletDeleteContactRequest {
-    pub wallet_id: String,
-    pub node_id: String,
+pub struct DeleteContactRequest {
+    pub bitcoin_network: String,
+    pub contact_id: String,
 }
 
 #[derive(Debug, Clone)]
-pub struct WalletDeleteContactResponse {
-    pub node_id: String,
+pub struct DeleteContactResponse {
+    pub contact_id: String,
 }
 
 #[derive(Debug, Clone)]
-pub struct WalletGetContactRequest {
-    pub wallet_id: String,
-    pub node_id: String,
+pub struct GetContactRequest {
+    pub bitcoin_network: String,
+    pub contact_id: String,
 }
 
 #[derive(Debug, Clone)]
-pub struct WalletGetContactResponse {
+pub struct GetContactResponse {
     pub contact: Contact,
 }
 
 #[derive(Debug, Clone)]
-pub struct WalletListContactsRequest {
-    pub wallet_id: String,
+pub struct ListContactsRequest {
+    pub bitcoin_network: String,
     pub search_term: Option<String>,
 }
 
 #[derive(Debug, Clone)]
-pub struct WalletListContactsResponse {
+pub struct ListContactsResponse {
     pub contacts: Vec<Contact>,
 }
 
 #[derive(Debug, Clone)]
 pub struct WalletRequestPaymentFromContactRequest {
     pub wallet_id: String,
-    pub node_id: String,
+    pub contact_id: String,
     pub amount: u64,
     pub description: Option<String>,
     pub deadline: Option<u64>,
@@ -2210,6 +2276,7 @@ pub enum WalletErrorCode {
     Network,
     WalletNotFound,
     ContactNotFound,
+    ContactMustHaveNodeId,
     PaymentRequestNotFound,
     PaymentRequestInWrongState,
     ContactAlreadyExists,
@@ -2250,6 +2317,9 @@ pub enum WalletErrorCode {
     InvalidBillId,
     InvalidName,
     EmptyName,
+    InvalidEmail,
+    EmptyEmail,
+    InvalidContact,
     MintClientResourceNotFound,
     MintClientServiceUnavailable,
     MintClientBadRequest,
@@ -2472,6 +2542,18 @@ impl From<BcrWalletError> for WalletError {
             }
             BcrWalletError::BitcoinClient(_) => {
                 WalletError::bad_request(value.to_string(), WalletErrorCode::BitcoinApi)
+            }
+            BcrWalletError::InvalidEmail => {
+                WalletError::bad_request(value.to_string(), WalletErrorCode::InvalidEmail)
+            }
+            BcrWalletError::EmptyEmail => {
+                WalletError::bad_request(value.to_string(), WalletErrorCode::EmptyEmail)
+            }
+            BcrWalletError::InvalidContact => {
+                WalletError::bad_request(value.to_string(), WalletErrorCode::InvalidContact)
+            }
+            BcrWalletError::ContactMustHaveNodeId(_) => {
+                WalletError::bad_request(value.to_string(), WalletErrorCode::ContactMustHaveNodeId)
             }
         }
     }

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 822415845;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1690913843;
 
 // Section: executor
 
@@ -98,6 +98,42 @@ fn wire__crate__api__WalletPaymentCheckHandle_cancel_impl(
         },
     )
 }
+fn wire__crate__api__add_contact_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "add_contact",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::AddContactRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok = crate::api::add_contact(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__check_btc_tx_status_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -134,6 +170,78 @@ fn wire__crate__api__check_btc_tx_status_impl(
         },
     )
 }
+fn wire__crate__api__delete_contact_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "delete_contact",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::DeleteContactRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok = crate::api::delete_contact(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__edit_contact_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "edit_contact",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::EditContactRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok = crate::api::edit_contact(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__generate_random_mnemonic_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -162,6 +270,42 @@ fn wire__crate__api__generate_random_mnemonic_impl(
                 transform_result_sse::<_, crate::api::WalletError>(
                     (move || async move {
                         let output_ok = crate::api::generate_random_mnemonic(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__get_contact_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_contact",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::GetContactRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok = crate::api::get_contact(api_req).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -270,6 +414,42 @@ fn wire__crate__api__is_valid_token_impl(
                 transform_result_sse::<_, crate::api::WalletError>(
                     (move || async move {
                         let output_ok = crate::api::is_valid_token(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__list_contacts_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "list_contacts",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::ListContactsRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok = crate::api::list_contacts(api_req).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -507,42 +687,6 @@ fn wire__crate__api__wallet_add_impl(
         },
     )
 }
-fn wire__crate__api__wallet_add_contact_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "wallet_add_contact",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_req = <crate::api::WalletAddContactRequest>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, crate::api::WalletError>(
-                    (move || async move {
-                        let output_ok = crate::api::wallet_add_contact(api_req).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
 fn wire__crate__api__wallet_cancel_payment_request_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -668,42 +812,6 @@ fn wire__crate__api__wallet_delete_impl(
         },
     )
 }
-fn wire__crate__api__wallet_delete_contact_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "wallet_delete_contact",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_req = <crate::api::WalletDeleteContactRequest>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, crate::api::WalletError>(
-                    (move || async move {
-                        let output_ok = crate::api::wallet_delete_contact(api_req).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
 fn wire__crate__api__wallet_dev_mode_get_detailed_balance_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -733,42 +841,6 @@ fn wire__crate__api__wallet_dev_mode_get_detailed_balance_impl(
                     (move || async move {
                         let output_ok =
                             crate::api::wallet_dev_mode_get_detailed_balance(api_req).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
-fn wire__crate__api__wallet_edit_contact_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "wallet_edit_contact",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_req = <crate::api::WalletEditContactRequest>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, crate::api::WalletError>(
-                    (move || async move {
-                        let output_ok = crate::api::wallet_edit_contact(api_req).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -1052,42 +1124,6 @@ fn wire__crate__api__wallet_get_balance_impl(
                 transform_result_sse::<_, crate::api::WalletError>(
                     (move || async move {
                         let output_ok = crate::api::wallet_get_balance(api_req).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
-fn wire__crate__api__wallet_get_contact_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "wallet_get_contact",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_req = <crate::api::WalletGetContactRequest>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, crate::api::WalletError>(
-                    (move || async move {
-                        let output_ok = crate::api::wallet_get_contact(api_req).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -1494,42 +1530,6 @@ fn wire__crate__api__wallet_id_for_mnemonic_and_network_impl(
         },
     )
 }
-fn wire__crate__api__wallet_list_contacts_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "wallet_list_contacts",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_req = <crate::api::WalletListContactsRequest>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, crate::api::WalletError>(
-                    (move || async move {
-                        let output_ok = crate::api::wallet_list_contacts(api_req).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
 fn wire__crate__api__wallet_list_payment_requests_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1890,6 +1890,43 @@ fn wire__crate__api__wallet_pay_payment_request_impl(
         },
     )
 }
+fn wire__crate__api__wallet_pay_to_contact_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_pay_to_contact",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req =
+                <crate::api::WalletPaymentByContactRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok = crate::api::wallet_pay_to_contact(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet_prepare_melt_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1993,6 +2030,43 @@ fn wire__crate__api__wallet_prepare_pay_payment_request_impl(
                     (move || async move {
                         let output_ok =
                             crate::api::wallet_prepare_pay_payment_request(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet_prepare_pay_to_contact_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_prepare_pay_to_contact",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req =
+                <crate::api::WalletPreparePaymentByContactRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok = crate::api::wallet_prepare_pay_to_contact(api_req).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -2671,6 +2745,34 @@ impl SseDecode for String {
     }
 }
 
+impl SseDecode for crate::api::AddContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bitcoinNetwork = <String>::sse_decode(deserializer);
+        let mut var_email = <Option<String>>::sse_decode(deserializer);
+        let mut var_nodeId = <Option<String>>::sse_decode(deserializer);
+        let mut var_name = <Option<String>>::sse_decode(deserializer);
+        let mut var_company = <Option<String>>::sse_decode(deserializer);
+        return crate::api::AddContactRequest {
+            bitcoin_network: var_bitcoinNetwork,
+            email: var_email,
+            node_id: var_nodeId,
+            name: var_name,
+            company: var_company,
+        };
+    }
+}
+
+impl SseDecode for crate::api::AddContactResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_contactId = <String>::sse_decode(deserializer);
+        return crate::api::AddContactResponse {
+            contact_id: var_contactId,
+        };
+    }
+}
+
 impl SseDecode for crate::api::AddWalletResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2747,11 +2849,17 @@ impl SseDecode for crate::api::Cdk18PaymentRequest {
 impl SseDecode for crate::api::Contact {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_nodeId = <String>::sse_decode(deserializer);
-        let mut var_name = <String>::sse_decode(deserializer);
+        let mut var_id = <String>::sse_decode(deserializer);
+        let mut var_nodeId = <Option<String>>::sse_decode(deserializer);
+        let mut var_email = <Option<String>>::sse_decode(deserializer);
+        let mut var_name = <Option<String>>::sse_decode(deserializer);
+        let mut var_company = <Option<String>>::sse_decode(deserializer);
         return crate::api::Contact {
+            id: var_id,
             node_id: var_nodeId,
+            email: var_email,
             name: var_name,
+            company: var_company,
         };
     }
 }
@@ -2774,6 +2882,58 @@ impl SseDecode for crate::api::CreateWalletRequest {
     }
 }
 
+impl SseDecode for crate::api::DeleteContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bitcoinNetwork = <String>::sse_decode(deserializer);
+        let mut var_contactId = <String>::sse_decode(deserializer);
+        return crate::api::DeleteContactRequest {
+            bitcoin_network: var_bitcoinNetwork,
+            contact_id: var_contactId,
+        };
+    }
+}
+
+impl SseDecode for crate::api::DeleteContactResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_contactId = <String>::sse_decode(deserializer);
+        return crate::api::DeleteContactResponse {
+            contact_id: var_contactId,
+        };
+    }
+}
+
+impl SseDecode for crate::api::EditContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bitcoinNetwork = <String>::sse_decode(deserializer);
+        let mut var_contactId = <String>::sse_decode(deserializer);
+        let mut var_nodeId = <Option<String>>::sse_decode(deserializer);
+        let mut var_email = <Option<String>>::sse_decode(deserializer);
+        let mut var_name = <Option<String>>::sse_decode(deserializer);
+        let mut var_company = <Option<String>>::sse_decode(deserializer);
+        return crate::api::EditContactRequest {
+            bitcoin_network: var_bitcoinNetwork,
+            contact_id: var_contactId,
+            node_id: var_nodeId,
+            email: var_email,
+            name: var_name,
+            company: var_company,
+        };
+    }
+}
+
+impl SseDecode for crate::api::EditContactResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_contactId = <String>::sse_decode(deserializer);
+        return crate::api::EditContactResponse {
+            contact_id: var_contactId,
+        };
+    }
+}
+
 impl SseDecode for f32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2791,6 +2951,28 @@ impl SseDecode for crate::api::FeesByMonth {
             year: var_year,
             month: var_month,
             fees: var_fees,
+        };
+    }
+}
+
+impl SseDecode for crate::api::GetContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bitcoinNetwork = <String>::sse_decode(deserializer);
+        let mut var_contactId = <String>::sse_decode(deserializer);
+        return crate::api::GetContactRequest {
+            bitcoin_network: var_bitcoinNetwork,
+            contact_id: var_contactId,
+        };
+    }
+}
+
+impl SseDecode for crate::api::GetContactResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_contact = <crate::api::Contact>::sse_decode(deserializer);
+        return crate::api::GetContactResponse {
+            contact: var_contact,
         };
     }
 }
@@ -2866,6 +3048,28 @@ impl SseDecode for Vec<crate::api::Contact> {
             ans_.push(<crate::api::Contact>::sse_decode(deserializer));
         }
         return ans_;
+    }
+}
+
+impl SseDecode for crate::api::ListContactsRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bitcoinNetwork = <String>::sse_decode(deserializer);
+        let mut var_searchTerm = <Option<String>>::sse_decode(deserializer);
+        return crate::api::ListContactsRequest {
+            bitcoin_network: var_bitcoinNetwork,
+            search_term: var_searchTerm,
+        };
+    }
+}
+
+impl SseDecode for crate::api::ListContactsResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_contacts = <Vec<crate::api::Contact>>::sse_decode(deserializer);
+        return crate::api::ListContactsResponse {
+            contacts: var_contacts,
+        };
     }
 }
 
@@ -3470,30 +3674,6 @@ impl SseDecode for usize {
     }
 }
 
-impl SseDecode for crate::api::WalletAddContactRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_walletId = <String>::sse_decode(deserializer);
-        let mut var_nodeId = <String>::sse_decode(deserializer);
-        let mut var_name = <String>::sse_decode(deserializer);
-        return crate::api::WalletAddContactRequest {
-            wallet_id: var_walletId,
-            node_id: var_nodeId,
-            name: var_name,
-        };
-    }
-}
-
-impl SseDecode for crate::api::WalletAddContactResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_nodeId = <String>::sse_decode(deserializer);
-        return crate::api::WalletAddContactResponse {
-            node_id: var_nodeId,
-        };
-    }
-}
-
 impl SseDecode for crate::api::WalletBalanceResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3560,28 +3740,6 @@ impl SseDecode for crate::api::WalletCurrencyUnitResponse {
     }
 }
 
-impl SseDecode for crate::api::WalletDeleteContactRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_walletId = <String>::sse_decode(deserializer);
-        let mut var_nodeId = <String>::sse_decode(deserializer);
-        return crate::api::WalletDeleteContactRequest {
-            wallet_id: var_walletId,
-            node_id: var_nodeId,
-        };
-    }
-}
-
-impl SseDecode for crate::api::WalletDeleteContactResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_nodeId = <String>::sse_decode(deserializer);
-        return crate::api::WalletDeleteContactResponse {
-            node_id: var_nodeId,
-        };
-    }
-}
-
 impl SseDecode for crate::api::WalletDevModeDetailedBalanceEntry {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3603,30 +3761,6 @@ impl SseDecode for crate::api::WalletDevModeDetailedBalanceResponse {
             <Vec<crate::api::WalletDevModeDetailedBalanceEntry>>::sse_decode(deserializer);
         return crate::api::WalletDevModeDetailedBalanceResponse {
             entries: var_entries,
-        };
-    }
-}
-
-impl SseDecode for crate::api::WalletEditContactRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_walletId = <String>::sse_decode(deserializer);
-        let mut var_nodeId = <String>::sse_decode(deserializer);
-        let mut var_name = <String>::sse_decode(deserializer);
-        return crate::api::WalletEditContactRequest {
-            wallet_id: var_walletId,
-            node_id: var_nodeId,
-            name: var_name,
-        };
-    }
-}
-
-impl SseDecode for crate::api::WalletEditContactResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_nodeId = <String>::sse_decode(deserializer);
-        return crate::api::WalletEditContactResponse {
-            node_id: var_nodeId,
         };
     }
 }
@@ -3678,58 +3812,62 @@ impl SseDecode for crate::api::WalletErrorCode {
             1 => crate::api::WalletErrorCode::Network,
             2 => crate::api::WalletErrorCode::WalletNotFound,
             3 => crate::api::WalletErrorCode::ContactNotFound,
-            4 => crate::api::WalletErrorCode::PaymentRequestNotFound,
-            5 => crate::api::WalletErrorCode::PaymentRequestInWrongState,
-            6 => crate::api::WalletErrorCode::ContactAlreadyExists,
-            7 => crate::api::WalletErrorCode::EmptyToken,
-            8 => crate::api::WalletErrorCode::InvalidToken,
-            9 => crate::api::WalletErrorCode::CashuMintUrl,
-            10 => crate::api::WalletErrorCode::Url,
-            11 => crate::api::WalletErrorCode::Uuid,
-            12 => crate::api::WalletErrorCode::Amount,
-            13 => crate::api::WalletErrorCode::InsufficientBalance,
-            14 => crate::api::WalletErrorCode::NoActiveKeyset,
-            15 => crate::api::WalletErrorCode::UnknownKeysetId,
-            16 => crate::api::WalletErrorCode::InvalidCurrencyUnit,
-            17 => crate::api::WalletErrorCode::NoPrepareRef,
-            18 => crate::api::WalletErrorCode::InactiveKeyset,
-            19 => crate::api::WalletErrorCode::NoDebitCurrencyInMint,
-            20 => crate::api::WalletErrorCode::InvalidNetwork,
-            21 => crate::api::WalletErrorCode::InvalidBitcoinNetwork,
-            22 => crate::api::WalletErrorCode::InvalidBitcoinTxId,
-            23 => crate::api::WalletErrorCode::MissingAmount,
-            24 => crate::api::WalletErrorCode::UnknownPaymentRequest,
-            25 => crate::api::WalletErrorCode::Unsupported,
-            26 => crate::api::WalletErrorCode::TransactionCantBeReclaimed,
-            27 => crate::api::WalletErrorCode::InsufficientOnChainMeltAmount,
-            28 => crate::api::WalletErrorCode::InsufficientOnChainMintAmount,
-            29 => crate::api::WalletErrorCode::NoDevMode,
-            30 => crate::api::WalletErrorCode::MeltQuoteMismatch,
-            31 => crate::api::WalletErrorCode::SwapCommitmentMismatch,
-            32 => crate::api::WalletErrorCode::InvalidBitcoinAddress,
-            33 => crate::api::WalletErrorCode::InvalidMnemonic,
-            34 => crate::api::WalletErrorCode::InvalidTransactionId,
-            35 => crate::api::WalletErrorCode::InvalidCursor,
-            36 => crate::api::WalletErrorCode::SortMismatch,
-            37 => crate::api::WalletErrorCode::MnemonicNotFound,
-            38 => crate::api::WalletErrorCode::WalletUniqueName,
-            39 => crate::api::WalletErrorCode::WalletUniqueId,
-            40 => crate::api::WalletErrorCode::InvalidNodeId,
-            41 => crate::api::WalletErrorCode::InvalidBillId,
-            42 => crate::api::WalletErrorCode::InvalidName,
-            43 => crate::api::WalletErrorCode::EmptyName,
-            44 => crate::api::WalletErrorCode::MintClientResourceNotFound,
-            45 => crate::api::WalletErrorCode::MintClientServiceUnavailable,
-            46 => crate::api::WalletErrorCode::MintClientBadRequest,
-            47 => crate::api::WalletErrorCode::MintClientKeysetNotFound,
-            48 => crate::api::WalletErrorCode::MintClientMeltOpSuspended,
-            49 => crate::api::WalletErrorCode::MintClientCommitmentMismatch,
-            50 => crate::api::WalletErrorCode::AttestationInvalidProof,
-            51 => crate::api::WalletErrorCode::AttestationDigestMismatch,
-            52 => crate::api::WalletErrorCode::AttestationUnknownBeta,
-            53 => crate::api::WalletErrorCode::AttestationVerifyNotFound,
-            54 => crate::api::WalletErrorCode::AttestationSignature,
-            55 => crate::api::WalletErrorCode::BitcoinApi,
+            4 => crate::api::WalletErrorCode::ContactMustHaveNodeId,
+            5 => crate::api::WalletErrorCode::PaymentRequestNotFound,
+            6 => crate::api::WalletErrorCode::PaymentRequestInWrongState,
+            7 => crate::api::WalletErrorCode::ContactAlreadyExists,
+            8 => crate::api::WalletErrorCode::EmptyToken,
+            9 => crate::api::WalletErrorCode::InvalidToken,
+            10 => crate::api::WalletErrorCode::CashuMintUrl,
+            11 => crate::api::WalletErrorCode::Url,
+            12 => crate::api::WalletErrorCode::Uuid,
+            13 => crate::api::WalletErrorCode::Amount,
+            14 => crate::api::WalletErrorCode::InsufficientBalance,
+            15 => crate::api::WalletErrorCode::NoActiveKeyset,
+            16 => crate::api::WalletErrorCode::UnknownKeysetId,
+            17 => crate::api::WalletErrorCode::InvalidCurrencyUnit,
+            18 => crate::api::WalletErrorCode::NoPrepareRef,
+            19 => crate::api::WalletErrorCode::InactiveKeyset,
+            20 => crate::api::WalletErrorCode::NoDebitCurrencyInMint,
+            21 => crate::api::WalletErrorCode::InvalidNetwork,
+            22 => crate::api::WalletErrorCode::InvalidBitcoinNetwork,
+            23 => crate::api::WalletErrorCode::InvalidBitcoinTxId,
+            24 => crate::api::WalletErrorCode::MissingAmount,
+            25 => crate::api::WalletErrorCode::UnknownPaymentRequest,
+            26 => crate::api::WalletErrorCode::Unsupported,
+            27 => crate::api::WalletErrorCode::TransactionCantBeReclaimed,
+            28 => crate::api::WalletErrorCode::InsufficientOnChainMeltAmount,
+            29 => crate::api::WalletErrorCode::InsufficientOnChainMintAmount,
+            30 => crate::api::WalletErrorCode::NoDevMode,
+            31 => crate::api::WalletErrorCode::MeltQuoteMismatch,
+            32 => crate::api::WalletErrorCode::SwapCommitmentMismatch,
+            33 => crate::api::WalletErrorCode::InvalidBitcoinAddress,
+            34 => crate::api::WalletErrorCode::InvalidMnemonic,
+            35 => crate::api::WalletErrorCode::InvalidTransactionId,
+            36 => crate::api::WalletErrorCode::InvalidCursor,
+            37 => crate::api::WalletErrorCode::SortMismatch,
+            38 => crate::api::WalletErrorCode::MnemonicNotFound,
+            39 => crate::api::WalletErrorCode::WalletUniqueName,
+            40 => crate::api::WalletErrorCode::WalletUniqueId,
+            41 => crate::api::WalletErrorCode::InvalidNodeId,
+            42 => crate::api::WalletErrorCode::InvalidBillId,
+            43 => crate::api::WalletErrorCode::InvalidName,
+            44 => crate::api::WalletErrorCode::EmptyName,
+            45 => crate::api::WalletErrorCode::InvalidEmail,
+            46 => crate::api::WalletErrorCode::EmptyEmail,
+            47 => crate::api::WalletErrorCode::InvalidContact,
+            48 => crate::api::WalletErrorCode::MintClientResourceNotFound,
+            49 => crate::api::WalletErrorCode::MintClientServiceUnavailable,
+            50 => crate::api::WalletErrorCode::MintClientBadRequest,
+            51 => crate::api::WalletErrorCode::MintClientKeysetNotFound,
+            52 => crate::api::WalletErrorCode::MintClientMeltOpSuspended,
+            53 => crate::api::WalletErrorCode::MintClientCommitmentMismatch,
+            54 => crate::api::WalletErrorCode::AttestationInvalidProof,
+            55 => crate::api::WalletErrorCode::AttestationDigestMismatch,
+            56 => crate::api::WalletErrorCode::AttestationUnknownBeta,
+            57 => crate::api::WalletErrorCode::AttestationVerifyNotFound,
+            58 => crate::api::WalletErrorCode::AttestationSignature,
+            59 => crate::api::WalletErrorCode::BitcoinApi,
             _ => unreachable!("Invalid variant for WalletErrorCode: {}", inner),
         };
     }
@@ -3818,28 +3956,6 @@ impl SseDecode for crate::api::WalletFfiConfig {
     }
 }
 
-impl SseDecode for crate::api::WalletGetContactRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_walletId = <String>::sse_decode(deserializer);
-        let mut var_nodeId = <String>::sse_decode(deserializer);
-        return crate::api::WalletGetContactRequest {
-            wallet_id: var_walletId,
-            node_id: var_nodeId,
-        };
-    }
-}
-
-impl SseDecode for crate::api::WalletGetContactResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_contact = <crate::api::Contact>::sse_decode(deserializer);
-        return crate::api::WalletGetContactResponse {
-            contact: var_contact,
-        };
-    }
-}
-
 impl SseDecode for crate::api::WalletGetPaymentRequestRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3898,28 +4014,6 @@ impl SseDecode for crate::api::WalletInfoResponse {
             network: var_network,
             default_mint_url: var_defaultMintUrl,
             nostr_relays: var_nostrRelays,
-        };
-    }
-}
-
-impl SseDecode for crate::api::WalletListContactsRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_walletId = <String>::sse_decode(deserializer);
-        let mut var_searchTerm = <Option<String>>::sse_decode(deserializer);
-        return crate::api::WalletListContactsRequest {
-            wallet_id: var_walletId,
-            search_term: var_searchTerm,
-        };
-    }
-}
-
-impl SseDecode for crate::api::WalletListContactsResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_contacts = <Vec<crate::api::Contact>>::sse_decode(deserializer);
-        return crate::api::WalletListContactsResponse {
-            contacts: var_contacts,
         };
     }
 }
@@ -4056,6 +4150,18 @@ impl SseDecode for crate::api::WalletPayRequest {
     }
 }
 
+impl SseDecode for crate::api::WalletPaymentByContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_walletId = <String>::sse_decode(deserializer);
+        let mut var_rid = <String>::sse_decode(deserializer);
+        return crate::api::WalletPaymentByContactRequest {
+            wallet_id: var_walletId,
+            rid: var_rid,
+        };
+    }
+}
+
 impl SseDecode for crate::api::WalletPaymentByTokenRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4116,6 +4222,22 @@ impl SseDecode for crate::api::WalletPreparePayPaymentRequestRequest {
         return crate::api::WalletPreparePayPaymentRequestRequest {
             wallet_id: var_walletId,
             payment_request_id: var_paymentRequestId,
+        };
+    }
+}
+
+impl SseDecode for crate::api::WalletPreparePaymentByContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_walletId = <String>::sse_decode(deserializer);
+        let mut var_contactId = <String>::sse_decode(deserializer);
+        let mut var_amount = <u64>::sse_decode(deserializer);
+        let mut var_description = <Option<String>>::sse_decode(deserializer);
+        return crate::api::WalletPreparePaymentByContactRequest {
+            wallet_id: var_walletId,
+            contact_id: var_contactId,
+            amount: var_amount,
+            description: var_description,
         };
     }
 }
@@ -4362,13 +4484,13 @@ impl SseDecode for crate::api::WalletRequestPaymentFromContactRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_walletId = <String>::sse_decode(deserializer);
-        let mut var_nodeId = <String>::sse_decode(deserializer);
+        let mut var_contactId = <String>::sse_decode(deserializer);
         let mut var_amount = <u64>::sse_decode(deserializer);
         let mut var_description = <Option<String>>::sse_decode(deserializer);
         let mut var_deadline = <Option<u64>>::sse_decode(deserializer);
         return crate::api::WalletRequestPaymentFromContactRequest {
             wallet_id: var_walletId,
-            node_id: var_nodeId,
+            contact_id: var_contactId,
             amount: var_amount,
             description: var_description,
             deadline: var_deadline,
@@ -4457,65 +4579,65 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        2 => wire__crate__api__check_btc_tx_status_impl(port, ptr, rust_vec_len, data_len),
-        3 => wire__crate__api__generate_random_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__init_app_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__init_wallet_ffi_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__is_valid_token_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__payment_type_default_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__protest_status_default_impl(port, ptr, rust_vec_len, data_len),
-        9 => {
+        2 => wire__crate__api__add_contact_impl(port, ptr, rust_vec_len, data_len),
+        3 => wire__crate__api__check_btc_tx_status_impl(port, ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__delete_contact_impl(port, ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__edit_contact_impl(port, ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__generate_random_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__get_contact_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__init_app_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__init_wallet_ffi_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__is_valid_token_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__list_contacts_impl(port, ptr, rust_vec_len, data_len),
+        12 => wire__crate__api__payment_type_default_impl(port, ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__protest_status_default_impl(port, ptr, rust_vec_len, data_len),
+        14 => {
             wire__crate__api__transaction_direction_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        10 => wire__crate__api__transaction_filters_default_impl(port, ptr, rust_vec_len, data_len),
-        11 => wire__crate__api__transaction_sort_default_impl(port, ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__transaction_status_default_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__wallet_add_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__wallet_add_contact_impl(port, ptr, rust_vec_len, data_len),
-        15 => {
+        15 => wire__crate__api__transaction_filters_default_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__transaction_sort_default_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__transaction_status_default_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__wallet_add_impl(port, ptr, rust_vec_len, data_len),
+        19 => {
             wire__crate__api__wallet_cancel_payment_request_impl(port, ptr, rust_vec_len, data_len)
         }
-        16 => wire__crate__api__wallet_check_pending_mints_impl(port, ptr, rust_vec_len, data_len),
-        17 => {
+        20 => wire__crate__api__wallet_check_pending_mints_impl(port, ptr, rust_vec_len, data_len),
+        21 => {
             wire__crate__api__wallet_check_received_payment_impl(port, ptr, rust_vec_len, data_len)
         }
-        18 => wire__crate__api__wallet_delete_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__wallet_delete_contact_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__wallet_dev_mode_get_detailed_balance_impl(
+        22 => wire__crate__api__wallet_delete_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__wallet_dev_mode_get_detailed_balance_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        21 => wire__crate__api__wallet_edit_contact_impl(port, ptr, rust_vec_len, data_len),
-        22 => {
+        24 => {
             wire__crate__api__wallet_edit_transaction_memo_impl(port, ptr, rust_vec_len, data_len)
         }
-        23 => wire__crate__api__wallet_error_bad_request_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__wallet_error_internal_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__wallet_error_network_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__wallet_error_not_found_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__wallet_error_unavailable_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__wallet_estimate_melt_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__wallet_get_balance_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__wallet_get_contact_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__wallet_get_currency_unit_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__wallet_get_ids_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__wallet_get_info_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__wallet_get_mint_url_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__wallet_get_name_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__wallet_get_node_id_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__wallet_get_payment_request_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__wallet_get_status_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__wallet_get_transaction_ids_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__wallet_get_transactions_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__wallet_id_for_mnemonic_and_network_impl(
+        25 => wire__crate__api__wallet_error_bad_request_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__wallet_error_internal_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__wallet_error_network_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__wallet_error_not_found_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__wallet_error_unavailable_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__wallet_estimate_melt_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__wallet_get_balance_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__wallet_get_currency_unit_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__wallet_get_ids_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__wallet_get_info_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__wallet_get_mint_url_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__wallet_get_name_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__wallet_get_node_id_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__wallet_get_payment_request_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__wallet_get_status_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__wallet_get_transaction_ids_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__wallet_get_transactions_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__wallet_id_for_mnemonic_and_network_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__wallet_list_contacts_impl(port, ptr, rust_vec_len, data_len),
         43 => {
             wire__crate__api__wallet_list_payment_requests_impl(port, ptr, rust_vec_len, data_len)
         }
@@ -4528,43 +4650,47 @@ fn pde_ffi_dispatcher_primary_impl(
         50 => wire__crate__api__wallet_pay_impl(port, ptr, rust_vec_len, data_len),
         51 => wire__crate__api__wallet_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
         52 => wire__crate__api__wallet_pay_payment_request_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__wallet_prepare_melt_impl(port, ptr, rust_vec_len, data_len),
-        54 => wire__crate__api__wallet_prepare_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__wallet_prepare_pay_payment_request_impl(
+        53 => wire__crate__api__wallet_pay_to_contact_impl(port, ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__wallet_prepare_melt_impl(port, ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__wallet_prepare_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__wallet_prepare_pay_payment_request_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        56 => wire__crate__api__wallet_prepare_payment_impl(port, ptr, rust_vec_len, data_len),
         57 => {
+            wire__crate__api__wallet_prepare_pay_to_contact_impl(port, ptr, rust_vec_len, data_len)
+        }
+        58 => wire__crate__api__wallet_prepare_payment_impl(port, ptr, rust_vec_len, data_len),
+        59 => {
             wire__crate__api__wallet_prepare_payment_request_impl(port, ptr, rust_vec_len, data_len)
         }
-        58 => wire__crate__api__wallet_protest_melt_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__wallet_protest_mint_impl(port, ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__wallet_protest_swap_impl(port, ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__wallet_receive_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__wallet_reclaim_transaction_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__wallet_recover_pending_stale_proofs_impl(
+        60 => wire__crate__api__wallet_protest_melt_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__wallet_protest_mint_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__wallet_protest_swap_impl(port, ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__wallet_receive_impl(port, ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__wallet_reclaim_transaction_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__wallet_recover_pending_stale_proofs_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        64 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
-        66 => {
+        66 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
+        67 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
+        68 => {
             wire__crate__api__wallet_reject_payment_request_impl(port, ptr, rust_vec_len, data_len)
         }
-        67 => wire__crate__api__wallet_request_payment_from_contact_impl(
+        69 => wire__crate__api__wallet_request_payment_from_contact_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        68 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__wallet_set_dev_mode_impl(port, ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__wallet_subscribe_to_payment_requests_impl(
+        70 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
+        71 => wire__crate__api__wallet_set_dev_mode_impl(port, ptr, rust_vec_len, data_len),
+        72 => wire__crate__api__wallet_subscribe_to_payment_requests_impl(
             port,
             ptr,
             rust_vec_len,
@@ -4608,6 +4734,44 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<WalletPaymentCheckHandle>>
     }
 }
 
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::AddContactRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.bitcoin_network.into_into_dart().into_dart(),
+            self.email.into_into_dart().into_dart(),
+            self.node_id.into_into_dart().into_dart(),
+            self.name.into_into_dart().into_dart(),
+            self.company.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::AddContactRequest {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::AddContactRequest>
+    for crate::api::AddContactRequest
+{
+    fn into_into_dart(self) -> crate::api::AddContactRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::AddContactResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.contact_id.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::AddContactResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::AddContactResponse>
+    for crate::api::AddContactResponse
+{
+    fn into_into_dart(self) -> crate::api::AddContactResponse {
+        self
+    }
+}
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::AddWalletResponse {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
@@ -4714,8 +4878,11 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::Cdk18PaymentRequest>
 impl flutter_rust_bridge::IntoDart for crate::api::Contact {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
+            self.id.into_into_dart().into_dart(),
             self.node_id.into_into_dart().into_dart(),
+            self.email.into_into_dart().into_dart(),
             self.name.into_into_dart().into_dart(),
+            self.company.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -4751,6 +4918,86 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::CreateWalletRequest>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::DeleteContactRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.bitcoin_network.into_into_dart().into_dart(),
+            self.contact_id.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::DeleteContactRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::DeleteContactRequest>
+    for crate::api::DeleteContactRequest
+{
+    fn into_into_dart(self) -> crate::api::DeleteContactRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::DeleteContactResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.contact_id.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::DeleteContactResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::DeleteContactResponse>
+    for crate::api::DeleteContactResponse
+{
+    fn into_into_dart(self) -> crate::api::DeleteContactResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::EditContactRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.bitcoin_network.into_into_dart().into_dart(),
+            self.contact_id.into_into_dart().into_dart(),
+            self.node_id.into_into_dart().into_dart(),
+            self.email.into_into_dart().into_dart(),
+            self.name.into_into_dart().into_dart(),
+            self.company.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::EditContactRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::EditContactRequest>
+    for crate::api::EditContactRequest
+{
+    fn into_into_dart(self) -> crate::api::EditContactRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::EditContactResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.contact_id.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::EditContactResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::EditContactResponse>
+    for crate::api::EditContactResponse
+{
+    fn into_into_dart(self) -> crate::api::EditContactResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::FeesByMonth {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -4764,6 +5011,41 @@ impl flutter_rust_bridge::IntoDart for crate::api::FeesByMonth {
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::FeesByMonth {}
 impl flutter_rust_bridge::IntoIntoDart<crate::api::FeesByMonth> for crate::api::FeesByMonth {
     fn into_into_dart(self) -> crate::api::FeesByMonth {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::GetContactRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.bitcoin_network.into_into_dart().into_dart(),
+            self.contact_id.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::GetContactRequest {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::GetContactRequest>
+    for crate::api::GetContactRequest
+{
+    fn into_into_dart(self) -> crate::api::GetContactRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::GetContactResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.contact.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::GetContactResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::GetContactResponse>
+    for crate::api::GetContactResponse
+{
+    fn into_into_dart(self) -> crate::api::GetContactResponse {
         self
     }
 }
@@ -4804,6 +5086,44 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::IsValidTokenResponse>
     for crate::api::IsValidTokenResponse
 {
     fn into_into_dart(self) -> crate::api::IsValidTokenResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::ListContactsRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.bitcoin_network.into_into_dart().into_dart(),
+            self.search_term.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::ListContactsRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::ListContactsRequest>
+    for crate::api::ListContactsRequest
+{
+    fn into_into_dart(self) -> crate::api::ListContactsRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::ListContactsResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.contacts.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::ListContactsResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::ListContactsResponse>
+    for crate::api::ListContactsResponse
+{
+    fn into_into_dart(self) -> crate::api::ListContactsResponse {
         self
     }
 }
@@ -5268,45 +5588,6 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::TransactionStatus>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::WalletAddContactRequest {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.wallet_id.into_into_dart().into_dart(),
-            self.node_id.into_into_dart().into_dart(),
-            self.name.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::WalletAddContactRequest
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletAddContactRequest>
-    for crate::api::WalletAddContactRequest
-{
-    fn into_into_dart(self) -> crate::api::WalletAddContactRequest {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::WalletAddContactResponse {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [self.node_id.into_into_dart().into_dart()].into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::WalletAddContactResponse
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletAddContactResponse>
-    for crate::api::WalletAddContactResponse
-{
-    fn into_into_dart(self) -> crate::api::WalletAddContactResponse {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::WalletBalanceResponse {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -5423,44 +5704,6 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletCurrencyUnitResponse>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::WalletDeleteContactRequest {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.wallet_id.into_into_dart().into_dart(),
-            self.node_id.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::WalletDeleteContactRequest
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletDeleteContactRequest>
-    for crate::api::WalletDeleteContactRequest
-{
-    fn into_into_dart(self) -> crate::api::WalletDeleteContactRequest {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::WalletDeleteContactResponse {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [self.node_id.into_into_dart().into_dart()].into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::WalletDeleteContactResponse
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletDeleteContactResponse>
-    for crate::api::WalletDeleteContactResponse
-{
-    fn into_into_dart(self) -> crate::api::WalletDeleteContactResponse {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::WalletDevModeDetailedBalanceEntry {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -5496,45 +5739,6 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletDevModeDetailedBalanceR
     for crate::api::WalletDevModeDetailedBalanceResponse
 {
     fn into_into_dart(self) -> crate::api::WalletDevModeDetailedBalanceResponse {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::WalletEditContactRequest {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.wallet_id.into_into_dart().into_dart(),
-            self.node_id.into_into_dart().into_dart(),
-            self.name.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::WalletEditContactRequest
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletEditContactRequest>
-    for crate::api::WalletEditContactRequest
-{
-    fn into_into_dart(self) -> crate::api::WalletEditContactRequest {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::WalletEditContactResponse {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [self.node_id.into_into_dart().into_dart()].into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::WalletEditContactResponse
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletEditContactResponse>
-    for crate::api::WalletEditContactResponse
-{
-    fn into_into_dart(self) -> crate::api::WalletEditContactResponse {
         self
     }
 }
@@ -5602,58 +5806,62 @@ impl flutter_rust_bridge::IntoDart for crate::api::WalletErrorCode {
             Self::Network => 1.into_dart(),
             Self::WalletNotFound => 2.into_dart(),
             Self::ContactNotFound => 3.into_dart(),
-            Self::PaymentRequestNotFound => 4.into_dart(),
-            Self::PaymentRequestInWrongState => 5.into_dart(),
-            Self::ContactAlreadyExists => 6.into_dart(),
-            Self::EmptyToken => 7.into_dart(),
-            Self::InvalidToken => 8.into_dart(),
-            Self::CashuMintUrl => 9.into_dart(),
-            Self::Url => 10.into_dart(),
-            Self::Uuid => 11.into_dart(),
-            Self::Amount => 12.into_dart(),
-            Self::InsufficientBalance => 13.into_dart(),
-            Self::NoActiveKeyset => 14.into_dart(),
-            Self::UnknownKeysetId => 15.into_dart(),
-            Self::InvalidCurrencyUnit => 16.into_dart(),
-            Self::NoPrepareRef => 17.into_dart(),
-            Self::InactiveKeyset => 18.into_dart(),
-            Self::NoDebitCurrencyInMint => 19.into_dart(),
-            Self::InvalidNetwork => 20.into_dart(),
-            Self::InvalidBitcoinNetwork => 21.into_dart(),
-            Self::InvalidBitcoinTxId => 22.into_dart(),
-            Self::MissingAmount => 23.into_dart(),
-            Self::UnknownPaymentRequest => 24.into_dart(),
-            Self::Unsupported => 25.into_dart(),
-            Self::TransactionCantBeReclaimed => 26.into_dart(),
-            Self::InsufficientOnChainMeltAmount => 27.into_dart(),
-            Self::InsufficientOnChainMintAmount => 28.into_dart(),
-            Self::NoDevMode => 29.into_dart(),
-            Self::MeltQuoteMismatch => 30.into_dart(),
-            Self::SwapCommitmentMismatch => 31.into_dart(),
-            Self::InvalidBitcoinAddress => 32.into_dart(),
-            Self::InvalidMnemonic => 33.into_dart(),
-            Self::InvalidTransactionId => 34.into_dart(),
-            Self::InvalidCursor => 35.into_dart(),
-            Self::SortMismatch => 36.into_dart(),
-            Self::MnemonicNotFound => 37.into_dart(),
-            Self::WalletUniqueName => 38.into_dart(),
-            Self::WalletUniqueId => 39.into_dart(),
-            Self::InvalidNodeId => 40.into_dart(),
-            Self::InvalidBillId => 41.into_dart(),
-            Self::InvalidName => 42.into_dart(),
-            Self::EmptyName => 43.into_dart(),
-            Self::MintClientResourceNotFound => 44.into_dart(),
-            Self::MintClientServiceUnavailable => 45.into_dart(),
-            Self::MintClientBadRequest => 46.into_dart(),
-            Self::MintClientKeysetNotFound => 47.into_dart(),
-            Self::MintClientMeltOpSuspended => 48.into_dart(),
-            Self::MintClientCommitmentMismatch => 49.into_dart(),
-            Self::AttestationInvalidProof => 50.into_dart(),
-            Self::AttestationDigestMismatch => 51.into_dart(),
-            Self::AttestationUnknownBeta => 52.into_dart(),
-            Self::AttestationVerifyNotFound => 53.into_dart(),
-            Self::AttestationSignature => 54.into_dart(),
-            Self::BitcoinApi => 55.into_dart(),
+            Self::ContactMustHaveNodeId => 4.into_dart(),
+            Self::PaymentRequestNotFound => 5.into_dart(),
+            Self::PaymentRequestInWrongState => 6.into_dart(),
+            Self::ContactAlreadyExists => 7.into_dart(),
+            Self::EmptyToken => 8.into_dart(),
+            Self::InvalidToken => 9.into_dart(),
+            Self::CashuMintUrl => 10.into_dart(),
+            Self::Url => 11.into_dart(),
+            Self::Uuid => 12.into_dart(),
+            Self::Amount => 13.into_dart(),
+            Self::InsufficientBalance => 14.into_dart(),
+            Self::NoActiveKeyset => 15.into_dart(),
+            Self::UnknownKeysetId => 16.into_dart(),
+            Self::InvalidCurrencyUnit => 17.into_dart(),
+            Self::NoPrepareRef => 18.into_dart(),
+            Self::InactiveKeyset => 19.into_dart(),
+            Self::NoDebitCurrencyInMint => 20.into_dart(),
+            Self::InvalidNetwork => 21.into_dart(),
+            Self::InvalidBitcoinNetwork => 22.into_dart(),
+            Self::InvalidBitcoinTxId => 23.into_dart(),
+            Self::MissingAmount => 24.into_dart(),
+            Self::UnknownPaymentRequest => 25.into_dart(),
+            Self::Unsupported => 26.into_dart(),
+            Self::TransactionCantBeReclaimed => 27.into_dart(),
+            Self::InsufficientOnChainMeltAmount => 28.into_dart(),
+            Self::InsufficientOnChainMintAmount => 29.into_dart(),
+            Self::NoDevMode => 30.into_dart(),
+            Self::MeltQuoteMismatch => 31.into_dart(),
+            Self::SwapCommitmentMismatch => 32.into_dart(),
+            Self::InvalidBitcoinAddress => 33.into_dart(),
+            Self::InvalidMnemonic => 34.into_dart(),
+            Self::InvalidTransactionId => 35.into_dart(),
+            Self::InvalidCursor => 36.into_dart(),
+            Self::SortMismatch => 37.into_dart(),
+            Self::MnemonicNotFound => 38.into_dart(),
+            Self::WalletUniqueName => 39.into_dart(),
+            Self::WalletUniqueId => 40.into_dart(),
+            Self::InvalidNodeId => 41.into_dart(),
+            Self::InvalidBillId => 42.into_dart(),
+            Self::InvalidName => 43.into_dart(),
+            Self::EmptyName => 44.into_dart(),
+            Self::InvalidEmail => 45.into_dart(),
+            Self::EmptyEmail => 46.into_dart(),
+            Self::InvalidContact => 47.into_dart(),
+            Self::MintClientResourceNotFound => 48.into_dart(),
+            Self::MintClientServiceUnavailable => 49.into_dart(),
+            Self::MintClientBadRequest => 50.into_dart(),
+            Self::MintClientKeysetNotFound => 51.into_dart(),
+            Self::MintClientMeltOpSuspended => 52.into_dart(),
+            Self::MintClientCommitmentMismatch => 53.into_dart(),
+            Self::AttestationInvalidProof => 54.into_dart(),
+            Self::AttestationDigestMismatch => 55.into_dart(),
+            Self::AttestationUnknownBeta => 56.into_dart(),
+            Self::AttestationVerifyNotFound => 57.into_dart(),
+            Self::AttestationSignature => 58.into_dart(),
+            Self::BitcoinApi => 59.into_dart(),
             _ => unreachable!(),
         }
     }
@@ -5779,44 +5987,6 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletFfiConfig>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::WalletGetContactRequest {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.wallet_id.into_into_dart().into_dart(),
-            self.node_id.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::WalletGetContactRequest
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletGetContactRequest>
-    for crate::api::WalletGetContactRequest
-{
-    fn into_into_dart(self) -> crate::api::WalletGetContactRequest {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::WalletGetContactResponse {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [self.contact.into_into_dart().into_dart()].into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::WalletGetContactResponse
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletGetContactResponse>
-    for crate::api::WalletGetContactResponse
-{
-    fn into_into_dart(self) -> crate::api::WalletGetContactResponse {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::WalletGetPaymentRequestRequest {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -5913,44 +6083,6 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletInfoResponse>
     for crate::api::WalletInfoResponse
 {
     fn into_into_dart(self) -> crate::api::WalletInfoResponse {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::WalletListContactsRequest {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.wallet_id.into_into_dart().into_dart(),
-            self.search_term.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::WalletListContactsRequest
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletListContactsRequest>
-    for crate::api::WalletListContactsRequest
-{
-    fn into_into_dart(self) -> crate::api::WalletListContactsRequest {
-        self
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for crate::api::WalletListContactsResponse {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [self.contacts.into_into_dart().into_dart()].into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for crate::api::WalletListContactsResponse
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletListContactsResponse>
-    for crate::api::WalletListContactsResponse
-{
-    fn into_into_dart(self) -> crate::api::WalletListContactsResponse {
         self
     }
 }
@@ -6167,6 +6299,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletPayRequest>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletPaymentByContactRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.wallet_id.into_into_dart().into_dart(),
+            self.rid.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletPaymentByContactRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletPaymentByContactRequest>
+    for crate::api::WalletPaymentByContactRequest
+{
+    fn into_into_dart(self) -> crate::api::WalletPaymentByContactRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::WalletPaymentByTokenRequest {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -6268,6 +6421,29 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletPreparePayPaymentReques
     for crate::api::WalletPreparePayPaymentRequestRequest
 {
     fn into_into_dart(self) -> crate::api::WalletPreparePayPaymentRequestRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletPreparePaymentByContactRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.wallet_id.into_into_dart().into_dart(),
+            self.contact_id.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
+            self.description.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletPreparePaymentByContactRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletPreparePaymentByContactRequest>
+    for crate::api::WalletPreparePaymentByContactRequest
+{
+    fn into_into_dart(self) -> crate::api::WalletPreparePaymentByContactRequest {
         self
     }
 }
@@ -6683,7 +6859,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::WalletRequestPaymentFromConta
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.wallet_id.into_into_dart().into_dart(),
-            self.node_id.into_into_dart().into_dart(),
+            self.contact_id.into_into_dart().into_dart(),
             self.amount.into_into_dart().into_dart(),
             self.description.into_into_dart().into_dart(),
             self.deadline.into_into_dart().into_dart(),
@@ -6886,6 +7062,24 @@ impl SseEncode for String {
     }
 }
 
+impl SseEncode for crate::api::AddContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.bitcoin_network, serializer);
+        <Option<String>>::sse_encode(self.email, serializer);
+        <Option<String>>::sse_encode(self.node_id, serializer);
+        <Option<String>>::sse_encode(self.name, serializer);
+        <Option<String>>::sse_encode(self.company, serializer);
+    }
+}
+
+impl SseEncode for crate::api::AddContactResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.contact_id, serializer);
+    }
+}
+
 impl SseEncode for crate::api::AddWalletResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -6939,8 +7133,11 @@ impl SseEncode for crate::api::Cdk18PaymentRequest {
 impl SseEncode for crate::api::Contact {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.node_id, serializer);
-        <String>::sse_encode(self.name, serializer);
+        <String>::sse_encode(self.id, serializer);
+        <Option<String>>::sse_encode(self.node_id, serializer);
+        <Option<String>>::sse_encode(self.email, serializer);
+        <Option<String>>::sse_encode(self.name, serializer);
+        <Option<String>>::sse_encode(self.company, serializer);
     }
 }
 
@@ -6952,6 +7149,40 @@ impl SseEncode for crate::api::CreateWalletRequest {
         <String>::sse_encode(self.bitcoin_network, serializer);
         <String>::sse_encode(self.mnemonic, serializer);
         <Vec<String>>::sse_encode(self.nostr_relays, serializer);
+    }
+}
+
+impl SseEncode for crate::api::DeleteContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.bitcoin_network, serializer);
+        <String>::sse_encode(self.contact_id, serializer);
+    }
+}
+
+impl SseEncode for crate::api::DeleteContactResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.contact_id, serializer);
+    }
+}
+
+impl SseEncode for crate::api::EditContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.bitcoin_network, serializer);
+        <String>::sse_encode(self.contact_id, serializer);
+        <Option<String>>::sse_encode(self.node_id, serializer);
+        <Option<String>>::sse_encode(self.email, serializer);
+        <Option<String>>::sse_encode(self.name, serializer);
+        <Option<String>>::sse_encode(self.company, serializer);
+    }
+}
+
+impl SseEncode for crate::api::EditContactResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.contact_id, serializer);
     }
 }
 
@@ -6968,6 +7199,21 @@ impl SseEncode for crate::api::FeesByMonth {
         <i32>::sse_encode(self.year, serializer);
         <u32>::sse_encode(self.month, serializer);
         <u64>::sse_encode(self.fees, serializer);
+    }
+}
+
+impl SseEncode for crate::api::GetContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.bitcoin_network, serializer);
+        <String>::sse_encode(self.contact_id, serializer);
+    }
+}
+
+impl SseEncode for crate::api::GetContactResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::Contact>::sse_encode(self.contact, serializer);
     }
 }
 
@@ -7032,6 +7278,21 @@ impl SseEncode for Vec<crate::api::Contact> {
         for item in self {
             <crate::api::Contact>::sse_encode(item, serializer);
         }
+    }
+}
+
+impl SseEncode for crate::api::ListContactsRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.bitcoin_network, serializer);
+        <Option<String>>::sse_encode(self.search_term, serializer);
+    }
+}
+
+impl SseEncode for crate::api::ListContactsResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<crate::api::Contact>>::sse_encode(self.contacts, serializer);
     }
 }
 
@@ -7550,22 +7811,6 @@ impl SseEncode for usize {
     }
 }
 
-impl SseEncode for crate::api::WalletAddContactRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.wallet_id, serializer);
-        <String>::sse_encode(self.node_id, serializer);
-        <String>::sse_encode(self.name, serializer);
-    }
-}
-
-impl SseEncode for crate::api::WalletAddContactResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.node_id, serializer);
-    }
-}
-
 impl SseEncode for crate::api::WalletBalanceResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7613,21 +7858,6 @@ impl SseEncode for crate::api::WalletCurrencyUnitResponse {
     }
 }
 
-impl SseEncode for crate::api::WalletDeleteContactRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.wallet_id, serializer);
-        <String>::sse_encode(self.node_id, serializer);
-    }
-}
-
-impl SseEncode for crate::api::WalletDeleteContactResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.node_id, serializer);
-    }
-}
-
 impl SseEncode for crate::api::WalletDevModeDetailedBalanceEntry {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7641,22 +7871,6 @@ impl SseEncode for crate::api::WalletDevModeDetailedBalanceResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <Vec<crate::api::WalletDevModeDetailedBalanceEntry>>::sse_encode(self.entries, serializer);
-    }
-}
-
-impl SseEncode for crate::api::WalletEditContactRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.wallet_id, serializer);
-        <String>::sse_encode(self.node_id, serializer);
-        <String>::sse_encode(self.name, serializer);
-    }
-}
-
-impl SseEncode for crate::api::WalletEditContactResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.node_id, serializer);
     }
 }
 
@@ -7694,58 +7908,62 @@ impl SseEncode for crate::api::WalletErrorCode {
                 crate::api::WalletErrorCode::Network => 1,
                 crate::api::WalletErrorCode::WalletNotFound => 2,
                 crate::api::WalletErrorCode::ContactNotFound => 3,
-                crate::api::WalletErrorCode::PaymentRequestNotFound => 4,
-                crate::api::WalletErrorCode::PaymentRequestInWrongState => 5,
-                crate::api::WalletErrorCode::ContactAlreadyExists => 6,
-                crate::api::WalletErrorCode::EmptyToken => 7,
-                crate::api::WalletErrorCode::InvalidToken => 8,
-                crate::api::WalletErrorCode::CashuMintUrl => 9,
-                crate::api::WalletErrorCode::Url => 10,
-                crate::api::WalletErrorCode::Uuid => 11,
-                crate::api::WalletErrorCode::Amount => 12,
-                crate::api::WalletErrorCode::InsufficientBalance => 13,
-                crate::api::WalletErrorCode::NoActiveKeyset => 14,
-                crate::api::WalletErrorCode::UnknownKeysetId => 15,
-                crate::api::WalletErrorCode::InvalidCurrencyUnit => 16,
-                crate::api::WalletErrorCode::NoPrepareRef => 17,
-                crate::api::WalletErrorCode::InactiveKeyset => 18,
-                crate::api::WalletErrorCode::NoDebitCurrencyInMint => 19,
-                crate::api::WalletErrorCode::InvalidNetwork => 20,
-                crate::api::WalletErrorCode::InvalidBitcoinNetwork => 21,
-                crate::api::WalletErrorCode::InvalidBitcoinTxId => 22,
-                crate::api::WalletErrorCode::MissingAmount => 23,
-                crate::api::WalletErrorCode::UnknownPaymentRequest => 24,
-                crate::api::WalletErrorCode::Unsupported => 25,
-                crate::api::WalletErrorCode::TransactionCantBeReclaimed => 26,
-                crate::api::WalletErrorCode::InsufficientOnChainMeltAmount => 27,
-                crate::api::WalletErrorCode::InsufficientOnChainMintAmount => 28,
-                crate::api::WalletErrorCode::NoDevMode => 29,
-                crate::api::WalletErrorCode::MeltQuoteMismatch => 30,
-                crate::api::WalletErrorCode::SwapCommitmentMismatch => 31,
-                crate::api::WalletErrorCode::InvalidBitcoinAddress => 32,
-                crate::api::WalletErrorCode::InvalidMnemonic => 33,
-                crate::api::WalletErrorCode::InvalidTransactionId => 34,
-                crate::api::WalletErrorCode::InvalidCursor => 35,
-                crate::api::WalletErrorCode::SortMismatch => 36,
-                crate::api::WalletErrorCode::MnemonicNotFound => 37,
-                crate::api::WalletErrorCode::WalletUniqueName => 38,
-                crate::api::WalletErrorCode::WalletUniqueId => 39,
-                crate::api::WalletErrorCode::InvalidNodeId => 40,
-                crate::api::WalletErrorCode::InvalidBillId => 41,
-                crate::api::WalletErrorCode::InvalidName => 42,
-                crate::api::WalletErrorCode::EmptyName => 43,
-                crate::api::WalletErrorCode::MintClientResourceNotFound => 44,
-                crate::api::WalletErrorCode::MintClientServiceUnavailable => 45,
-                crate::api::WalletErrorCode::MintClientBadRequest => 46,
-                crate::api::WalletErrorCode::MintClientKeysetNotFound => 47,
-                crate::api::WalletErrorCode::MintClientMeltOpSuspended => 48,
-                crate::api::WalletErrorCode::MintClientCommitmentMismatch => 49,
-                crate::api::WalletErrorCode::AttestationInvalidProof => 50,
-                crate::api::WalletErrorCode::AttestationDigestMismatch => 51,
-                crate::api::WalletErrorCode::AttestationUnknownBeta => 52,
-                crate::api::WalletErrorCode::AttestationVerifyNotFound => 53,
-                crate::api::WalletErrorCode::AttestationSignature => 54,
-                crate::api::WalletErrorCode::BitcoinApi => 55,
+                crate::api::WalletErrorCode::ContactMustHaveNodeId => 4,
+                crate::api::WalletErrorCode::PaymentRequestNotFound => 5,
+                crate::api::WalletErrorCode::PaymentRequestInWrongState => 6,
+                crate::api::WalletErrorCode::ContactAlreadyExists => 7,
+                crate::api::WalletErrorCode::EmptyToken => 8,
+                crate::api::WalletErrorCode::InvalidToken => 9,
+                crate::api::WalletErrorCode::CashuMintUrl => 10,
+                crate::api::WalletErrorCode::Url => 11,
+                crate::api::WalletErrorCode::Uuid => 12,
+                crate::api::WalletErrorCode::Amount => 13,
+                crate::api::WalletErrorCode::InsufficientBalance => 14,
+                crate::api::WalletErrorCode::NoActiveKeyset => 15,
+                crate::api::WalletErrorCode::UnknownKeysetId => 16,
+                crate::api::WalletErrorCode::InvalidCurrencyUnit => 17,
+                crate::api::WalletErrorCode::NoPrepareRef => 18,
+                crate::api::WalletErrorCode::InactiveKeyset => 19,
+                crate::api::WalletErrorCode::NoDebitCurrencyInMint => 20,
+                crate::api::WalletErrorCode::InvalidNetwork => 21,
+                crate::api::WalletErrorCode::InvalidBitcoinNetwork => 22,
+                crate::api::WalletErrorCode::InvalidBitcoinTxId => 23,
+                crate::api::WalletErrorCode::MissingAmount => 24,
+                crate::api::WalletErrorCode::UnknownPaymentRequest => 25,
+                crate::api::WalletErrorCode::Unsupported => 26,
+                crate::api::WalletErrorCode::TransactionCantBeReclaimed => 27,
+                crate::api::WalletErrorCode::InsufficientOnChainMeltAmount => 28,
+                crate::api::WalletErrorCode::InsufficientOnChainMintAmount => 29,
+                crate::api::WalletErrorCode::NoDevMode => 30,
+                crate::api::WalletErrorCode::MeltQuoteMismatch => 31,
+                crate::api::WalletErrorCode::SwapCommitmentMismatch => 32,
+                crate::api::WalletErrorCode::InvalidBitcoinAddress => 33,
+                crate::api::WalletErrorCode::InvalidMnemonic => 34,
+                crate::api::WalletErrorCode::InvalidTransactionId => 35,
+                crate::api::WalletErrorCode::InvalidCursor => 36,
+                crate::api::WalletErrorCode::SortMismatch => 37,
+                crate::api::WalletErrorCode::MnemonicNotFound => 38,
+                crate::api::WalletErrorCode::WalletUniqueName => 39,
+                crate::api::WalletErrorCode::WalletUniqueId => 40,
+                crate::api::WalletErrorCode::InvalidNodeId => 41,
+                crate::api::WalletErrorCode::InvalidBillId => 42,
+                crate::api::WalletErrorCode::InvalidName => 43,
+                crate::api::WalletErrorCode::EmptyName => 44,
+                crate::api::WalletErrorCode::InvalidEmail => 45,
+                crate::api::WalletErrorCode::EmptyEmail => 46,
+                crate::api::WalletErrorCode::InvalidContact => 47,
+                crate::api::WalletErrorCode::MintClientResourceNotFound => 48,
+                crate::api::WalletErrorCode::MintClientServiceUnavailable => 49,
+                crate::api::WalletErrorCode::MintClientBadRequest => 50,
+                crate::api::WalletErrorCode::MintClientKeysetNotFound => 51,
+                crate::api::WalletErrorCode::MintClientMeltOpSuspended => 52,
+                crate::api::WalletErrorCode::MintClientCommitmentMismatch => 53,
+                crate::api::WalletErrorCode::AttestationInvalidProof => 54,
+                crate::api::WalletErrorCode::AttestationDigestMismatch => 55,
+                crate::api::WalletErrorCode::AttestationUnknownBeta => 56,
+                crate::api::WalletErrorCode::AttestationVerifyNotFound => 57,
+                crate::api::WalletErrorCode::AttestationSignature => 58,
+                crate::api::WalletErrorCode::BitcoinApi => 59,
                 _ => {
                     unimplemented!("");
                 }
@@ -7816,21 +8034,6 @@ impl SseEncode for crate::api::WalletFfiConfig {
     }
 }
 
-impl SseEncode for crate::api::WalletGetContactRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.wallet_id, serializer);
-        <String>::sse_encode(self.node_id, serializer);
-    }
-}
-
-impl SseEncode for crate::api::WalletGetContactResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <crate::api::Contact>::sse_encode(self.contact, serializer);
-    }
-}
-
 impl SseEncode for crate::api::WalletGetPaymentRequestRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7869,21 +8072,6 @@ impl SseEncode for crate::api::WalletInfoResponse {
         <String>::sse_encode(self.network, serializer);
         <String>::sse_encode(self.default_mint_url, serializer);
         <Vec<String>>::sse_encode(self.nostr_relays, serializer);
-    }
-}
-
-impl SseEncode for crate::api::WalletListContactsRequest {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.wallet_id, serializer);
-        <Option<String>>::sse_encode(self.search_term, serializer);
-    }
-}
-
-impl SseEncode for crate::api::WalletListContactsResponse {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <Vec<crate::api::Contact>>::sse_encode(self.contacts, serializer);
     }
 }
 
@@ -7977,6 +8165,14 @@ impl SseEncode for crate::api::WalletPayRequest {
     }
 }
 
+impl SseEncode for crate::api::WalletPaymentByContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.wallet_id, serializer);
+        <String>::sse_encode(self.rid, serializer);
+    }
+}
+
 impl SseEncode for crate::api::WalletPaymentByTokenRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -8017,6 +8213,16 @@ impl SseEncode for crate::api::WalletPreparePayPaymentRequestRequest {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.wallet_id, serializer);
         <String>::sse_encode(self.payment_request_id, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletPreparePaymentByContactRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.wallet_id, serializer);
+        <String>::sse_encode(self.contact_id, serializer);
+        <u64>::sse_encode(self.amount, serializer);
+        <Option<String>>::sse_encode(self.description, serializer);
     }
 }
 
@@ -8187,7 +8393,7 @@ impl SseEncode for crate::api::WalletRequestPaymentFromContactRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.wallet_id, serializer);
-        <String>::sse_encode(self.node_id, serializer);
+        <String>::sse_encode(self.contact_id, serializer);
         <u64>::sse_encode(self.amount, serializer);
         <Option<String>>::sse_encode(self.description, serializer);
         <Option<u64>>::sse_encode(self.deadline, serializer);

--- a/crates/bcr-wallet-persistence/src/lib.rs
+++ b/crates/bcr-wallet-persistence/src/lib.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use bcr_common::cashu::{self, nut00 as cdk00, nut01 as cdk01, nut07 as cdk07};
 use bcr_common::core::NodeId;
 use bcr_wallet_core::contact::Contact;
-use bcr_wallet_core::name::Name;
 use bcr_wallet_core::types::{
     PaymentRequestDirection, PaymentRequestState, Transaction, TransactionLinkReason,
     TransactionStatus,
@@ -195,11 +194,12 @@ pub trait NostrRepository: SendSync {
 #[cfg_attr(any(test, feature = "test-utils"), mockall::automock)]
 #[async_trait]
 pub trait ContactStoreApi: SendSync {
-    async fn add_contact(&self, contact: Contact) -> Result<()>;
-    async fn edit_contact(&self, node_id: NodeId, name: Name) -> Result<()>;
-    async fn edit_contact_relays(&self, node_id: NodeId, relays: Vec<RelayUrl>) -> Result<()>;
-    async fn delete_contact(&self, node_id: NodeId) -> Result<()>;
-    async fn get_contact(&self, node_id: NodeId) -> Result<Option<Contact>>;
+    async fn add_contact(&self, contact: Contact) -> Result<Uuid>;
+    async fn edit_contact(&self, id: Uuid, contact: Contact) -> Result<()>;
+    async fn edit_contact_relays(&self, id: Uuid, relays: Vec<RelayUrl>) -> Result<()>;
+    async fn delete_contact(&self, id: Uuid) -> Result<()>;
+    async fn get_contact(&self, id: Uuid) -> Result<Option<Contact>>;
+    async fn get_contacts_by_node_id(&self, node_id: NodeId) -> Result<Vec<Contact>>;
     async fn list_contacts(&self, search_term: Option<String>) -> Result<Vec<Contact>>;
     async fn delete_repo(&self) -> Result<()>;
 }

--- a/crates/bcr-wallet-persistence/src/redb/contact.rs
+++ b/crates/bcr-wallet-persistence/src/redb/contact.rs
@@ -3,36 +3,59 @@ use crate::{
     error::{Error, Result},
 };
 use async_trait::async_trait;
-use bcr_common::core::NodeId;
-use bcr_wallet_core::{contact::Contact, name::Name};
+use bcr_common::{
+    core::NodeId,
+    wire::borsh::{deserialize_vec_of_strs, serialize_vec_of_strs},
+};
+use bcr_wallet_core::{contact::Contact, email::Email, name::Name};
+use borsh::{BorshDeserialize, BorshSerialize};
 use nostr::types::RelayUrl;
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, TableError};
 use std::sync::Arc;
 use tokio::task::spawn_blocking;
+use uuid::Uuid;
 
-///////////////////////////////////////////// ContactEntry
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
-pub struct ContactEntry {
-    pub node_id: NodeId,
-    pub name: Name,
+/// StoredContact is a versioned, borsh-serialized contact
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) enum StoredContact {
+    V1(StoredContactPayloadV1),
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct StoredContactPayloadV1 {
+    pub id: Uuid,
+    pub node_id: Option<NodeId>,
+    pub email: Option<Email>,
+    pub name: Option<Name>,
+    pub company: Option<Name>,
+    #[borsh(
+        serialize_with = "serialize_vec_of_strs",
+        deserialize_with = "deserialize_vec_of_strs"
+    )]
     pub nostr_relays: Vec<RelayUrl>,
 }
 
-impl From<ContactEntry> for Contact {
-    fn from(value: ContactEntry) -> Self {
+impl From<StoredContactPayloadV1> for Contact {
+    fn from(value: StoredContactPayloadV1) -> Self {
         Self {
+            id: value.id,
             node_id: value.node_id,
+            email: value.email,
             name: value.name,
+            company: value.company,
             nostr_relays: value.nostr_relays,
         }
     }
 }
 
-impl From<Contact> for ContactEntry {
+impl From<Contact> for StoredContactPayloadV1 {
     fn from(value: Contact) -> Self {
         Self {
+            id: value.id,
             node_id: value.node_id,
+            email: value.email,
             name: value.name,
+            company: value.company,
             nostr_relays: value.nostr_relays,
         }
     }
@@ -47,10 +70,14 @@ pub struct ContactDB {
 impl ContactDB {
     const CONTACT_DB_NAME: &'static str = "contact";
 
-    pub fn new(db: Arc<Database>, wallet_id: &str) -> Result<Self> {
+    pub fn contact_table_name(bitcoin_network: bitcoin::Network) -> String {
+        format!("{bitcoin_network}_{}", Self::CONTACT_DB_NAME)
+    }
+
+    pub fn new(db: Arc<Database>, bitcoin_network: bitcoin::Network) -> Result<Self> {
         // Leak once to get static string, because of dynamically generated table names
         let contact_name: &'static str =
-            Box::leak(format!("{wallet_id}_{}", Self::CONTACT_DB_NAME).into_boxed_str());
+            Box::leak(Self::contact_table_name(bitcoin_network).into_boxed_str());
 
         let contact_table = TableDefinition::new(contact_name);
 
@@ -60,46 +87,56 @@ impl ContactDB {
     fn add_contact_sync(
         db: Arc<Database>,
         contact_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-        contact: ContactEntry,
-    ) -> Result<()> {
-        let id = contact.node_id.clone();
+        contact: Contact,
+    ) -> Result<Uuid> {
+        let id = contact.id;
+        let entry = StoredContact::V1(contact.into());
         let write_txn = db.begin_write()?;
 
         {
             let mut table = write_txn.open_table(contact_table)?;
-            let old_value = table.get(id.to_string().as_bytes())?.map(|v| v.value());
 
-            if old_value.is_some() {
-                return Err(Error::ContactAlreadyExists(id.to_string()));
-            }
-            let mut serialized = Vec::new();
-            ciborium::into_writer(&contact, &mut serialized)?;
-            table.insert(id.to_string().as_bytes(), serialized)?;
+            let serialized =
+                borsh::to_vec(&entry).map_err(|e| Error::BorshSerialization(e.to_string()))?;
+            table.insert(id.as_bytes().as_slice(), serialized)?;
         }
 
         write_txn.commit()?;
-        Ok(())
+        Ok(id)
     }
 
     fn edit_contact_sync(
         db: Arc<Database>,
         contact_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-        node_id: NodeId,
-        name: Name,
+        id: Uuid,
+        contact: Contact,
     ) -> Result<()> {
-        let id = node_id.clone();
         let write_txn = db.begin_write()?;
 
         {
             let mut table = write_txn.open_table(contact_table)?;
-            let Some(old_value) = table.get(id.to_string().as_bytes())?.map(|v| v.value()) else {
-                return Ok(());
+            let Some(old_value) = table.get(id.as_bytes().as_slice())?.map(|v| v.value()) else {
+                return Err(Error::ContactNotFound(id.to_string()));
             };
-            let mut entry: ContactEntry = ciborium::from_reader(old_value.as_slice())?;
-            entry.name = name;
-            let mut serialized = Vec::new();
-            ciborium::into_writer(&entry, &mut serialized)?;
-            table.insert(id.to_string().as_bytes(), serialized)?;
+
+            let deserialized: StoredContact = borsh::from_slice(&old_value)
+                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+            let StoredContact::V1(mut entry) = deserialized;
+
+            if entry.id != id {
+                return Err(Error::ContactNotFound(id.to_string()));
+            }
+
+            entry.node_id = contact.node_id;
+            entry.email = contact.email;
+            entry.name = contact.name;
+            entry.company = contact.company;
+            entry.nostr_relays = contact.nostr_relays;
+
+            let serialized = borsh::to_vec(&StoredContact::V1(entry))
+                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+
+            table.insert(id.as_bytes().as_slice(), serialized)?;
         }
 
         write_txn.commit()?;
@@ -109,22 +146,31 @@ impl ContactDB {
     fn edit_contact_relays_sync(
         db: Arc<Database>,
         contact_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-        node_id: NodeId,
+        id: Uuid,
         relays: Vec<RelayUrl>,
     ) -> Result<()> {
-        let id = node_id.clone();
         let write_txn = db.begin_write()?;
 
         {
             let mut table = write_txn.open_table(contact_table)?;
-            let Some(old_value) = table.get(id.to_string().as_bytes())?.map(|v| v.value()) else {
-                return Ok(());
+            let Some(old_value) = table.get(id.as_bytes().as_slice())?.map(|v| v.value()) else {
+                return Err(Error::ContactNotFound(id.to_string()));
             };
-            let mut entry: ContactEntry = ciborium::from_reader(old_value.as_slice())?;
+
+            let deserialized: StoredContact = borsh::from_slice(&old_value)
+                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+            let StoredContact::V1(mut entry) = deserialized;
+
+            if entry.id != id {
+                return Err(Error::ContactNotFound(id.to_string()));
+            }
+
             entry.nostr_relays = relays;
-            let mut serialized = Vec::new();
-            ciborium::into_writer(&entry, &mut serialized)?;
-            table.insert(id.to_string().as_bytes(), serialized)?;
+
+            let serialized = borsh::to_vec(&StoredContact::V1(entry))
+                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+
+            table.insert(id.as_bytes().as_slice(), serialized)?;
         }
 
         write_txn.commit()?;
@@ -134,13 +180,13 @@ impl ContactDB {
     fn delete_contact_sync(
         db: Arc<Database>,
         contact_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-        node_id: NodeId,
+        id: Uuid,
     ) -> Result<()> {
         let write_txn = db.begin_write()?;
 
         {
             let mut table = write_txn.open_table(contact_table)?;
-            table.remove(node_id.to_string().as_bytes())?;
+            table.remove(id.as_bytes().as_slice())?;
         }
 
         write_txn.commit()?;
@@ -150,17 +196,20 @@ impl ContactDB {
     fn get_contact_sync(
         db: Arc<Database>,
         contact_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
-        node_id: NodeId,
-    ) -> Result<Option<ContactEntry>> {
+        id: Uuid,
+    ) -> Result<Option<Contact>> {
         let read_txn = db.begin_read()?;
 
         match read_txn.open_table(contact_table) {
             Ok(table) => {
-                let entry = table.get(node_id.to_string().as_bytes())?;
+                let entry = table.get(id.as_bytes().as_slice())?;
                 match entry {
                     Some(e) => {
-                        let contact: ContactEntry = ciborium::from_reader(e.value().as_slice())?;
-                        Ok(Some(contact))
+                        let deserialized: StoredContact =
+                            borsh::from_slice(e.value().as_slice())
+                                .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                        let StoredContact::V1(contact) = deserialized;
+                        Ok(Some(contact.into()))
                     }
                     None => Ok(None),
                 }
@@ -170,25 +219,63 @@ impl ContactDB {
         }
     }
 
+    fn get_contacts_by_node_id_sync(
+        db: Arc<Database>,
+        contact_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        node_id: NodeId,
+    ) -> Result<Vec<Contact>> {
+        let read_txn = db.begin_read()?;
+        let to_find = Some(node_id);
+
+        match read_txn.open_table(contact_table) {
+            Ok(table) => {
+                let mut res: Vec<Contact> = Vec::new();
+                for item in table.range::<&[u8]>(..)? {
+                    let (_, v) = item?;
+                    let deserialized: StoredContact = borsh::from_slice(v.value().as_slice())
+                        .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                    let StoredContact::V1(contact) = deserialized;
+                    if contact.node_id == to_find {
+                        res.push(contact.into());
+                    }
+                }
+                Ok(res)
+            }
+            Err(TableError::TableDoesNotExist(_)) => Ok(vec![]),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     fn list_contacts_sync(
         db: Arc<Database>,
         contact_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
         search_term: Option<String>,
-    ) -> Result<Vec<ContactEntry>> {
+    ) -> Result<Vec<Contact>> {
         let read_txn = db.begin_read()?;
 
         match read_txn.open_table(contact_table) {
             Ok(table) => {
-                let mut res = Vec::new();
-                for (_, v) in table.range::<&[u8]>(..)?.flatten() {
-                    let entry: ContactEntry = ciborium::from_reader(v.value().as_slice())?;
-                    res.push(entry);
+                let mut res: Vec<Contact> = Vec::new();
+                for item in table.range::<&[u8]>(..)? {
+                    let (_, v) = item?;
+                    let deserialized: StoredContact = borsh::from_slice(v.value().as_slice())
+                        .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                    let StoredContact::V1(contact) = deserialized;
+                    res.push(contact.into());
                 }
                 let search_term = search_term.map(|st| st.to_lowercase());
+                // search in name and company
                 match search_term {
                     Some(st) => Ok(res
                         .into_iter()
-                        .filter(|ct| ct.name.as_str().to_lowercase().contains(&st))
+                        .filter(|ct| {
+                            ct.name
+                                .as_ref()
+                                .is_some_and(|name| name.as_str().to_lowercase().contains(&st))
+                                || ct.company.as_ref().is_some_and(|company| {
+                                    company.as_str().to_lowercase().contains(&st)
+                                })
+                        })
                         .collect()),
                     None => Ok(res),
                 }
@@ -217,38 +304,47 @@ impl ContactDB {
 
 #[async_trait]
 impl ContactStoreApi for ContactDB {
-    async fn add_contact(&self, contact: Contact) -> Result<()> {
-        let db_clone = self.db.clone();
-        let table = self.contact_table;
-        spawn_blocking(move || Self::add_contact_sync(db_clone, table, contact.into())).await?
-    }
-
-    async fn edit_contact(&self, node_id: NodeId, name: Name) -> Result<()> {
-        let db_clone = self.db.clone();
-        let table = self.contact_table;
-        spawn_blocking(move || Self::edit_contact_sync(db_clone, table, node_id, name)).await?
-    }
-
-    async fn edit_contact_relays(&self, node_id: NodeId, relays: Vec<RelayUrl>) -> Result<()> {
-        let db_clone = self.db.clone();
-        let table = self.contact_table;
-        spawn_blocking(move || Self::edit_contact_relays_sync(db_clone, table, node_id, relays))
-            .await?
-    }
-
-    async fn delete_contact(&self, node_id: NodeId) -> Result<()> {
-        let db_clone = self.db.clone();
-        let table = self.contact_table;
-        spawn_blocking(move || Self::delete_contact_sync(db_clone, table, node_id)).await??;
-        Ok(())
-    }
-
-    async fn get_contact(&self, node_id: NodeId) -> Result<Option<Contact>> {
+    async fn add_contact(&self, contact: Contact) -> Result<Uuid> {
         let db_clone = self.db.clone();
         let table = self.contact_table;
         let res =
-            spawn_blocking(move || Self::get_contact_sync(db_clone, table, node_id)).await??;
-        Ok(res.map(|c| c.into()))
+            spawn_blocking(move || Self::add_contact_sync(db_clone, table, contact)).await??;
+        Ok(res)
+    }
+
+    async fn edit_contact(&self, id: Uuid, contact: Contact) -> Result<()> {
+        let db_clone = self.db.clone();
+        let table = self.contact_table;
+        spawn_blocking(move || Self::edit_contact_sync(db_clone, table, id, contact)).await?
+    }
+
+    async fn edit_contact_relays(&self, id: Uuid, relays: Vec<RelayUrl>) -> Result<()> {
+        let db_clone = self.db.clone();
+        let table = self.contact_table;
+        spawn_blocking(move || Self::edit_contact_relays_sync(db_clone, table, id, relays)).await?
+    }
+
+    async fn delete_contact(&self, id: Uuid) -> Result<()> {
+        let db_clone = self.db.clone();
+        let table = self.contact_table;
+        spawn_blocking(move || Self::delete_contact_sync(db_clone, table, id)).await??;
+        Ok(())
+    }
+
+    async fn get_contact(&self, id: Uuid) -> Result<Option<Contact>> {
+        let db_clone = self.db.clone();
+        let table = self.contact_table;
+        let res = spawn_blocking(move || Self::get_contact_sync(db_clone, table, id)).await??;
+        Ok(res)
+    }
+
+    async fn get_contacts_by_node_id(&self, node_id: NodeId) -> Result<Vec<Contact>> {
+        let db_clone = self.db.clone();
+        let table = self.contact_table;
+        let res =
+            spawn_blocking(move || Self::get_contacts_by_node_id_sync(db_clone, table, node_id))
+                .await??;
+        Ok(res)
     }
 
     async fn list_contacts(&self, search_term: Option<String>) -> Result<Vec<Contact>> {
@@ -256,7 +352,7 @@ impl ContactStoreApi for ContactDB {
         let table = self.contact_table;
         let res = spawn_blocking(move || Self::list_contacts_sync(db_clone, table, search_term))
             .await??;
-        Ok(res.into_iter().map(|entry| entry.into()).collect())
+        Ok(res)
     }
 
     async fn delete_repo(&self) -> Result<()> {
@@ -281,7 +377,7 @@ mod tests {
     const NODE_ID_3: &str =
         "bitcrt03f9f94d1fdc2090d46f3524807e3f58618c36988e69577d70d5d4d1e9e9645a4f";
 
-    fn get_db(wallet_id: &str) -> ContactDB {
+    fn get_db(bitcoin_network: bitcoin::Network) -> ContactDB {
         let in_mem = InMemoryBackend::new();
         let db = Arc::new(
             Builder::new()
@@ -289,7 +385,7 @@ mod tests {
                 .expect("can create in-memory redb"),
         );
 
-        ContactDB::new(db, wallet_id).expect("can create ContactDB")
+        ContactDB::new(db, bitcoin_network).expect("can create ContactDB")
     }
 
     fn node_id(value: &str) -> NodeId {
@@ -302,18 +398,21 @@ mod tests {
 
     fn contact(node_id: &str, name: &str) -> Contact {
         Contact {
-            node_id: self::node_id(node_id),
-            name: self::name(name),
+            id: Uuid::new_v4(),
+            node_id: Some(self::node_id(node_id)),
+            email: None,
+            name: Some(self::name(name)),
+            company: None,
             nostr_relays: vec![],
         }
     }
 
     #[tokio::test]
     async fn test_get_contact_empty_returns_none() {
-        let repo = get_db("wallet-empty-contact");
+        let repo = get_db(bitcoin::Network::Testnet);
 
         let result = repo
-            .get_contact(node_id(NODE_ID_1))
+            .get_contact(Uuid::new_v4())
             .await
             .expect("get_contact works");
 
@@ -322,7 +421,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_contacts_empty_returns_empty_vec() {
-        let repo = get_db("wallet-empty-list");
+        let repo = get_db(bitcoin::Network::Testnet);
 
         let result = repo.list_contacts(None).await.expect("list_contacts works");
 
@@ -331,73 +430,88 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_contact_can_be_retrieved() {
-        let repo = get_db("wallet-store-contact");
+        let repo = get_db(bitcoin::Network::Testnet);
         let node_id = node_id(NODE_ID_1);
+        let id = Uuid::new_v4();
 
         repo.add_contact(Contact {
-            node_id: node_id.clone(),
-            name: name("Alice"),
+            id,
+            node_id: Some(node_id.clone()),
+            email: None,
+            name: Some(name("Alice")),
+            company: None,
             nostr_relays: vec![],
         })
         .await
         .expect("add_contact works");
 
         let result = repo
-            .get_contact(node_id)
+            .get_contact(id)
             .await
             .expect("get_contact works")
             .expect("contact exists");
 
-        assert_eq!(result.name, name("Alice"));
+        assert_eq!(result.name, Some(name("Alice")));
     }
 
     #[tokio::test]
-    async fn test_edit_contact_overwrites_existing_contact_for_same_node_id() {
-        let repo = get_db("wallet-overwrite-contact");
+    async fn test_edit_contact_overwrites_existing_contact_for_same_id() {
+        let repo = get_db(bitcoin::Network::Testnet);
         let node_id = node_id(NODE_ID_1);
-
-        repo.add_contact(Contact {
-            node_id: node_id.clone(),
-            name: name("Alice"),
+        let id = Uuid::new_v4();
+        let c = Contact {
+            id,
+            node_id: Some(node_id.clone()),
+            email: None,
+            name: Some(name("Alice")),
+            company: None,
             nostr_relays: vec![],
-        })
-        .await
-        .expect("add first contact works");
+        };
 
-        repo.edit_contact(node_id.clone(), name("Alice Updated"))
+        repo.add_contact(c.clone())
+            .await
+            .expect("add first contact works");
+        let mut updated = c.clone();
+        updated.name = Some(name("Alice Updated"));
+
+        repo.edit_contact(id, updated)
             .await
             .expect("edit updated contact works");
 
         let result = repo
-            .get_contact(node_id)
+            .get_contact(id)
             .await
             .expect("get_contact works")
             .expect("contact exists");
 
-        assert_eq!(result.name, name("Alice Updated"));
+        assert_eq!(result.name, Some(name("Alice Updated")));
     }
 
     #[tokio::test]
-    async fn test_edit_contact_relays_overwrites_existing_contact_relays_for_same_node_id() {
-        let repo = get_db("wallet-overwrite-contact");
+    async fn test_edit_contact_relays_overwrites_existing_contact_relays_for_same_id() {
+        let repo = get_db(bitcoin::Network::Testnet);
         let node_id = node_id(NODE_ID_1);
+        let id = Uuid::new_v4();
 
         repo.add_contact(Contact {
-            node_id: node_id.clone(),
-            name: name("Alice"),
-            nostr_relays: vec![RelayUrl::from_str("wss://test.example").unwrap()],
+            id,
+            node_id: Some(node_id.clone()),
+            email: None,
+            name: Some(name("Alice")),
+            company: None,
+            nostr_relays: vec![],
         })
         .await
         .expect("add contact works");
 
         let new_relays = vec![RelayUrl::from_str("wss://test2.example").unwrap()];
 
-        repo.edit_contact_relays(node_id.clone(), new_relays)
+        repo.edit_contact_relays(id, new_relays)
             .await
             .expect("edit updated contact relays works");
 
         let result = repo
-            .get_contact(node_id)
+            .get_contact(id)
             .await
             .expect("get_contact works")
             .expect("contact exists");
@@ -411,15 +525,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_contact_returns_none_for_unknown_node_id() {
-        let repo = get_db("wallet-missing-contact");
+    async fn test_get_contact_returns_none_for_unknown_id() {
+        let repo = get_db(bitcoin::Network::Testnet);
 
         repo.add_contact(contact(NODE_ID_1, "Alice"))
             .await
             .expect("add_contact works");
 
         let result = repo
-            .get_contact(node_id(NODE_ID_2))
+            .get_contact(Uuid::new_v4())
             .await
             .expect("get_contact works");
 
@@ -427,8 +541,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_contacts_by_node_id_returns_all_contacts() {
+        let repo = get_db(bitcoin::Network::Testnet);
+
+        repo.add_contact(contact(NODE_ID_1, "Alice"))
+            .await
+            .expect("store Alice works");
+
+        repo.add_contact(contact(NODE_ID_1, "Bob"))
+            .await
+            .expect("store Bob works");
+
+        let mut result = repo
+            .get_contacts_by_node_id(node_id(NODE_ID_1))
+            .await
+            .expect("works works");
+
+        result.sort_by(|a, b| a.name.cmp(&b.name));
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name, Some(name("Alice")));
+        assert_eq!(result[1].name, Some(name("Bob")));
+    }
+
+    #[tokio::test]
     async fn test_list_contacts_returns_all_contacts() {
-        let repo = get_db("wallet-list-contacts");
+        let repo = get_db(bitcoin::Network::Testnet);
 
         repo.add_contact(contact(NODE_ID_1, "Alice"))
             .await
@@ -440,16 +578,16 @@ mod tests {
 
         let mut result = repo.list_contacts(None).await.expect("list_contacts works");
 
-        result.sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
+        result.sort_by(|a, b| a.name.cmp(&b.name));
 
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0].name, name("Alice"));
-        assert_eq!(result[1].name, name("Bob"));
+        assert_eq!(result[0].name, Some(name("Alice")));
+        assert_eq!(result[1].name, Some(name("Bob")));
     }
 
     #[tokio::test]
     async fn test_list_contacts_filters_by_search_term() {
-        let repo = get_db("wallet-search-contacts");
+        let repo = get_db(bitcoin::Network::Testnet);
 
         repo.add_contact(contact(NODE_ID_1, "Alice"))
             .await
@@ -468,16 +606,16 @@ mod tests {
             .await
             .expect("list_contacts with search term works");
 
-        result.sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
+        result.sort_by(|a, b| a.name.cmp(&b.name));
 
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0].name, name("Alice"));
-        assert_eq!(result[1].name, name("Alicia"));
+        assert_eq!(result[0].name, Some(name("Alice")));
+        assert_eq!(result[1].name, Some(name("Alicia")));
     }
 
     #[tokio::test]
     async fn test_list_contacts_filters_by_search_term_case_insensitive() {
-        let repo = get_db("wallet-search-contacts-case-insensitive");
+        let repo = get_db(bitcoin::Network::Testnet);
 
         repo.add_contact(contact(NODE_ID_1, "Alice"))
             .await
@@ -496,16 +634,16 @@ mod tests {
             .await
             .expect("list_contacts with lowercase search term works");
 
-        result.sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
+        result.sort_by(|a, b| a.name.cmp(&b.name));
 
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0].name, name("Alice"));
-        assert_eq!(result[1].name, name("Alicia"));
+        assert_eq!(result[0].name, Some(name("Alice")));
+        assert_eq!(result[1].name, Some(name("Alicia")));
     }
 
     #[tokio::test]
     async fn test_list_contacts_search_term_without_matches_returns_empty_vec() {
-        let repo = get_db("wallet-search-no-matches");
+        let repo = get_db(bitcoin::Network::Testnet);
 
         repo.add_contact(contact(NODE_ID_1, "Alice"))
             .await
@@ -525,62 +663,66 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_contact_removes_existing_contact() {
-        let repo = get_db("wallet-delete-contact");
+        let repo = get_db(bitcoin::Network::Testnet);
         let node_id = node_id(NODE_ID_1);
+        let id = Uuid::new_v4();
 
         repo.add_contact(Contact {
-            node_id: node_id.clone(),
-            name: name("Alice"),
+            id,
+            email: None,
+            node_id: Some(node_id.clone()),
+            name: Some(name("Alice")),
+            company: None,
             nostr_relays: vec![],
         })
         .await
         .expect("add_contact works");
 
-        repo.delete_contact(node_id.clone())
-            .await
-            .expect("delete_contact works");
+        repo.delete_contact(id).await.expect("delete_contact works");
 
-        let result = repo.get_contact(node_id).await.expect("get_contact works");
+        let result = repo.get_contact(id).await.expect("get_contact works");
 
         assert!(result.is_none());
     }
 
     #[tokio::test]
     async fn test_delete_contact_does_not_remove_other_contacts() {
-        let repo = get_db("wallet-delete-other-contact");
+        let repo = get_db(bitcoin::Network::Testnet);
+        let c_1 = contact(NODE_ID_1, "Alice");
+        let c_2 = contact(NODE_ID_2, "Bob");
 
-        repo.add_contact(contact(NODE_ID_1, "Alice"))
+        repo.add_contact(c_1.clone())
             .await
             .expect("store Alice works");
 
-        repo.add_contact(contact(NODE_ID_2, "Bob"))
+        repo.add_contact(c_2.clone())
             .await
             .expect("store Bob works");
 
-        repo.delete_contact(node_id(NODE_ID_1))
+        repo.delete_contact(c_1.id)
             .await
             .expect("delete_contact works");
 
         let deleted = repo
-            .get_contact(node_id(NODE_ID_1))
+            .get_contact(c_1.id)
             .await
             .expect("get deleted contact works");
 
         let remaining = repo
-            .get_contact(node_id(NODE_ID_2))
+            .get_contact(c_2.id)
             .await
             .expect("get remaining contact works")
             .expect("Bob remains");
 
         assert!(deleted.is_none());
-        assert_eq!(remaining.name, name("Bob"));
+        assert_eq!(remaining.name, Some(name("Bob")));
     }
 
     #[tokio::test]
     async fn test_delete_contact_ignores_missing_contact() {
-        let repo = get_db("wallet-delete-missing-contact");
+        let repo = get_db(bitcoin::Network::Testnet);
 
-        repo.delete_contact(node_id(NODE_ID_1))
+        repo.delete_contact(Uuid::new_v4())
             .await
             .expect("delete_contact ignores missing contacts");
     }
@@ -594,17 +736,21 @@ mod tests {
                 .expect("can create in-memory redb"),
         );
 
-        let repo_a = ContactDB::new(db.clone(), "wallet-a").expect("can create repo a");
-        let repo_b = ContactDB::new(db.clone(), "wallet-b").expect("can create repo b");
+        let repo_a =
+            ContactDB::new(db.clone(), bitcoin::Network::Testnet).expect("can create repo testnet");
+        let repo_b = ContactDB::new(db.clone(), bitcoin::Network::Testnet4)
+            .expect("can create repo testnet4");
+
+        let c_1 = contact(NODE_ID_1, "Alice");
 
         repo_a
-            .add_contact(contact(NODE_ID_1, "Alice"))
+            .add_contact(c_1.clone())
             .await
             .expect("store contact in repo a works");
 
         assert!(
             repo_a
-                .get_contact(node_id(NODE_ID_1))
+                .get_contact(c_1.id)
                 .await
                 .expect("get_contact repo a works")
                 .is_some()
@@ -612,7 +758,7 @@ mod tests {
 
         assert!(
             repo_b
-                .get_contact(node_id(NODE_ID_1))
+                .get_contact(c_1.id)
                 .await
                 .expect("get_contact repo b works")
                 .is_none()

--- a/crates/bcr-wallet-persistence/src/redb/mod.rs
+++ b/crates/bcr-wallet-persistence/src/redb/mod.rs
@@ -12,6 +12,7 @@ pub use ::redb::Database;
 use bcr_common::cashu::CurrencyUnit;
 use bcr_wallet_core::types::Seed;
 use bcr_wallet_core::util::keypair_from_seed;
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -20,11 +21,55 @@ pub fn create_db(path: impl AsRef<Path>) -> Result<Database> {
     Ok(db)
 }
 
-pub async fn build_pursedb(_db_version: u32, db: Arc<Database>) -> Result<purse::PurseDB> {
+pub async fn build_pursedbs(
+    _db_version: u32,
+    db: Arc<Database>,
+) -> Result<(
+    purse::PurseDB,
+    HashMap<bitcoin::Network, Arc<contact::ContactDB>>,
+)> {
     // Execute Migrations for purse
     migration::migrate_purse(db.clone()).await?;
 
-    purse::PurseDB::new(db)
+    let mut contact_dbs = HashMap::new();
+    contact_dbs.insert(
+        bitcoin::Network::Testnet,
+        Arc::new(contact::ContactDB::new(
+            db.clone(),
+            bitcoin::Network::Testnet,
+        )?),
+    );
+    contact_dbs.insert(
+        bitcoin::Network::Testnet4,
+        Arc::new(contact::ContactDB::new(
+            db.clone(),
+            bitcoin::Network::Testnet4,
+        )?),
+    );
+    contact_dbs.insert(
+        bitcoin::Network::Regtest,
+        Arc::new(contact::ContactDB::new(
+            db.clone(),
+            bitcoin::Network::Regtest,
+        )?),
+    );
+    contact_dbs.insert(
+        bitcoin::Network::Signet,
+        Arc::new(contact::ContactDB::new(
+            db.clone(),
+            bitcoin::Network::Signet,
+        )?),
+    );
+    contact_dbs.insert(
+        bitcoin::Network::Bitcoin,
+        Arc::new(contact::ContactDB::new(
+            db.clone(),
+            bitcoin::Network::Bitcoin,
+        )?),
+    );
+
+    let pursedb = purse::PurseDB::new(db)?;
+    Ok((pursedb, contact_dbs))
 }
 
 pub async fn build_wallet_dbs(
@@ -38,7 +83,6 @@ pub async fn build_wallet_dbs(
     pocket::PocketDB,
     mintmelt::MintMeltDB,
     nostr::NostrDB,
-    contact::ContactDB,
     payment_request::PaymentRequestDB,
 )> {
     let keys = keypair_from_seed(seed);
@@ -52,7 +96,6 @@ pub async fn build_wallet_dbs(
     let debitdb = pocket::PocketDB::new(db.clone(), wallet_id, debit, keys)?;
     let mintmeltdb = mintmelt::MintMeltDB::new(db.clone(), wallet_id, debit)?;
     let nostrdb = nostr::NostrDB::new(db.clone(), wallet_id)?;
-    let contactdb = contact::ContactDB::new(db.clone(), wallet_id)?;
     let pending_payment_requests_db =
         payment_request::PaymentRequestDB::new(db.clone(), wallet_id)?;
     Ok((
@@ -60,7 +103,6 @@ pub async fn build_wallet_dbs(
         debitdb,
         mintmeltdb,
         nostrdb,
-        contactdb,
         pending_payment_requests_db,
     ))
 }

--- a/crates/bcr-wallet-transport/src/lib.rs
+++ b/crates/bcr-wallet-transport/src/lib.rs
@@ -22,7 +22,7 @@ pub enum SortOrder {
 pub trait TransportApi: SendSync {
     async fn send_private_msg(&self, target: String, payload: String) -> Result<EventId>;
     async fn cdk18_transport(&self) -> Result<cdk18::Transport>;
-    async fn nip19_for_contact(&self, contact: &Contact) -> Result<String>;
+    async fn nip19_for_contact(&self, contact: &Contact) -> Result<Option<String>>;
     async fn shutdown(&self);
     fn relays(&self) -> &[RelayUrl];
     async fn has_connected_relays(&self) -> bool;

--- a/crates/bcr-wallet-transport/src/nostr.rs
+++ b/crates/bcr-wallet-transport/src/nostr.rs
@@ -289,10 +289,15 @@ impl TransportApi for Transport {
         })
     }
 
-    async fn nip19_for_contact(&self, contact: &Contact) -> Result<String> {
-        let target =
-            Nip19Profile::new(contact.node_id.npub(), contact.nostr_relays.clone()).to_bech32()?;
-        Ok(target)
+    async fn nip19_for_contact(&self, contact: &Contact) -> Result<Option<String>> {
+        Ok(match contact.node_id.as_ref() {
+            Some(node_id) => {
+                let target =
+                    Nip19Profile::new(node_id.npub(), contact.nostr_relays.clone()).to_bech32()?;
+                Some(target)
+            }
+            None => None,
+        })
     }
 
     async fn shutdown(&self) {

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `get_app_state`, `init_logging`, `init_panic_hook`, `new`, `reset_runtime`, `start_jobs`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `PaymentRequestState`, `WalletCleanLocalDbResponse`, `WalletRuntime`, `WalletsNamesResponse`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
 
 Future<void> initWalletFfi({required WalletFfiConfig conf}) =>
     RustLib.instance.api.crateApiInitWalletFfi(conf: conf);
@@ -142,25 +142,29 @@ Future<WalletListTransactionsResponse> walletGetTransactions({
 Future<WalletsIdsResponse> walletGetIds() =>
     RustLib.instance.api.crateApiWalletGetIds();
 
-Future<WalletAddContactResponse> walletAddContact({
-  required WalletAddContactRequest req,
-}) => RustLib.instance.api.crateApiWalletAddContact(req: req);
+Future<AddContactResponse> addContact({required AddContactRequest req}) =>
+    RustLib.instance.api.crateApiAddContact(req: req);
 
-Future<WalletEditContactResponse> walletEditContact({
-  required WalletEditContactRequest req,
-}) => RustLib.instance.api.crateApiWalletEditContact(req: req);
+Future<EditContactResponse> editContact({required EditContactRequest req}) =>
+    RustLib.instance.api.crateApiEditContact(req: req);
 
-Future<WalletDeleteContactResponse> walletDeleteContact({
-  required WalletDeleteContactRequest req,
-}) => RustLib.instance.api.crateApiWalletDeleteContact(req: req);
+Future<DeleteContactResponse> deleteContact({
+  required DeleteContactRequest req,
+}) => RustLib.instance.api.crateApiDeleteContact(req: req);
 
-Future<WalletGetContactResponse> walletGetContact({
-  required WalletGetContactRequest req,
-}) => RustLib.instance.api.crateApiWalletGetContact(req: req);
+Future<GetContactResponse> getContact({required GetContactRequest req}) =>
+    RustLib.instance.api.crateApiGetContact(req: req);
 
-Future<WalletListContactsResponse> walletListContacts({
-  required WalletListContactsRequest req,
-}) => RustLib.instance.api.crateApiWalletListContacts(req: req);
+Future<ListContactsResponse> listContacts({required ListContactsRequest req}) =>
+    RustLib.instance.api.crateApiListContacts(req: req);
+
+Future<WalletPreparePaymentResponse> walletPreparePayToContact({
+  required WalletPreparePaymentByContactRequest req,
+}) => RustLib.instance.api.crateApiWalletPreparePayToContact(req: req);
+
+Future<WalletTransactionIdResponse> walletPayToContact({
+  required WalletPaymentByContactRequest req,
+}) => RustLib.instance.api.crateApiWalletPayToContact(req: req);
 
 Future<WalletRequestPaymentFromContactResponse>
 walletRequestPaymentFromContact({
@@ -238,6 +242,57 @@ Future<SetDevModeResponse> walletSetDevMode({required SetDevModeRequest req}) =>
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<WalletPaymentCheckHandle>>
 abstract class WalletPaymentCheckHandle implements RustOpaqueInterface {
   Future<void> cancel();
+}
+
+class AddContactRequest {
+  final String bitcoinNetwork;
+  final String? email;
+  final String? nodeId;
+  final String? name;
+  final String? company;
+
+  const AddContactRequest({
+    required this.bitcoinNetwork,
+    this.email,
+    this.nodeId,
+    this.name,
+    this.company,
+  });
+
+  @override
+  int get hashCode =>
+      bitcoinNetwork.hashCode ^
+      email.hashCode ^
+      nodeId.hashCode ^
+      name.hashCode ^
+      company.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AddContactRequest &&
+          runtimeType == other.runtimeType &&
+          bitcoinNetwork == other.bitcoinNetwork &&
+          email == other.email &&
+          nodeId == other.nodeId &&
+          name == other.name &&
+          company == other.company;
+}
+
+class AddContactResponse {
+  final String contactId;
+
+  const AddContactResponse({required this.contactId});
+
+  @override
+  int get hashCode => contactId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AddContactResponse &&
+          runtimeType == other.runtimeType &&
+          contactId == other.contactId;
 }
 
 class AddWalletResponse {
@@ -350,21 +405,38 @@ class Cdk18PaymentRequest {
 }
 
 class Contact {
-  final String nodeId;
-  final String name;
+  final String id;
+  final String? nodeId;
+  final String? email;
+  final String? name;
+  final String? company;
 
-  const Contact({required this.nodeId, required this.name});
+  const Contact({
+    required this.id,
+    this.nodeId,
+    this.email,
+    this.name,
+    this.company,
+  });
 
   @override
-  int get hashCode => nodeId.hashCode ^ name.hashCode;
+  int get hashCode =>
+      id.hashCode ^
+      nodeId.hashCode ^
+      email.hashCode ^
+      name.hashCode ^
+      company.hashCode;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is Contact &&
           runtimeType == other.runtimeType &&
+          id == other.id &&
           nodeId == other.nodeId &&
-          name == other.name;
+          email == other.email &&
+          name == other.name &&
+          company == other.company;
 }
 
 class CreateWalletRequest {
@@ -402,6 +474,98 @@ class CreateWalletRequest {
           nostrRelays == other.nostrRelays;
 }
 
+class DeleteContactRequest {
+  final String bitcoinNetwork;
+  final String contactId;
+
+  const DeleteContactRequest({
+    required this.bitcoinNetwork,
+    required this.contactId,
+  });
+
+  @override
+  int get hashCode => bitcoinNetwork.hashCode ^ contactId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DeleteContactRequest &&
+          runtimeType == other.runtimeType &&
+          bitcoinNetwork == other.bitcoinNetwork &&
+          contactId == other.contactId;
+}
+
+class DeleteContactResponse {
+  final String contactId;
+
+  const DeleteContactResponse({required this.contactId});
+
+  @override
+  int get hashCode => contactId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DeleteContactResponse &&
+          runtimeType == other.runtimeType &&
+          contactId == other.contactId;
+}
+
+class EditContactRequest {
+  final String bitcoinNetwork;
+  final String contactId;
+  final String? nodeId;
+  final String? email;
+  final String? name;
+  final String? company;
+
+  const EditContactRequest({
+    required this.bitcoinNetwork,
+    required this.contactId,
+    this.nodeId,
+    this.email,
+    this.name,
+    this.company,
+  });
+
+  @override
+  int get hashCode =>
+      bitcoinNetwork.hashCode ^
+      contactId.hashCode ^
+      nodeId.hashCode ^
+      email.hashCode ^
+      name.hashCode ^
+      company.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EditContactRequest &&
+          runtimeType == other.runtimeType &&
+          bitcoinNetwork == other.bitcoinNetwork &&
+          contactId == other.contactId &&
+          nodeId == other.nodeId &&
+          email == other.email &&
+          name == other.name &&
+          company == other.company;
+}
+
+class EditContactResponse {
+  final String contactId;
+
+  const EditContactResponse({required this.contactId});
+
+  @override
+  int get hashCode => contactId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EditContactResponse &&
+          runtimeType == other.runtimeType &&
+          contactId == other.contactId;
+}
+
 class FeesByMonth {
   final int year;
   final int month;
@@ -424,6 +588,43 @@ class FeesByMonth {
           year == other.year &&
           month == other.month &&
           fees == other.fees;
+}
+
+class GetContactRequest {
+  final String bitcoinNetwork;
+  final String contactId;
+
+  const GetContactRequest({
+    required this.bitcoinNetwork,
+    required this.contactId,
+  });
+
+  @override
+  int get hashCode => bitcoinNetwork.hashCode ^ contactId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GetContactRequest &&
+          runtimeType == other.runtimeType &&
+          bitcoinNetwork == other.bitcoinNetwork &&
+          contactId == other.contactId;
+}
+
+class GetContactResponse {
+  final Contact contact;
+
+  const GetContactResponse({required this.contact});
+
+  @override
+  int get hashCode => contact.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GetContactResponse &&
+          runtimeType == other.runtimeType &&
+          contact == other.contact;
 }
 
 class IsValidTokenRequest {
@@ -468,6 +669,40 @@ class IsValidTokenResponse {
           memo == other.memo &&
           mintUrl == other.mintUrl &&
           unit == other.unit;
+}
+
+class ListContactsRequest {
+  final String bitcoinNetwork;
+  final String? searchTerm;
+
+  const ListContactsRequest({required this.bitcoinNetwork, this.searchTerm});
+
+  @override
+  int get hashCode => bitcoinNetwork.hashCode ^ searchTerm.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ListContactsRequest &&
+          runtimeType == other.runtimeType &&
+          bitcoinNetwork == other.bitcoinNetwork &&
+          searchTerm == other.searchTerm;
+}
+
+class ListContactsResponse {
+  final List<Contact> contacts;
+
+  const ListContactsResponse({required this.contacts});
+
+  @override
+  int get hashCode => contacts.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ListContactsResponse &&
+          runtimeType == other.runtimeType &&
+          contacts == other.contacts;
 }
 
 class MigrateRabidResponse {
@@ -943,46 +1178,6 @@ enum TransactionStatus {
       RustLib.instance.api.crateApiTransactionStatusDefault();
 }
 
-class WalletAddContactRequest {
-  final String walletId;
-  final String nodeId;
-  final String name;
-
-  const WalletAddContactRequest({
-    required this.walletId,
-    required this.nodeId,
-    required this.name,
-  });
-
-  @override
-  int get hashCode => walletId.hashCode ^ nodeId.hashCode ^ name.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is WalletAddContactRequest &&
-          runtimeType == other.runtimeType &&
-          walletId == other.walletId &&
-          nodeId == other.nodeId &&
-          name == other.name;
-}
-
-class WalletAddContactResponse {
-  final String nodeId;
-
-  const WalletAddContactResponse({required this.nodeId});
-
-  @override
-  int get hashCode => nodeId.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is WalletAddContactResponse &&
-          runtimeType == other.runtimeType &&
-          nodeId == other.nodeId;
-}
-
 class WalletBalanceResponse {
   final BigInt debit;
   final BigInt credit;
@@ -1100,43 +1295,6 @@ class WalletCurrencyUnitResponse {
           unit == other.unit;
 }
 
-class WalletDeleteContactRequest {
-  final String walletId;
-  final String nodeId;
-
-  const WalletDeleteContactRequest({
-    required this.walletId,
-    required this.nodeId,
-  });
-
-  @override
-  int get hashCode => walletId.hashCode ^ nodeId.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is WalletDeleteContactRequest &&
-          runtimeType == other.runtimeType &&
-          walletId == other.walletId &&
-          nodeId == other.nodeId;
-}
-
-class WalletDeleteContactResponse {
-  final String nodeId;
-
-  const WalletDeleteContactResponse({required this.nodeId});
-
-  @override
-  int get hashCode => nodeId.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is WalletDeleteContactResponse &&
-          runtimeType == other.runtimeType &&
-          nodeId == other.nodeId;
-}
-
 class WalletDevModeDetailedBalanceEntry {
   final String kid;
   final BigInt? finalExpiry;
@@ -1175,46 +1333,6 @@ class WalletDevModeDetailedBalanceResponse {
       other is WalletDevModeDetailedBalanceResponse &&
           runtimeType == other.runtimeType &&
           entries == other.entries;
-}
-
-class WalletEditContactRequest {
-  final String walletId;
-  final String nodeId;
-  final String name;
-
-  const WalletEditContactRequest({
-    required this.walletId,
-    required this.nodeId,
-    required this.name,
-  });
-
-  @override
-  int get hashCode => walletId.hashCode ^ nodeId.hashCode ^ name.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is WalletEditContactRequest &&
-          runtimeType == other.runtimeType &&
-          walletId == other.walletId &&
-          nodeId == other.nodeId &&
-          name == other.name;
-}
-
-class WalletEditContactResponse {
-  final String nodeId;
-
-  const WalletEditContactResponse({required this.nodeId});
-
-  @override
-  int get hashCode => nodeId.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is WalletEditContactResponse &&
-          runtimeType == other.runtimeType &&
-          nodeId == other.nodeId;
 }
 
 class WalletEditTransactionMemoRequest {
@@ -1309,6 +1427,7 @@ enum WalletErrorCode {
   network,
   walletNotFound,
   contactNotFound,
+  contactMustHaveNodeId,
   paymentRequestNotFound,
   paymentRequestInWrongState,
   contactAlreadyExists,
@@ -1349,6 +1468,9 @@ enum WalletErrorCode {
   invalidBillId,
   invalidName,
   emptyName,
+  invalidEmail,
+  emptyEmail,
+  invalidContact,
   mintClientResourceNotFound,
   mintClientServiceUnavailable,
   mintClientBadRequest,
@@ -1493,40 +1615,6 @@ class WalletFfiConfig {
           devMode == other.devMode;
 }
 
-class WalletGetContactRequest {
-  final String walletId;
-  final String nodeId;
-
-  const WalletGetContactRequest({required this.walletId, required this.nodeId});
-
-  @override
-  int get hashCode => walletId.hashCode ^ nodeId.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is WalletGetContactRequest &&
-          runtimeType == other.runtimeType &&
-          walletId == other.walletId &&
-          nodeId == other.nodeId;
-}
-
-class WalletGetContactResponse {
-  final Contact contact;
-
-  const WalletGetContactResponse({required this.contact});
-
-  @override
-  int get hashCode => contact.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is WalletGetContactResponse &&
-          runtimeType == other.runtimeType &&
-          contact == other.contact;
-}
-
 class WalletGetPaymentRequestRequest {
   final String walletId;
   final String paymentRequestId;
@@ -1634,40 +1722,6 @@ class WalletInfoResponse {
           network == other.network &&
           defaultMintUrl == other.defaultMintUrl &&
           nostrRelays == other.nostrRelays;
-}
-
-class WalletListContactsRequest {
-  final String walletId;
-  final String? searchTerm;
-
-  const WalletListContactsRequest({required this.walletId, this.searchTerm});
-
-  @override
-  int get hashCode => walletId.hashCode ^ searchTerm.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is WalletListContactsRequest &&
-          runtimeType == other.runtimeType &&
-          walletId == other.walletId &&
-          searchTerm == other.searchTerm;
-}
-
-class WalletListContactsResponse {
-  final List<Contact> contacts;
-
-  const WalletListContactsResponse({required this.contacts});
-
-  @override
-  int get hashCode => contacts.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is WalletListContactsResponse &&
-          runtimeType == other.runtimeType &&
-          contacts == other.contacts;
 }
 
 class WalletListPaymentRequestsRequest {
@@ -1897,6 +1951,27 @@ class WalletPayRequest {
           rid == other.rid;
 }
 
+class WalletPaymentByContactRequest {
+  final String walletId;
+  final String rid;
+
+  const WalletPaymentByContactRequest({
+    required this.walletId,
+    required this.rid,
+  });
+
+  @override
+  int get hashCode => walletId.hashCode ^ rid.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletPaymentByContactRequest &&
+          runtimeType == other.runtimeType &&
+          walletId == other.walletId &&
+          rid == other.rid;
+}
+
 class WalletPaymentByTokenRequest {
   final String walletId;
   final String rid;
@@ -2010,6 +2085,37 @@ class WalletPreparePayPaymentRequestRequest {
           runtimeType == other.runtimeType &&
           walletId == other.walletId &&
           paymentRequestId == other.paymentRequestId;
+}
+
+class WalletPreparePaymentByContactRequest {
+  final String walletId;
+  final String contactId;
+  final BigInt amount;
+  final String? description;
+
+  const WalletPreparePaymentByContactRequest({
+    required this.walletId,
+    required this.contactId,
+    required this.amount,
+    this.description,
+  });
+
+  @override
+  int get hashCode =>
+      walletId.hashCode ^
+      contactId.hashCode ^
+      amount.hashCode ^
+      description.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletPreparePaymentByContactRequest &&
+          runtimeType == other.runtimeType &&
+          walletId == other.walletId &&
+          contactId == other.contactId &&
+          amount == other.amount &&
+          description == other.description;
 }
 
 class WalletPreparePaymentByTokenRequest {
@@ -2417,14 +2523,14 @@ class WalletRequest {
 
 class WalletRequestPaymentFromContactRequest {
   final String walletId;
-  final String nodeId;
+  final String contactId;
   final BigInt amount;
   final String? description;
   final BigInt? deadline;
 
   const WalletRequestPaymentFromContactRequest({
     required this.walletId,
-    required this.nodeId,
+    required this.contactId,
     required this.amount,
     this.description,
     this.deadline,
@@ -2433,7 +2539,7 @@ class WalletRequestPaymentFromContactRequest {
   @override
   int get hashCode =>
       walletId.hashCode ^
-      nodeId.hashCode ^
+      contactId.hashCode ^
       amount.hashCode ^
       description.hashCode ^
       deadline.hashCode;
@@ -2444,7 +2550,7 @@ class WalletRequestPaymentFromContactRequest {
       other is WalletRequestPaymentFromContactRequest &&
           runtimeType == other.runtimeType &&
           walletId == other.walletId &&
-          nodeId == other.nodeId &&
+          contactId == other.contactId &&
           amount == other.amount &&
           description == other.description &&
           deadline == other.deadline;

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -66,7 +66,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 822415845;
+  int get rustContentHash => 1690913843;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -82,12 +82,28 @@ abstract class RustLibApi extends BaseApi {
     required WalletPaymentCheckHandle that,
   });
 
+  Future<AddContactResponse> crateApiAddContact({
+    required AddContactRequest req,
+  });
+
   Future<BtcTxStatusResponse> crateApiCheckBtcTxStatus({
     required BtcTxStatusRequest req,
   });
 
+  Future<DeleteContactResponse> crateApiDeleteContact({
+    required DeleteContactRequest req,
+  });
+
+  Future<EditContactResponse> crateApiEditContact({
+    required EditContactRequest req,
+  });
+
   Future<MnemonicResponse> crateApiGenerateRandomMnemonic({
     required MnemonicRequest req,
+  });
+
+  Future<GetContactResponse> crateApiGetContact({
+    required GetContactRequest req,
   });
 
   Future<void> crateApiInitApp();
@@ -96,6 +112,10 @@ abstract class RustLibApi extends BaseApi {
 
   Future<IsValidTokenResponse> crateApiIsValidToken({
     required IsValidTokenRequest req,
+  });
+
+  Future<ListContactsResponse> crateApiListContacts({
+    required ListContactsRequest req,
   });
 
   Future<PaymentType> crateApiPaymentTypeDefault();
@@ -112,10 +132,6 @@ abstract class RustLibApi extends BaseApi {
 
   Future<AddWalletResponse> crateApiWalletAdd({
     required CreateWalletRequest req,
-  });
-
-  Future<WalletAddContactResponse> crateApiWalletAddContact({
-    required WalletAddContactRequest req,
   });
 
   Future<WalletCancelPaymentRequestResponse>
@@ -135,16 +151,8 @@ abstract class RustLibApi extends BaseApi {
 
   Future<void> crateApiWalletDelete({required WalletRequest req});
 
-  Future<WalletDeleteContactResponse> crateApiWalletDeleteContact({
-    required WalletDeleteContactRequest req,
-  });
-
   Future<WalletDevModeDetailedBalanceResponse>
   crateApiWalletDevModeGetDetailedBalance({required WalletRequest req});
-
-  Future<WalletEditContactResponse> crateApiWalletEditContact({
-    required WalletEditContactRequest req,
-  });
 
   Future<WalletEditTransactionMemoResponse> crateApiWalletEditTransactionMemo({
     required WalletEditTransactionMemoRequest req,
@@ -175,10 +183,6 @@ abstract class RustLibApi extends BaseApi {
 
   Future<WalletBalanceResponse> crateApiWalletGetBalance({
     required WalletRequest req,
-  });
-
-  Future<WalletGetContactResponse> crateApiWalletGetContact({
-    required WalletGetContactRequest req,
   });
 
   Future<WalletCurrencyUnitResponse> crateApiWalletGetCurrencyUnit({
@@ -222,10 +226,6 @@ abstract class RustLibApi extends BaseApi {
     required WalletIdForMnemonicAndNetworkRequest req,
   });
 
-  Future<WalletListContactsResponse> crateApiWalletListContacts({
-    required WalletListContactsRequest req,
-  });
-
   Future<WalletListPaymentRequestsResponse> crateApiWalletListPaymentRequests({
     required WalletListPaymentRequestsRequest req,
   });
@@ -264,6 +264,10 @@ abstract class RustLibApi extends BaseApi {
     required WalletPayRequest req,
   });
 
+  Future<WalletTransactionIdResponse> crateApiWalletPayToContact({
+    required WalletPaymentByContactRequest req,
+  });
+
   Future<WalletPreparePaymentResponse> crateApiWalletPrepareMelt({
     required WalletPrepareMeltRequest req,
   });
@@ -274,6 +278,10 @@ abstract class RustLibApi extends BaseApi {
 
   Future<WalletPreparePaymentResponse> crateApiWalletPreparePayPaymentRequest({
     required WalletPreparePayPaymentRequestRequest req,
+  });
+
+  Future<WalletPreparePaymentResponse> crateApiWalletPreparePayToContact({
+    required WalletPreparePaymentByContactRequest req,
   });
 
   Future<WalletPreparePaymentResponse> crateApiWalletPreparePayment({
@@ -394,6 +402,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<AddContactResponse> crateApiAddContact({
+    required AddContactRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_add_contact_request(req, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 2,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_add_contact_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiAddContactConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiAddContactConstMeta =>
+      const TaskConstMeta(debugName: "add_contact", argNames: ["req"]);
+
+  @override
   Future<BtcTxStatusResponse> crateApiCheckBtcTxStatus({
     required BtcTxStatusRequest req,
   }) {
@@ -405,7 +443,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 2,
+            funcId: 3,
             port: port_,
           );
         },
@@ -424,6 +462,66 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "check_btc_tx_status", argNames: ["req"]);
 
   @override
+  Future<DeleteContactResponse> crateApiDeleteContact({
+    required DeleteContactRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_delete_contact_request(req, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 4,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_delete_contact_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiDeleteContactConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiDeleteContactConstMeta =>
+      const TaskConstMeta(debugName: "delete_contact", argNames: ["req"]);
+
+  @override
+  Future<EditContactResponse> crateApiEditContact({
+    required EditContactRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_edit_contact_request(req, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 5,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_edit_contact_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiEditContactConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiEditContactConstMeta =>
+      const TaskConstMeta(debugName: "edit_contact", argNames: ["req"]);
+
+  @override
   Future<MnemonicResponse> crateApiGenerateRandomMnemonic({
     required MnemonicRequest req,
   }) {
@@ -435,7 +533,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 3,
+            funcId: 6,
             port: port_,
           );
         },
@@ -457,6 +555,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<GetContactResponse> crateApiGetContact({
+    required GetContactRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_get_contact_request(req, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 7,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_get_contact_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiGetContactConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiGetContactConstMeta =>
+      const TaskConstMeta(debugName: "get_contact", argNames: ["req"]);
+
+  @override
   Future<void> crateApiInitApp() {
     return handler.executeNormal(
       NormalTask(
@@ -465,7 +593,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 4,
+            funcId: 8,
             port: port_,
           );
         },
@@ -493,7 +621,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 9,
             port: port_,
           );
         },
@@ -523,7 +651,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 10,
             port: port_,
           );
         },
@@ -542,6 +670,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "is_valid_token", argNames: ["req"]);
 
   @override
+  Future<ListContactsResponse> crateApiListContacts({
+    required ListContactsRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_list_contacts_request(req, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 11,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_contacts_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiListContactsConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiListContactsConstMeta =>
+      const TaskConstMeta(debugName: "list_contacts", argNames: ["req"]);
+
+  @override
   Future<PaymentType> crateApiPaymentTypeDefault() {
     return handler.executeNormal(
       NormalTask(
@@ -550,7 +708,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 12,
             port: port_,
           );
         },
@@ -577,7 +735,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 13,
             port: port_,
           );
         },
@@ -604,7 +762,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 14,
             port: port_,
           );
         },
@@ -634,7 +792,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 15,
             port: port_,
           );
         },
@@ -664,7 +822,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 16,
             port: port_,
           );
         },
@@ -691,7 +849,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 17,
             port: port_,
           );
         },
@@ -724,7 +882,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 18,
             port: port_,
           );
         },
@@ -743,36 +901,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "wallet_add", argNames: ["req"]);
 
   @override
-  Future<WalletAddContactResponse> crateApiWalletAddContact({
-    required WalletAddContactRequest req,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_box_autoadd_wallet_add_contact_request(req, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 14,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_wallet_add_contact_response,
-          decodeErrorData: sse_decode_wallet_error,
-        ),
-        constMeta: kCrateApiWalletAddContactConstMeta,
-        argValues: [req],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiWalletAddContactConstMeta =>
-      const TaskConstMeta(debugName: "wallet_add_contact", argNames: ["req"]);
-
-  @override
   Future<WalletCancelPaymentRequestResponse>
   crateApiWalletCancelPaymentRequest({
     required WalletCancelPaymentRequestRequest req,
@@ -788,7 +916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 19,
             port: port_,
           );
         },
@@ -821,7 +949,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 20,
             port: port_,
           );
         },
@@ -863,7 +991,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 21,
             port: port_,
           );
         },
@@ -895,7 +1023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 22,
             port: port_,
           );
         },
@@ -914,39 +1042,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "wallet_delete", argNames: ["req"]);
 
   @override
-  Future<WalletDeleteContactResponse> crateApiWalletDeleteContact({
-    required WalletDeleteContactRequest req,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_box_autoadd_wallet_delete_contact_request(req, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 19,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_wallet_delete_contact_response,
-          decodeErrorData: sse_decode_wallet_error,
-        ),
-        constMeta: kCrateApiWalletDeleteContactConstMeta,
-        argValues: [req],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiWalletDeleteContactConstMeta =>
-      const TaskConstMeta(
-        debugName: "wallet_delete_contact",
-        argNames: ["req"],
-      );
-
-  @override
   Future<WalletDevModeDetailedBalanceResponse>
   crateApiWalletDevModeGetDetailedBalance({required WalletRequest req}) {
     return handler.executeNormal(
@@ -957,7 +1052,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 23,
             port: port_,
           );
         },
@@ -980,36 +1075,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<WalletEditContactResponse> crateApiWalletEditContact({
-    required WalletEditContactRequest req,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_box_autoadd_wallet_edit_contact_request(req, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 21,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_wallet_edit_contact_response,
-          decodeErrorData: sse_decode_wallet_error,
-        ),
-        constMeta: kCrateApiWalletEditContactConstMeta,
-        argValues: [req],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiWalletEditContactConstMeta =>
-      const TaskConstMeta(debugName: "wallet_edit_contact", argNames: ["req"]);
-
-  @override
   Future<WalletEditTransactionMemoResponse> crateApiWalletEditTransactionMemo({
     required WalletEditTransactionMemoRequest req,
   }) {
@@ -1024,7 +1089,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 24,
             port: port_,
           );
         },
@@ -1059,7 +1124,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1090,7 +1155,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1121,7 +1186,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1153,7 +1218,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1188,7 +1253,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1221,7 +1286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1251,7 +1316,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1270,36 +1335,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "wallet_get_balance", argNames: ["req"]);
 
   @override
-  Future<WalletGetContactResponse> crateApiWalletGetContact({
-    required WalletGetContactRequest req,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_box_autoadd_wallet_get_contact_request(req, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 30,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_wallet_get_contact_response,
-          decodeErrorData: sse_decode_wallet_error,
-        ),
-        constMeta: kCrateApiWalletGetContactConstMeta,
-        argValues: [req],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiWalletGetContactConstMeta =>
-      const TaskConstMeta(debugName: "wallet_get_contact", argNames: ["req"]);
-
-  @override
   Future<WalletCurrencyUnitResponse> crateApiWalletGetCurrencyUnit({
     required WalletRequest req,
   }) {
@@ -1311,7 +1346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1341,7 +1376,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1371,7 +1406,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1401,7 +1436,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1431,7 +1466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1461,7 +1496,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1494,7 +1529,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -1524,7 +1559,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1554,7 +1589,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1590,7 +1625,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1627,7 +1662,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1648,36 +1683,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         debugName: "wallet_id_for_mnemonic_and_network",
         argNames: ["req"],
       );
-
-  @override
-  Future<WalletListContactsResponse> crateApiWalletListContacts({
-    required WalletListContactsRequest req,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_box_autoadd_wallet_list_contacts_request(req, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 42,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_wallet_list_contacts_response,
-          decodeErrorData: sse_decode_wallet_error,
-        ),
-        constMeta: kCrateApiWalletListContactsConstMeta,
-        argValues: [req],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiWalletListContactsConstMeta =>
-      const TaskConstMeta(debugName: "wallet_list_contacts", argNames: ["req"]);
 
   @override
   Future<WalletListPaymentRequestsResponse> crateApiWalletListPaymentRequests({
@@ -1995,6 +2000,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<WalletTransactionIdResponse> crateApiWalletPayToContact({
+    required WalletPaymentByContactRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_payment_by_contact_request(
+            req,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 53,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_wallet_transaction_id_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletPayToContactConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletPayToContactConstMeta => const TaskConstMeta(
+    debugName: "wallet_pay_to_contact",
+    argNames: ["req"],
+  );
+
+  @override
   Future<WalletPreparePaymentResponse> crateApiWalletPrepareMelt({
     required WalletPrepareMeltRequest req,
   }) {
@@ -2006,7 +2046,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -2039,7 +2079,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2075,7 +2115,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2097,6 +2137,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<WalletPreparePaymentResponse> crateApiWalletPreparePayToContact({
+    required WalletPreparePaymentByContactRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_prepare_payment_by_contact_request(
+            req,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 57,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_wallet_prepare_payment_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletPreparePayToContactConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletPreparePayToContactConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_prepare_pay_to_contact",
+        argNames: ["req"],
+      );
+
+  @override
   Future<WalletPreparePaymentResponse> crateApiWalletPreparePayment({
     required WalletPreparePaymentRequest req,
   }) {
@@ -2111,7 +2187,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2147,7 +2223,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2180,7 +2256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2210,7 +2286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2240,7 +2316,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2270,7 +2346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 63,
             port: port_,
           );
         },
@@ -2303,7 +2379,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 64,
             port: port_,
           );
         },
@@ -2335,7 +2411,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 65,
             port: port_,
           );
         },
@@ -2372,7 +2448,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 66,
             port: port_,
           );
         },
@@ -2405,7 +2481,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 67,
             port: port_,
           );
         },
@@ -2442,7 +2518,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 68,
             port: port_,
           );
         },
@@ -2479,7 +2555,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 69,
             port: port_,
           );
         },
@@ -2513,7 +2589,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 70,
             port: port_,
           );
         },
@@ -2543,7 +2619,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 71,
             port: port_,
           );
         },
@@ -2582,7 +2658,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 72,
             port: port_,
           );
         },
@@ -2770,6 +2846,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  AddContactRequest dco_decode_add_contact_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    return AddContactRequest(
+      bitcoinNetwork: dco_decode_String(arr[0]),
+      email: dco_decode_opt_String(arr[1]),
+      nodeId: dco_decode_opt_String(arr[2]),
+      name: dco_decode_opt_String(arr[3]),
+      company: dco_decode_opt_String(arr[4]),
+    );
+  }
+
+  @protected
+  AddContactResponse dco_decode_add_contact_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return AddContactResponse(contactId: dco_decode_String(arr[0]));
+  }
+
+  @protected
   AddWalletResponse dco_decode_add_wallet_response(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -2782,6 +2882,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   bool dco_decode_bool(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as bool;
+  }
+
+  @protected
+  AddContactRequest dco_decode_box_autoadd_add_contact_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_add_contact_request(raw);
   }
 
   @protected
@@ -2799,11 +2905,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  DeleteContactRequest dco_decode_box_autoadd_delete_contact_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_delete_contact_request(raw);
+  }
+
+  @protected
+  EditContactRequest dco_decode_box_autoadd_edit_contact_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_edit_contact_request(raw);
+  }
+
+  @protected
+  GetContactRequest dco_decode_box_autoadd_get_contact_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_get_contact_request(raw);
+  }
+
+  @protected
   IsValidTokenRequest dco_decode_box_autoadd_is_valid_token_request(
     dynamic raw,
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_is_valid_token_request(raw);
+  }
+
+  @protected
+  ListContactsRequest dco_decode_box_autoadd_list_contacts_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_list_contacts_request(raw);
   }
 
   @protected
@@ -2845,14 +2979,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  WalletAddContactRequest dco_decode_box_autoadd_wallet_add_contact_request(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_wallet_add_contact_request(raw);
-  }
-
-  @protected
   WalletCancelPaymentRequestRequest
   dco_decode_box_autoadd_wallet_cancel_payment_request_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -2864,21 +2990,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   dco_decode_box_autoadd_wallet_check_received_payment_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_wallet_check_received_payment_request(raw);
-  }
-
-  @protected
-  WalletDeleteContactRequest
-  dco_decode_box_autoadd_wallet_delete_contact_request(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_wallet_delete_contact_request(raw);
-  }
-
-  @protected
-  WalletEditContactRequest dco_decode_box_autoadd_wallet_edit_contact_request(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_wallet_edit_contact_request(raw);
   }
 
   @protected
@@ -2903,14 +3014,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  WalletGetContactRequest dco_decode_box_autoadd_wallet_get_contact_request(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_wallet_get_contact_request(raw);
-  }
-
-  @protected
   WalletGetPaymentRequestRequest
   dco_decode_box_autoadd_wallet_get_payment_request_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -2924,14 +3027,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_wallet_id_for_mnemonic_and_network_request(raw);
-  }
-
-  @protected
-  WalletListContactsRequest dco_decode_box_autoadd_wallet_list_contacts_request(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_wallet_list_contacts_request(raw);
   }
 
   @protected
@@ -2961,6 +3056,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletPaymentByContactRequest
+  dco_decode_box_autoadd_wallet_payment_by_contact_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_wallet_payment_by_contact_request(raw);
+  }
+
+  @protected
   WalletPaymentByTokenRequest
   dco_decode_box_autoadd_wallet_payment_by_token_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -2982,6 +3084,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_wallet_prepare_pay_payment_request_request(raw);
+  }
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  dco_decode_box_autoadd_wallet_prepare_payment_by_contact_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_wallet_prepare_payment_by_contact_request(raw);
   }
 
   @protected
@@ -3146,11 +3257,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Contact dco_decode_contact(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return Contact(
-      nodeId: dco_decode_String(arr[0]),
-      name: dco_decode_String(arr[1]),
+      id: dco_decode_String(arr[0]),
+      nodeId: dco_decode_opt_String(arr[1]),
+      email: dco_decode_opt_String(arr[2]),
+      name: dco_decode_opt_String(arr[3]),
+      company: dco_decode_opt_String(arr[4]),
     );
   }
 
@@ -3170,6 +3284,52 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  DeleteContactRequest dco_decode_delete_contact_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return DeleteContactRequest(
+      bitcoinNetwork: dco_decode_String(arr[0]),
+      contactId: dco_decode_String(arr[1]),
+    );
+  }
+
+  @protected
+  DeleteContactResponse dco_decode_delete_contact_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return DeleteContactResponse(contactId: dco_decode_String(arr[0]));
+  }
+
+  @protected
+  EditContactRequest dco_decode_edit_contact_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 6)
+      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    return EditContactRequest(
+      bitcoinNetwork: dco_decode_String(arr[0]),
+      contactId: dco_decode_String(arr[1]),
+      nodeId: dco_decode_opt_String(arr[2]),
+      email: dco_decode_opt_String(arr[3]),
+      name: dco_decode_opt_String(arr[4]),
+      company: dco_decode_opt_String(arr[5]),
+    );
+  }
+
+  @protected
+  EditContactResponse dco_decode_edit_contact_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return EditContactResponse(contactId: dco_decode_String(arr[0]));
+  }
+
+  @protected
   double dco_decode_f_32(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as double;
@@ -3186,6 +3346,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       month: dco_decode_u_32(arr[1]),
       fees: dco_decode_u_64(arr[2]),
     );
+  }
+
+  @protected
+  GetContactRequest dco_decode_get_contact_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return GetContactRequest(
+      bitcoinNetwork: dco_decode_String(arr[0]),
+      contactId: dco_decode_String(arr[1]),
+    );
+  }
+
+  @protected
+  GetContactResponse dco_decode_get_contact_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return GetContactResponse(contact: dco_decode_contact(arr[0]));
   }
 
   @protected
@@ -3243,6 +3424,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<Contact> dco_decode_list_contact(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_contact).toList();
+  }
+
+  @protected
+  ListContactsRequest dco_decode_list_contacts_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return ListContactsRequest(
+      bitcoinNetwork: dco_decode_String(arr[0]),
+      searchTerm: dco_decode_opt_String(arr[1]),
+    );
+  }
+
+  @protected
+  ListContactsResponse dco_decode_list_contacts_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return ListContactsResponse(contacts: dco_decode_list_contact(arr[0]));
   }
 
   @protected
@@ -3669,28 +3871,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  WalletAddContactRequest dco_decode_wallet_add_contact_request(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
-    return WalletAddContactRequest(
-      walletId: dco_decode_String(arr[0]),
-      nodeId: dco_decode_String(arr[1]),
-      name: dco_decode_String(arr[2]),
-    );
-  }
-
-  @protected
-  WalletAddContactResponse dco_decode_wallet_add_contact_response(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 1)
-      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return WalletAddContactResponse(nodeId: dco_decode_String(arr[0]));
-  }
-
-  @protected
   WalletBalanceResponse dco_decode_wallet_balance_response(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -3766,31 +3946,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  WalletDeleteContactRequest dco_decode_wallet_delete_contact_request(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return WalletDeleteContactRequest(
-      walletId: dco_decode_String(arr[0]),
-      nodeId: dco_decode_String(arr[1]),
-    );
-  }
-
-  @protected
-  WalletDeleteContactResponse dco_decode_wallet_delete_contact_response(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 1)
-      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return WalletDeleteContactResponse(nodeId: dco_decode_String(arr[0]));
-  }
-
-  @protected
   WalletDevModeDetailedBalanceEntry
   dco_decode_wallet_dev_mode_detailed_balance_entry(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -3814,30 +3969,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return WalletDevModeDetailedBalanceResponse(
       entries: dco_decode_list_wallet_dev_mode_detailed_balance_entry(arr[0]),
     );
-  }
-
-  @protected
-  WalletEditContactRequest dco_decode_wallet_edit_contact_request(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
-    return WalletEditContactRequest(
-      walletId: dco_decode_String(arr[0]),
-      nodeId: dco_decode_String(arr[1]),
-      name: dco_decode_String(arr[2]),
-    );
-  }
-
-  @protected
-  WalletEditContactResponse dco_decode_wallet_edit_contact_response(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 1)
-      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return WalletEditContactResponse(nodeId: dco_decode_String(arr[0]));
   }
 
   @protected
@@ -3952,27 +4083,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  WalletGetContactRequest dco_decode_wallet_get_contact_request(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return WalletGetContactRequest(
-      walletId: dco_decode_String(arr[0]),
-      nodeId: dco_decode_String(arr[1]),
-    );
-  }
-
-  @protected
-  WalletGetContactResponse dco_decode_wallet_get_contact_response(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 1)
-      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return WalletGetContactResponse(contact: dco_decode_contact(arr[0]));
-  }
-
-  @protected
   WalletGetPaymentRequestRequest dco_decode_wallet_get_payment_request_request(
     dynamic raw,
   ) {
@@ -4035,33 +4145,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       network: dco_decode_String(arr[2]),
       defaultMintUrl: dco_decode_String(arr[3]),
       nostrRelays: dco_decode_list_String(arr[4]),
-    );
-  }
-
-  @protected
-  WalletListContactsRequest dco_decode_wallet_list_contacts_request(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return WalletListContactsRequest(
-      walletId: dco_decode_String(arr[0]),
-      searchTerm: dco_decode_opt_String(arr[1]),
-    );
-  }
-
-  @protected
-  WalletListContactsResponse dco_decode_wallet_list_contacts_response(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 1)
-      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return WalletListContactsResponse(
-      contacts: dco_decode_list_contact(arr[0]),
     );
   }
 
@@ -4203,6 +4286,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletPaymentByContactRequest dco_decode_wallet_payment_by_contact_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return WalletPaymentByContactRequest(
+      walletId: dco_decode_String(arr[0]),
+      rid: dco_decode_String(arr[1]),
+    );
+  }
+
+  @protected
   WalletPaymentByTokenRequest dco_decode_wallet_payment_by_token_request(
     dynamic raw,
   ) {
@@ -4266,6 +4363,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return WalletPreparePayPaymentRequestRequest(
       walletId: dco_decode_String(arr[0]),
       paymentRequestId: dco_decode_String(arr[1]),
+    );
+  }
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  dco_decode_wallet_prepare_payment_by_contact_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return WalletPreparePaymentByContactRequest(
+      walletId: dco_decode_String(arr[0]),
+      contactId: dco_decode_String(arr[1]),
+      amount: dco_decode_u_64(arr[2]),
+      description: dco_decode_opt_String(arr[3]),
     );
   }
 
@@ -4541,7 +4653,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return WalletRequestPaymentFromContactRequest(
       walletId: dco_decode_String(arr[0]),
-      nodeId: dco_decode_String(arr[1]),
+      contactId: dco_decode_String(arr[1]),
       amount: dco_decode_u_64(arr[2]),
       description: dco_decode_opt_String(arr[3]),
       deadline: dco_decode_opt_box_autoadd_u_64(arr[4]),
@@ -4704,6 +4816,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  AddContactRequest sse_decode_add_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_bitcoinNetwork = sse_decode_String(deserializer);
+    var var_email = sse_decode_opt_String(deserializer);
+    var var_nodeId = sse_decode_opt_String(deserializer);
+    var var_name = sse_decode_opt_String(deserializer);
+    var var_company = sse_decode_opt_String(deserializer);
+    return AddContactRequest(
+      bitcoinNetwork: var_bitcoinNetwork,
+      email: var_email,
+      nodeId: var_nodeId,
+      name: var_name,
+      company: var_company,
+    );
+  }
+
+  @protected
+  AddContactResponse sse_decode_add_contact_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_contactId = sse_decode_String(deserializer);
+    return AddContactResponse(contactId: var_contactId);
+  }
+
+  @protected
   AddWalletResponse sse_decode_add_wallet_response(
     SseDeserializer deserializer,
   ) {
@@ -4716,6 +4856,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   bool sse_decode_bool(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getUint8() != 0;
+  }
+
+  @protected
+  AddContactRequest sse_decode_box_autoadd_add_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_add_contact_request(deserializer));
   }
 
   @protected
@@ -4735,11 +4883,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  DeleteContactRequest sse_decode_box_autoadd_delete_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_delete_contact_request(deserializer));
+  }
+
+  @protected
+  EditContactRequest sse_decode_box_autoadd_edit_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_edit_contact_request(deserializer));
+  }
+
+  @protected
+  GetContactRequest sse_decode_box_autoadd_get_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_get_contact_request(deserializer));
+  }
+
+  @protected
   IsValidTokenRequest sse_decode_box_autoadd_is_valid_token_request(
     SseDeserializer deserializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_is_valid_token_request(deserializer));
+  }
+
+  @protected
+  ListContactsRequest sse_decode_box_autoadd_list_contacts_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_list_contacts_request(deserializer));
   }
 
   @protected
@@ -4787,14 +4967,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  WalletAddContactRequest sse_decode_box_autoadd_wallet_add_contact_request(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_wallet_add_contact_request(deserializer));
-  }
-
-  @protected
   WalletCancelPaymentRequestRequest
   sse_decode_box_autoadd_wallet_cancel_payment_request_request(
     SseDeserializer deserializer,
@@ -4810,23 +4982,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_wallet_check_received_payment_request(deserializer));
-  }
-
-  @protected
-  WalletDeleteContactRequest
-  sse_decode_box_autoadd_wallet_delete_contact_request(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_wallet_delete_contact_request(deserializer));
-  }
-
-  @protected
-  WalletEditContactRequest sse_decode_box_autoadd_wallet_edit_contact_request(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_wallet_edit_contact_request(deserializer));
   }
 
   @protected
@@ -4855,14 +5010,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  WalletGetContactRequest sse_decode_box_autoadd_wallet_get_contact_request(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_wallet_get_contact_request(deserializer));
-  }
-
-  @protected
   WalletGetPaymentRequestRequest
   sse_decode_box_autoadd_wallet_get_payment_request_request(
     SseDeserializer deserializer,
@@ -4880,14 +5027,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return (sse_decode_wallet_id_for_mnemonic_and_network_request(
       deserializer,
     ));
-  }
-
-  @protected
-  WalletListContactsRequest sse_decode_box_autoadd_wallet_list_contacts_request(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_wallet_list_contacts_request(deserializer));
   }
 
   @protected
@@ -4925,6 +5064,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletPaymentByContactRequest
+  sse_decode_box_autoadd_wallet_payment_by_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_wallet_payment_by_contact_request(deserializer));
+  }
+
+  @protected
   WalletPaymentByTokenRequest
   sse_decode_box_autoadd_wallet_payment_by_token_request(
     SseDeserializer deserializer,
@@ -4950,6 +5098,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return (sse_decode_wallet_prepare_pay_payment_request_request(
       deserializer,
     ));
+  }
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  sse_decode_box_autoadd_wallet_prepare_payment_by_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_wallet_prepare_payment_by_contact_request(deserializer));
   }
 
   @protected
@@ -5133,9 +5290,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   Contact sse_decode_contact(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_nodeId = sse_decode_String(deserializer);
-    var var_name = sse_decode_String(deserializer);
-    return Contact(nodeId: var_nodeId, name: var_name);
+    var var_id = sse_decode_String(deserializer);
+    var var_nodeId = sse_decode_opt_String(deserializer);
+    var var_email = sse_decode_opt_String(deserializer);
+    var var_name = sse_decode_opt_String(deserializer);
+    var var_company = sse_decode_opt_String(deserializer);
+    return Contact(
+      id: var_id,
+      nodeId: var_nodeId,
+      email: var_email,
+      name: var_name,
+      company: var_company,
+    );
   }
 
   @protected
@@ -5158,6 +5324,58 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  DeleteContactRequest sse_decode_delete_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_bitcoinNetwork = sse_decode_String(deserializer);
+    var var_contactId = sse_decode_String(deserializer);
+    return DeleteContactRequest(
+      bitcoinNetwork: var_bitcoinNetwork,
+      contactId: var_contactId,
+    );
+  }
+
+  @protected
+  DeleteContactResponse sse_decode_delete_contact_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_contactId = sse_decode_String(deserializer);
+    return DeleteContactResponse(contactId: var_contactId);
+  }
+
+  @protected
+  EditContactRequest sse_decode_edit_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_bitcoinNetwork = sse_decode_String(deserializer);
+    var var_contactId = sse_decode_String(deserializer);
+    var var_nodeId = sse_decode_opt_String(deserializer);
+    var var_email = sse_decode_opt_String(deserializer);
+    var var_name = sse_decode_opt_String(deserializer);
+    var var_company = sse_decode_opt_String(deserializer);
+    return EditContactRequest(
+      bitcoinNetwork: var_bitcoinNetwork,
+      contactId: var_contactId,
+      nodeId: var_nodeId,
+      email: var_email,
+      name: var_name,
+      company: var_company,
+    );
+  }
+
+  @protected
+  EditContactResponse sse_decode_edit_contact_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_contactId = sse_decode_String(deserializer);
+    return EditContactResponse(contactId: var_contactId);
+  }
+
+  @protected
   double sse_decode_f_32(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getFloat32();
@@ -5170,6 +5388,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_month = sse_decode_u_32(deserializer);
     var var_fees = sse_decode_u_64(deserializer);
     return FeesByMonth(year: var_year, month: var_month, fees: var_fees);
+  }
+
+  @protected
+  GetContactRequest sse_decode_get_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_bitcoinNetwork = sse_decode_String(deserializer);
+    var var_contactId = sse_decode_String(deserializer);
+    return GetContactRequest(
+      bitcoinNetwork: var_bitcoinNetwork,
+      contactId: var_contactId,
+    );
+  }
+
+  @protected
+  GetContactResponse sse_decode_get_contact_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_contact = sse_decode_contact(deserializer);
+    return GetContactResponse(contact: var_contact);
   }
 
   @protected
@@ -5246,6 +5486,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       ans_.add(sse_decode_contact(deserializer));
     }
     return ans_;
+  }
+
+  @protected
+  ListContactsRequest sse_decode_list_contacts_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_bitcoinNetwork = sse_decode_String(deserializer);
+    var var_searchTerm = sse_decode_opt_String(deserializer);
+    return ListContactsRequest(
+      bitcoinNetwork: var_bitcoinNetwork,
+      searchTerm: var_searchTerm,
+    );
+  }
+
+  @protected
+  ListContactsResponse sse_decode_list_contacts_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_contacts = sse_decode_list_contact(deserializer);
+    return ListContactsResponse(contacts: var_contacts);
   }
 
   @protected
@@ -5800,30 +6062,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  WalletAddContactRequest sse_decode_wallet_add_contact_request(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_walletId = sse_decode_String(deserializer);
-    var var_nodeId = sse_decode_String(deserializer);
-    var var_name = sse_decode_String(deserializer);
-    return WalletAddContactRequest(
-      walletId: var_walletId,
-      nodeId: var_nodeId,
-      name: var_name,
-    );
-  }
-
-  @protected
-  WalletAddContactResponse sse_decode_wallet_add_contact_response(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_nodeId = sse_decode_String(deserializer);
-    return WalletAddContactResponse(nodeId: var_nodeId);
-  }
-
-  @protected
   WalletBalanceResponse sse_decode_wallet_balance_response(
     SseDeserializer deserializer,
   ) {
@@ -5898,28 +6136,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  WalletDeleteContactRequest sse_decode_wallet_delete_contact_request(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_walletId = sse_decode_String(deserializer);
-    var var_nodeId = sse_decode_String(deserializer);
-    return WalletDeleteContactRequest(
-      walletId: var_walletId,
-      nodeId: var_nodeId,
-    );
-  }
-
-  @protected
-  WalletDeleteContactResponse sse_decode_wallet_delete_contact_response(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_nodeId = sse_decode_String(deserializer);
-    return WalletDeleteContactResponse(nodeId: var_nodeId);
-  }
-
-  @protected
   WalletDevModeDetailedBalanceEntry
   sse_decode_wallet_dev_mode_detailed_balance_entry(
     SseDeserializer deserializer,
@@ -5945,30 +6161,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       deserializer,
     );
     return WalletDevModeDetailedBalanceResponse(entries: var_entries);
-  }
-
-  @protected
-  WalletEditContactRequest sse_decode_wallet_edit_contact_request(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_walletId = sse_decode_String(deserializer);
-    var var_nodeId = sse_decode_String(deserializer);
-    var var_name = sse_decode_String(deserializer);
-    return WalletEditContactRequest(
-      walletId: var_walletId,
-      nodeId: var_nodeId,
-      name: var_name,
-    );
-  }
-
-  @protected
-  WalletEditContactResponse sse_decode_wallet_edit_contact_response(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_nodeId = sse_decode_String(deserializer);
-    return WalletEditContactResponse(nodeId: var_nodeId);
   }
 
   @protected
@@ -6089,25 +6281,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  WalletGetContactRequest sse_decode_wallet_get_contact_request(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_walletId = sse_decode_String(deserializer);
-    var var_nodeId = sse_decode_String(deserializer);
-    return WalletGetContactRequest(walletId: var_walletId, nodeId: var_nodeId);
-  }
-
-  @protected
-  WalletGetContactResponse sse_decode_wallet_get_contact_response(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_contact = sse_decode_contact(deserializer);
-    return WalletGetContactResponse(contact: var_contact);
-  }
-
-  @protected
   WalletGetPaymentRequestRequest sse_decode_wallet_get_payment_request_request(
     SseDeserializer deserializer,
   ) {
@@ -6169,28 +6342,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       defaultMintUrl: var_defaultMintUrl,
       nostrRelays: var_nostrRelays,
     );
-  }
-
-  @protected
-  WalletListContactsRequest sse_decode_wallet_list_contacts_request(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_walletId = sse_decode_String(deserializer);
-    var var_searchTerm = sse_decode_opt_String(deserializer);
-    return WalletListContactsRequest(
-      walletId: var_walletId,
-      searchTerm: var_searchTerm,
-    );
-  }
-
-  @protected
-  WalletListContactsResponse sse_decode_wallet_list_contacts_response(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_contacts = sse_decode_list_contact(deserializer);
-    return WalletListContactsResponse(contacts: var_contacts);
   }
 
   @protected
@@ -6332,6 +6483,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletPaymentByContactRequest sse_decode_wallet_payment_by_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_walletId = sse_decode_String(deserializer);
+    var var_rid = sse_decode_String(deserializer);
+    return WalletPaymentByContactRequest(walletId: var_walletId, rid: var_rid);
+  }
+
+  @protected
   WalletPaymentByTokenRequest sse_decode_wallet_payment_by_token_request(
     SseDeserializer deserializer,
   ) {
@@ -6393,6 +6554,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return WalletPreparePayPaymentRequestRequest(
       walletId: var_walletId,
       paymentRequestId: var_paymentRequestId,
+    );
+  }
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  sse_decode_wallet_prepare_payment_by_contact_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_walletId = sse_decode_String(deserializer);
+    var var_contactId = sse_decode_String(deserializer);
+    var var_amount = sse_decode_u_64(deserializer);
+    var var_description = sse_decode_opt_String(deserializer);
+    return WalletPreparePaymentByContactRequest(
+      walletId: var_walletId,
+      contactId: var_contactId,
+      amount: var_amount,
+      description: var_description,
     );
   }
 
@@ -6640,13 +6819,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_walletId = sse_decode_String(deserializer);
-    var var_nodeId = sse_decode_String(deserializer);
+    var var_contactId = sse_decode_String(deserializer);
     var var_amount = sse_decode_u_64(deserializer);
     var var_description = sse_decode_opt_String(deserializer);
     var var_deadline = sse_decode_opt_box_autoadd_u_64(deserializer);
     return WalletRequestPaymentFromContactRequest(
       walletId: var_walletId,
-      nodeId: var_nodeId,
+      contactId: var_contactId,
       amount: var_amount,
       description: var_description,
       deadline: var_deadline,
@@ -6845,6 +7024,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_add_contact_request(
+    AddContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.bitcoinNetwork, serializer);
+    sse_encode_opt_String(self.email, serializer);
+    sse_encode_opt_String(self.nodeId, serializer);
+    sse_encode_opt_String(self.name, serializer);
+    sse_encode_opt_String(self.company, serializer);
+  }
+
+  @protected
+  void sse_encode_add_contact_response(
+    AddContactResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.contactId, serializer);
+  }
+
+  @protected
   void sse_encode_add_wallet_response(
     AddWalletResponse self,
     SseSerializer serializer,
@@ -6857,6 +7058,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_bool(bool self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putUint8(self ? 1 : 0);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_add_contact_request(
+    AddContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_add_contact_request(self, serializer);
   }
 
   @protected
@@ -6878,12 +7088,48 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_delete_contact_request(
+    DeleteContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_delete_contact_request(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_edit_contact_request(
+    EditContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_edit_contact_request(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_get_contact_request(
+    GetContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_get_contact_request(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_is_valid_token_request(
     IsValidTokenRequest self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_is_valid_token_request(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_list_contacts_request(
+    ListContactsRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_contacts_request(self, serializer);
   }
 
   @protected
@@ -6938,15 +7184,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_box_autoadd_wallet_add_contact_request(
-    WalletAddContactRequest self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_wallet_add_contact_request(self, serializer);
-  }
-
-  @protected
   void sse_encode_box_autoadd_wallet_cancel_payment_request_request(
     WalletCancelPaymentRequestRequest self,
     SseSerializer serializer,
@@ -6962,24 +7199,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_wallet_check_received_payment_request(self, serializer);
-  }
-
-  @protected
-  void sse_encode_box_autoadd_wallet_delete_contact_request(
-    WalletDeleteContactRequest self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_wallet_delete_contact_request(self, serializer);
-  }
-
-  @protected
-  void sse_encode_box_autoadd_wallet_edit_contact_request(
-    WalletEditContactRequest self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_wallet_edit_contact_request(self, serializer);
   }
 
   @protected
@@ -7010,15 +7229,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_box_autoadd_wallet_get_contact_request(
-    WalletGetContactRequest self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_wallet_get_contact_request(self, serializer);
-  }
-
-  @protected
   void sse_encode_box_autoadd_wallet_get_payment_request_request(
     WalletGetPaymentRequestRequest self,
     SseSerializer serializer,
@@ -7034,15 +7244,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_wallet_id_for_mnemonic_and_network_request(self, serializer);
-  }
-
-  @protected
-  void sse_encode_box_autoadd_wallet_list_contacts_request(
-    WalletListContactsRequest self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_wallet_list_contacts_request(self, serializer);
   }
 
   @protected
@@ -7082,6 +7283,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_wallet_payment_by_contact_request(
+    WalletPaymentByContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_wallet_payment_by_contact_request(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_wallet_payment_by_token_request(
     WalletPaymentByTokenRequest self,
     SseSerializer serializer,
@@ -7106,6 +7316,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_wallet_prepare_pay_payment_request_request(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_wallet_prepare_payment_by_contact_request(
+    WalletPreparePaymentByContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_wallet_prepare_payment_by_contact_request(self, serializer);
   }
 
   @protected
@@ -7281,8 +7500,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_contact(Contact self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.nodeId, serializer);
-    sse_encode_String(self.name, serializer);
+    sse_encode_String(self.id, serializer);
+    sse_encode_opt_String(self.nodeId, serializer);
+    sse_encode_opt_String(self.email, serializer);
+    sse_encode_opt_String(self.name, serializer);
+    sse_encode_opt_String(self.company, serializer);
   }
 
   @protected
@@ -7299,6 +7521,48 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_delete_contact_request(
+    DeleteContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.bitcoinNetwork, serializer);
+    sse_encode_String(self.contactId, serializer);
+  }
+
+  @protected
+  void sse_encode_delete_contact_response(
+    DeleteContactResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.contactId, serializer);
+  }
+
+  @protected
+  void sse_encode_edit_contact_request(
+    EditContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.bitcoinNetwork, serializer);
+    sse_encode_String(self.contactId, serializer);
+    sse_encode_opt_String(self.nodeId, serializer);
+    sse_encode_opt_String(self.email, serializer);
+    sse_encode_opt_String(self.name, serializer);
+    sse_encode_opt_String(self.company, serializer);
+  }
+
+  @protected
+  void sse_encode_edit_contact_response(
+    EditContactResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.contactId, serializer);
+  }
+
+  @protected
   void sse_encode_f_32(double self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putFloat32(self);
@@ -7310,6 +7574,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_32(self.year, serializer);
     sse_encode_u_32(self.month, serializer);
     sse_encode_u_64(self.fees, serializer);
+  }
+
+  @protected
+  void sse_encode_get_contact_request(
+    GetContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.bitcoinNetwork, serializer);
+    sse_encode_String(self.contactId, serializer);
+  }
+
+  @protected
+  void sse_encode_get_contact_response(
+    GetContactResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_contact(self.contact, serializer);
   }
 
   @protected
@@ -7373,6 +7656,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     for (final item in self) {
       sse_encode_contact(item, serializer);
     }
+  }
+
+  @protected
+  void sse_encode_list_contacts_request(
+    ListContactsRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.bitcoinNetwork, serializer);
+    sse_encode_opt_String(self.searchTerm, serializer);
+  }
+
+  @protected
+  void sse_encode_list_contacts_response(
+    ListContactsResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_contact(self.contacts, serializer);
   }
 
   @protected
@@ -7875,26 +8177,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_wallet_add_contact_request(
-    WalletAddContactRequest self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.walletId, serializer);
-    sse_encode_String(self.nodeId, serializer);
-    sse_encode_String(self.name, serializer);
-  }
-
-  @protected
-  void sse_encode_wallet_add_contact_response(
-    WalletAddContactResponse self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.nodeId, serializer);
-  }
-
-  @protected
   void sse_encode_wallet_balance_response(
     WalletBalanceResponse self,
     SseSerializer serializer,
@@ -7954,25 +8236,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_wallet_delete_contact_request(
-    WalletDeleteContactRequest self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.walletId, serializer);
-    sse_encode_String(self.nodeId, serializer);
-  }
-
-  @protected
-  void sse_encode_wallet_delete_contact_response(
-    WalletDeleteContactResponse self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.nodeId, serializer);
-  }
-
-  @protected
   void sse_encode_wallet_dev_mode_detailed_balance_entry(
     WalletDevModeDetailedBalanceEntry self,
     SseSerializer serializer,
@@ -7993,26 +8256,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       self.entries,
       serializer,
     );
-  }
-
-  @protected
-  void sse_encode_wallet_edit_contact_request(
-    WalletEditContactRequest self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.walletId, serializer);
-    sse_encode_String(self.nodeId, serializer);
-    sse_encode_String(self.name, serializer);
-  }
-
-  @protected
-  void sse_encode_wallet_edit_contact_response(
-    WalletEditContactResponse self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.nodeId, serializer);
   }
 
   @protected
@@ -8110,25 +8353,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_wallet_get_contact_request(
-    WalletGetContactRequest self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.walletId, serializer);
-    sse_encode_String(self.nodeId, serializer);
-  }
-
-  @protected
-  void sse_encode_wallet_get_contact_response(
-    WalletGetContactResponse self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_contact(self.contact, serializer);
-  }
-
-  @protected
   void sse_encode_wallet_get_payment_request_request(
     WalletGetPaymentRequestRequest self,
     SseSerializer serializer,
@@ -8177,25 +8401,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.network, serializer);
     sse_encode_String(self.defaultMintUrl, serializer);
     sse_encode_list_String(self.nostrRelays, serializer);
-  }
-
-  @protected
-  void sse_encode_wallet_list_contacts_request(
-    WalletListContactsRequest self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.walletId, serializer);
-    sse_encode_opt_String(self.searchTerm, serializer);
-  }
-
-  @protected
-  void sse_encode_wallet_list_contacts_response(
-    WalletListContactsResponse self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_list_contact(self.contacts, serializer);
   }
 
   @protected
@@ -8311,6 +8516,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_wallet_payment_by_contact_request(
+    WalletPaymentByContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.walletId, serializer);
+    sse_encode_String(self.rid, serializer);
+  }
+
+  @protected
   void sse_encode_wallet_payment_by_token_request(
     WalletPaymentByTokenRequest self,
     SseSerializer serializer,
@@ -8361,6 +8576,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.walletId, serializer);
     sse_encode_String(self.paymentRequestId, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_prepare_payment_by_contact_request(
+    WalletPreparePaymentByContactRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.walletId, serializer);
+    sse_encode_String(self.contactId, serializer);
+    sse_encode_u_64(self.amount, serializer);
+    sse_encode_opt_String(self.description, serializer);
   }
 
   @protected
@@ -8572,7 +8799,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.walletId, serializer);
-    sse_encode_String(self.nodeId, serializer);
+    sse_encode_String(self.contactId, serializer);
     sse_encode_u_64(self.amount, serializer);
     sse_encode_opt_String(self.description, serializer);
     sse_encode_opt_box_autoadd_u_64(self.deadline, serializer);

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -68,10 +68,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String dco_decode_String(dynamic raw);
 
   @protected
+  AddContactRequest dco_decode_add_contact_request(dynamic raw);
+
+  @protected
+  AddContactResponse dco_decode_add_contact_response(dynamic raw);
+
+  @protected
   AddWalletResponse dco_decode_add_wallet_response(dynamic raw);
 
   @protected
   bool dco_decode_bool(dynamic raw);
+
+  @protected
+  AddContactRequest dco_decode_box_autoadd_add_contact_request(dynamic raw);
 
   @protected
   BtcTxStatusRequest dco_decode_box_autoadd_btc_tx_status_request(dynamic raw);
@@ -80,9 +89,23 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   CreateWalletRequest dco_decode_box_autoadd_create_wallet_request(dynamic raw);
 
   @protected
+  DeleteContactRequest dco_decode_box_autoadd_delete_contact_request(
+    dynamic raw,
+  );
+
+  @protected
+  EditContactRequest dco_decode_box_autoadd_edit_contact_request(dynamic raw);
+
+  @protected
+  GetContactRequest dco_decode_box_autoadd_get_contact_request(dynamic raw);
+
+  @protected
   IsValidTokenRequest dco_decode_box_autoadd_is_valid_token_request(
     dynamic raw,
   );
+
+  @protected
+  ListContactsRequest dco_decode_box_autoadd_list_contacts_request(dynamic raw);
 
   @protected
   MnemonicRequest dco_decode_box_autoadd_mnemonic_request(dynamic raw);
@@ -105,26 +128,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt dco_decode_box_autoadd_u_64(dynamic raw);
 
   @protected
-  WalletAddContactRequest dco_decode_box_autoadd_wallet_add_contact_request(
-    dynamic raw,
-  );
-
-  @protected
   WalletCancelPaymentRequestRequest
   dco_decode_box_autoadd_wallet_cancel_payment_request_request(dynamic raw);
 
   @protected
   WalletCheckReceivedPaymentRequest
   dco_decode_box_autoadd_wallet_check_received_payment_request(dynamic raw);
-
-  @protected
-  WalletDeleteContactRequest
-  dco_decode_box_autoadd_wallet_delete_contact_request(dynamic raw);
-
-  @protected
-  WalletEditContactRequest dco_decode_box_autoadd_wallet_edit_contact_request(
-    dynamic raw,
-  );
 
   @protected
   WalletEditTransactionMemoRequest
@@ -139,22 +148,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletFfiConfig dco_decode_box_autoadd_wallet_ffi_config(dynamic raw);
 
   @protected
-  WalletGetContactRequest dco_decode_box_autoadd_wallet_get_contact_request(
-    dynamic raw,
-  );
-
-  @protected
   WalletGetPaymentRequestRequest
   dco_decode_box_autoadd_wallet_get_payment_request_request(dynamic raw);
 
   @protected
   WalletIdForMnemonicAndNetworkRequest
   dco_decode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
-    dynamic raw,
-  );
-
-  @protected
-  WalletListContactsRequest dco_decode_box_autoadd_wallet_list_contacts_request(
     dynamic raw,
   );
 
@@ -173,6 +172,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletPayRequest dco_decode_box_autoadd_wallet_pay_request(dynamic raw);
 
   @protected
+  WalletPaymentByContactRequest
+  dco_decode_box_autoadd_wallet_payment_by_contact_request(dynamic raw);
+
+  @protected
   WalletPaymentByTokenRequest
   dco_decode_box_autoadd_wallet_payment_by_token_request(dynamic raw);
 
@@ -186,6 +189,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_box_autoadd_wallet_prepare_pay_payment_request_request(
     dynamic raw,
   );
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  dco_decode_box_autoadd_wallet_prepare_payment_by_contact_request(dynamic raw);
 
   @protected
   WalletPreparePaymentByTokenRequest
@@ -270,10 +277,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   CreateWalletRequest dco_decode_create_wallet_request(dynamic raw);
 
   @protected
+  DeleteContactRequest dco_decode_delete_contact_request(dynamic raw);
+
+  @protected
+  DeleteContactResponse dco_decode_delete_contact_response(dynamic raw);
+
+  @protected
+  EditContactRequest dco_decode_edit_contact_request(dynamic raw);
+
+  @protected
+  EditContactResponse dco_decode_edit_contact_response(dynamic raw);
+
+  @protected
   double dco_decode_f_32(dynamic raw);
 
   @protected
   FeesByMonth dco_decode_fees_by_month(dynamic raw);
+
+  @protected
+  GetContactRequest dco_decode_get_contact_request(dynamic raw);
+
+  @protected
+  GetContactResponse dco_decode_get_contact_response(dynamic raw);
 
   @protected
   int dco_decode_i_32(dynamic raw);
@@ -295,6 +320,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<Contact> dco_decode_list_contact(dynamic raw);
+
+  @protected
+  ListContactsRequest dco_decode_list_contacts_request(dynamic raw);
+
+  @protected
+  ListContactsResponse dco_decode_list_contacts_response(dynamic raw);
 
   @protected
   List<FeesByMonth> dco_decode_list_fees_by_month(dynamic raw);
@@ -451,12 +482,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt dco_decode_usize(dynamic raw);
 
   @protected
-  WalletAddContactRequest dco_decode_wallet_add_contact_request(dynamic raw);
-
-  @protected
-  WalletAddContactResponse dco_decode_wallet_add_contact_response(dynamic raw);
-
-  @protected
   WalletBalanceResponse dco_decode_wallet_balance_response(dynamic raw);
 
   @protected
@@ -481,30 +506,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  WalletDeleteContactRequest dco_decode_wallet_delete_contact_request(
-    dynamic raw,
-  );
-
-  @protected
-  WalletDeleteContactResponse dco_decode_wallet_delete_contact_response(
-    dynamic raw,
-  );
-
-  @protected
   WalletDevModeDetailedBalanceEntry
   dco_decode_wallet_dev_mode_detailed_balance_entry(dynamic raw);
 
   @protected
   WalletDevModeDetailedBalanceResponse
   dco_decode_wallet_dev_mode_detailed_balance_response(dynamic raw);
-
-  @protected
-  WalletEditContactRequest dco_decode_wallet_edit_contact_request(dynamic raw);
-
-  @protected
-  WalletEditContactResponse dco_decode_wallet_edit_contact_response(
-    dynamic raw,
-  );
 
   @protected
   WalletEditTransactionMemoRequest
@@ -542,12 +549,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletFfiConfig dco_decode_wallet_ffi_config(dynamic raw);
 
   @protected
-  WalletGetContactRequest dco_decode_wallet_get_contact_request(dynamic raw);
-
-  @protected
-  WalletGetContactResponse dco_decode_wallet_get_contact_response(dynamic raw);
-
-  @protected
   WalletGetPaymentRequestRequest dco_decode_wallet_get_payment_request_request(
     dynamic raw,
   );
@@ -566,16 +567,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletInfoResponse dco_decode_wallet_info_response(dynamic raw);
-
-  @protected
-  WalletListContactsRequest dco_decode_wallet_list_contacts_request(
-    dynamic raw,
-  );
-
-  @protected
-  WalletListContactsResponse dco_decode_wallet_list_contacts_response(
-    dynamic raw,
-  );
 
   @protected
   WalletListPaymentRequestsRequest
@@ -620,6 +611,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletPayRequest dco_decode_wallet_pay_request(dynamic raw);
 
   @protected
+  WalletPaymentByContactRequest dco_decode_wallet_payment_by_contact_request(
+    dynamic raw,
+  );
+
+  @protected
   WalletPaymentByTokenRequest dco_decode_wallet_payment_by_token_request(
     dynamic raw,
   );
@@ -639,6 +635,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   dco_decode_wallet_prepare_pay_payment_request_request(dynamic raw);
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  dco_decode_wallet_prepare_payment_by_contact_request(dynamic raw);
 
   @protected
   WalletPreparePaymentByTokenRequest
@@ -796,12 +796,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
+  AddContactRequest sse_decode_add_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  AddContactResponse sse_decode_add_contact_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   AddWalletResponse sse_decode_add_wallet_response(
     SseDeserializer deserializer,
   );
 
   @protected
   bool sse_decode_bool(SseDeserializer deserializer);
+
+  @protected
+  AddContactRequest sse_decode_box_autoadd_add_contact_request(
+    SseDeserializer deserializer,
+  );
 
   @protected
   BtcTxStatusRequest sse_decode_box_autoadd_btc_tx_status_request(
@@ -814,7 +829,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  DeleteContactRequest sse_decode_box_autoadd_delete_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  EditContactRequest sse_decode_box_autoadd_edit_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GetContactRequest sse_decode_box_autoadd_get_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   IsValidTokenRequest sse_decode_box_autoadd_is_valid_token_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ListContactsRequest sse_decode_box_autoadd_list_contacts_request(
     SseDeserializer deserializer,
   );
 
@@ -845,11 +880,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt sse_decode_box_autoadd_u_64(SseDeserializer deserializer);
 
   @protected
-  WalletAddContactRequest sse_decode_box_autoadd_wallet_add_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   WalletCancelPaymentRequestRequest
   sse_decode_box_autoadd_wallet_cancel_payment_request_request(
     SseDeserializer deserializer,
@@ -858,17 +888,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletCheckReceivedPaymentRequest
   sse_decode_box_autoadd_wallet_check_received_payment_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletDeleteContactRequest
-  sse_decode_box_autoadd_wallet_delete_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletEditContactRequest sse_decode_box_autoadd_wallet_edit_contact_request(
     SseDeserializer deserializer,
   );
 
@@ -889,11 +908,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  WalletGetContactRequest sse_decode_box_autoadd_wallet_get_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   WalletGetPaymentRequestRequest
   sse_decode_box_autoadd_wallet_get_payment_request_request(
     SseDeserializer deserializer,
@@ -902,11 +916,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletIdForMnemonicAndNetworkRequest
   sse_decode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletListContactsRequest sse_decode_box_autoadd_wallet_list_contacts_request(
     SseDeserializer deserializer,
   );
 
@@ -933,6 +942,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletPaymentByContactRequest
+  sse_decode_box_autoadd_wallet_payment_by_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletPaymentByTokenRequest
   sse_decode_box_autoadd_wallet_payment_by_token_request(
     SseDeserializer deserializer,
@@ -946,6 +961,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   sse_decode_box_autoadd_wallet_prepare_pay_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  sse_decode_box_autoadd_wallet_prepare_payment_by_contact_request(
     SseDeserializer deserializer,
   );
 
@@ -1056,10 +1077,40 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  DeleteContactRequest sse_decode_delete_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  DeleteContactResponse sse_decode_delete_contact_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  EditContactRequest sse_decode_edit_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  EditContactResponse sse_decode_edit_contact_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   double sse_decode_f_32(SseDeserializer deserializer);
 
   @protected
   FeesByMonth sse_decode_fees_by_month(SseDeserializer deserializer);
+
+  @protected
+  GetContactRequest sse_decode_get_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GetContactResponse sse_decode_get_contact_response(
+    SseDeserializer deserializer,
+  );
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
@@ -1087,6 +1138,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<Contact> sse_decode_list_contact(SseDeserializer deserializer);
+
+  @protected
+  ListContactsRequest sse_decode_list_contacts_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ListContactsResponse sse_decode_list_contacts_response(
+    SseDeserializer deserializer,
+  );
 
   @protected
   List<FeesByMonth> sse_decode_list_fees_by_month(SseDeserializer deserializer);
@@ -1283,16 +1344,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt sse_decode_usize(SseDeserializer deserializer);
 
   @protected
-  WalletAddContactRequest sse_decode_wallet_add_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletAddContactResponse sse_decode_wallet_add_contact_response(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   WalletBalanceResponse sse_decode_wallet_balance_response(
     SseDeserializer deserializer,
   );
@@ -1325,16 +1376,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  WalletDeleteContactRequest sse_decode_wallet_delete_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletDeleteContactResponse sse_decode_wallet_delete_contact_response(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   WalletDevModeDetailedBalanceEntry
   sse_decode_wallet_dev_mode_detailed_balance_entry(
     SseDeserializer deserializer,
@@ -1343,16 +1384,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletDevModeDetailedBalanceResponse
   sse_decode_wallet_dev_mode_detailed_balance_response(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletEditContactRequest sse_decode_wallet_edit_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletEditContactResponse sse_decode_wallet_edit_contact_response(
     SseDeserializer deserializer,
   );
 
@@ -1394,16 +1425,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletFfiConfig sse_decode_wallet_ffi_config(SseDeserializer deserializer);
 
   @protected
-  WalletGetContactRequest sse_decode_wallet_get_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletGetContactResponse sse_decode_wallet_get_contact_response(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   WalletGetPaymentRequestRequest sse_decode_wallet_get_payment_request_request(
     SseDeserializer deserializer,
   );
@@ -1426,16 +1447,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletInfoResponse sse_decode_wallet_info_response(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletListContactsRequest sse_decode_wallet_list_contacts_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletListContactsResponse sse_decode_wallet_list_contacts_response(
     SseDeserializer deserializer,
   );
 
@@ -1492,6 +1503,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletPayRequest sse_decode_wallet_pay_request(SseDeserializer deserializer);
 
   @protected
+  WalletPaymentByContactRequest sse_decode_wallet_payment_by_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletPaymentByTokenRequest sse_decode_wallet_payment_by_token_request(
     SseDeserializer deserializer,
   );
@@ -1515,6 +1531,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   sse_decode_wallet_prepare_pay_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  sse_decode_wallet_prepare_payment_by_contact_request(
     SseDeserializer deserializer,
   );
 
@@ -1724,6 +1746,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
+  void sse_encode_add_contact_request(
+    AddContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_add_contact_response(
+    AddContactResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_add_wallet_response(
     AddWalletResponse self,
     SseSerializer serializer,
@@ -1731,6 +1765,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_bool(bool self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_add_contact_request(
+    AddContactRequest self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_box_autoadd_btc_tx_status_request(
@@ -1745,8 +1785,32 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_delete_contact_request(
+    DeleteContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_edit_contact_request(
+    EditContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_get_contact_request(
+    GetContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_is_valid_token_request(
     IsValidTokenRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_list_contacts_request(
+    ListContactsRequest self,
     SseSerializer serializer,
   );
 
@@ -1784,12 +1848,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_box_autoadd_u_64(BigInt self, SseSerializer serializer);
 
   @protected
-  void sse_encode_box_autoadd_wallet_add_contact_request(
-    WalletAddContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_box_autoadd_wallet_cancel_payment_request_request(
     WalletCancelPaymentRequestRequest self,
     SseSerializer serializer,
@@ -1798,18 +1856,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_check_received_payment_request(
     WalletCheckReceivedPaymentRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_box_autoadd_wallet_delete_contact_request(
-    WalletDeleteContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_box_autoadd_wallet_edit_contact_request(
-    WalletEditContactRequest self,
     SseSerializer serializer,
   );
 
@@ -1832,12 +1878,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_box_autoadd_wallet_get_contact_request(
-    WalletGetContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_box_autoadd_wallet_get_payment_request_request(
     WalletGetPaymentRequestRequest self,
     SseSerializer serializer,
@@ -1846,12 +1886,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
     WalletIdForMnemonicAndNetworkRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_box_autoadd_wallet_list_contacts_request(
-    WalletListContactsRequest self,
     SseSerializer serializer,
   );
 
@@ -1880,6 +1914,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_wallet_payment_by_contact_request(
+    WalletPaymentByContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_wallet_payment_by_token_request(
     WalletPaymentByTokenRequest self,
     SseSerializer serializer,
@@ -1894,6 +1934,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_prepare_pay_payment_request_request(
     WalletPreparePayPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_wallet_prepare_payment_by_contact_request(
+    WalletPreparePaymentByContactRequest self,
     SseSerializer serializer,
   );
 
@@ -2015,10 +2061,46 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_delete_contact_request(
+    DeleteContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_delete_contact_response(
+    DeleteContactResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_edit_contact_request(
+    EditContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_edit_contact_response(
+    EditContactResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_f_32(double self, SseSerializer serializer);
 
   @protected
   void sse_encode_fees_by_month(FeesByMonth self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_get_contact_request(
+    GetContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_get_contact_response(
+    GetContactResponse self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
@@ -2049,6 +2131,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_list_contact(List<Contact> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_contacts_request(
+    ListContactsRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_contacts_response(
+    ListContactsResponse self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_list_fees_by_month(
@@ -2309,18 +2403,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_usize(BigInt self, SseSerializer serializer);
 
   @protected
-  void sse_encode_wallet_add_contact_request(
-    WalletAddContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_add_contact_response(
-    WalletAddContactResponse self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_wallet_balance_response(
     WalletBalanceResponse self,
     SseSerializer serializer,
@@ -2357,18 +2439,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_wallet_delete_contact_request(
-    WalletDeleteContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_delete_contact_response(
-    WalletDeleteContactResponse self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_wallet_dev_mode_detailed_balance_entry(
     WalletDevModeDetailedBalanceEntry self,
     SseSerializer serializer,
@@ -2377,18 +2447,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_dev_mode_detailed_balance_response(
     WalletDevModeDetailedBalanceResponse self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_edit_contact_request(
-    WalletEditContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_edit_contact_response(
-    WalletEditContactResponse self,
     SseSerializer serializer,
   );
 
@@ -2444,18 +2502,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_wallet_get_contact_request(
-    WalletGetContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_get_contact_response(
-    WalletGetContactResponse self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_wallet_get_payment_request_request(
     WalletGetPaymentRequestRequest self,
     SseSerializer serializer,
@@ -2482,18 +2528,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_info_response(
     WalletInfoResponse self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_list_contacts_request(
-    WalletListContactsRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_list_contacts_response(
-    WalletListContactsResponse self,
     SseSerializer serializer,
   );
 
@@ -2564,6 +2598,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_wallet_payment_by_contact_request(
+    WalletPaymentByContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_wallet_payment_by_token_request(
     WalletPaymentByTokenRequest self,
     SseSerializer serializer,
@@ -2590,6 +2630,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_prepare_pay_payment_request_request(
     WalletPreparePayPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_prepare_payment_by_contact_request(
+    WalletPreparePaymentByContactRequest self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -70,10 +70,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String dco_decode_String(dynamic raw);
 
   @protected
+  AddContactRequest dco_decode_add_contact_request(dynamic raw);
+
+  @protected
+  AddContactResponse dco_decode_add_contact_response(dynamic raw);
+
+  @protected
   AddWalletResponse dco_decode_add_wallet_response(dynamic raw);
 
   @protected
   bool dco_decode_bool(dynamic raw);
+
+  @protected
+  AddContactRequest dco_decode_box_autoadd_add_contact_request(dynamic raw);
 
   @protected
   BtcTxStatusRequest dco_decode_box_autoadd_btc_tx_status_request(dynamic raw);
@@ -82,9 +91,23 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   CreateWalletRequest dco_decode_box_autoadd_create_wallet_request(dynamic raw);
 
   @protected
+  DeleteContactRequest dco_decode_box_autoadd_delete_contact_request(
+    dynamic raw,
+  );
+
+  @protected
+  EditContactRequest dco_decode_box_autoadd_edit_contact_request(dynamic raw);
+
+  @protected
+  GetContactRequest dco_decode_box_autoadd_get_contact_request(dynamic raw);
+
+  @protected
   IsValidTokenRequest dco_decode_box_autoadd_is_valid_token_request(
     dynamic raw,
   );
+
+  @protected
+  ListContactsRequest dco_decode_box_autoadd_list_contacts_request(dynamic raw);
 
   @protected
   MnemonicRequest dco_decode_box_autoadd_mnemonic_request(dynamic raw);
@@ -107,26 +130,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt dco_decode_box_autoadd_u_64(dynamic raw);
 
   @protected
-  WalletAddContactRequest dco_decode_box_autoadd_wallet_add_contact_request(
-    dynamic raw,
-  );
-
-  @protected
   WalletCancelPaymentRequestRequest
   dco_decode_box_autoadd_wallet_cancel_payment_request_request(dynamic raw);
 
   @protected
   WalletCheckReceivedPaymentRequest
   dco_decode_box_autoadd_wallet_check_received_payment_request(dynamic raw);
-
-  @protected
-  WalletDeleteContactRequest
-  dco_decode_box_autoadd_wallet_delete_contact_request(dynamic raw);
-
-  @protected
-  WalletEditContactRequest dco_decode_box_autoadd_wallet_edit_contact_request(
-    dynamic raw,
-  );
 
   @protected
   WalletEditTransactionMemoRequest
@@ -141,22 +150,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletFfiConfig dco_decode_box_autoadd_wallet_ffi_config(dynamic raw);
 
   @protected
-  WalletGetContactRequest dco_decode_box_autoadd_wallet_get_contact_request(
-    dynamic raw,
-  );
-
-  @protected
   WalletGetPaymentRequestRequest
   dco_decode_box_autoadd_wallet_get_payment_request_request(dynamic raw);
 
   @protected
   WalletIdForMnemonicAndNetworkRequest
   dco_decode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
-    dynamic raw,
-  );
-
-  @protected
-  WalletListContactsRequest dco_decode_box_autoadd_wallet_list_contacts_request(
     dynamic raw,
   );
 
@@ -175,6 +174,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletPayRequest dco_decode_box_autoadd_wallet_pay_request(dynamic raw);
 
   @protected
+  WalletPaymentByContactRequest
+  dco_decode_box_autoadd_wallet_payment_by_contact_request(dynamic raw);
+
+  @protected
   WalletPaymentByTokenRequest
   dco_decode_box_autoadd_wallet_payment_by_token_request(dynamic raw);
 
@@ -188,6 +191,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_box_autoadd_wallet_prepare_pay_payment_request_request(
     dynamic raw,
   );
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  dco_decode_box_autoadd_wallet_prepare_payment_by_contact_request(dynamic raw);
 
   @protected
   WalletPreparePaymentByTokenRequest
@@ -272,10 +279,28 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   CreateWalletRequest dco_decode_create_wallet_request(dynamic raw);
 
   @protected
+  DeleteContactRequest dco_decode_delete_contact_request(dynamic raw);
+
+  @protected
+  DeleteContactResponse dco_decode_delete_contact_response(dynamic raw);
+
+  @protected
+  EditContactRequest dco_decode_edit_contact_request(dynamic raw);
+
+  @protected
+  EditContactResponse dco_decode_edit_contact_response(dynamic raw);
+
+  @protected
   double dco_decode_f_32(dynamic raw);
 
   @protected
   FeesByMonth dco_decode_fees_by_month(dynamic raw);
+
+  @protected
+  GetContactRequest dco_decode_get_contact_request(dynamic raw);
+
+  @protected
+  GetContactResponse dco_decode_get_contact_response(dynamic raw);
 
   @protected
   int dco_decode_i_32(dynamic raw);
@@ -297,6 +322,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<Contact> dco_decode_list_contact(dynamic raw);
+
+  @protected
+  ListContactsRequest dco_decode_list_contacts_request(dynamic raw);
+
+  @protected
+  ListContactsResponse dco_decode_list_contacts_response(dynamic raw);
 
   @protected
   List<FeesByMonth> dco_decode_list_fees_by_month(dynamic raw);
@@ -453,12 +484,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt dco_decode_usize(dynamic raw);
 
   @protected
-  WalletAddContactRequest dco_decode_wallet_add_contact_request(dynamic raw);
-
-  @protected
-  WalletAddContactResponse dco_decode_wallet_add_contact_response(dynamic raw);
-
-  @protected
   WalletBalanceResponse dco_decode_wallet_balance_response(dynamic raw);
 
   @protected
@@ -483,30 +508,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  WalletDeleteContactRequest dco_decode_wallet_delete_contact_request(
-    dynamic raw,
-  );
-
-  @protected
-  WalletDeleteContactResponse dco_decode_wallet_delete_contact_response(
-    dynamic raw,
-  );
-
-  @protected
   WalletDevModeDetailedBalanceEntry
   dco_decode_wallet_dev_mode_detailed_balance_entry(dynamic raw);
 
   @protected
   WalletDevModeDetailedBalanceResponse
   dco_decode_wallet_dev_mode_detailed_balance_response(dynamic raw);
-
-  @protected
-  WalletEditContactRequest dco_decode_wallet_edit_contact_request(dynamic raw);
-
-  @protected
-  WalletEditContactResponse dco_decode_wallet_edit_contact_response(
-    dynamic raw,
-  );
 
   @protected
   WalletEditTransactionMemoRequest
@@ -544,12 +551,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletFfiConfig dco_decode_wallet_ffi_config(dynamic raw);
 
   @protected
-  WalletGetContactRequest dco_decode_wallet_get_contact_request(dynamic raw);
-
-  @protected
-  WalletGetContactResponse dco_decode_wallet_get_contact_response(dynamic raw);
-
-  @protected
   WalletGetPaymentRequestRequest dco_decode_wallet_get_payment_request_request(
     dynamic raw,
   );
@@ -568,16 +569,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletInfoResponse dco_decode_wallet_info_response(dynamic raw);
-
-  @protected
-  WalletListContactsRequest dco_decode_wallet_list_contacts_request(
-    dynamic raw,
-  );
-
-  @protected
-  WalletListContactsResponse dco_decode_wallet_list_contacts_response(
-    dynamic raw,
-  );
 
   @protected
   WalletListPaymentRequestsRequest
@@ -622,6 +613,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletPayRequest dco_decode_wallet_pay_request(dynamic raw);
 
   @protected
+  WalletPaymentByContactRequest dco_decode_wallet_payment_by_contact_request(
+    dynamic raw,
+  );
+
+  @protected
   WalletPaymentByTokenRequest dco_decode_wallet_payment_by_token_request(
     dynamic raw,
   );
@@ -641,6 +637,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   dco_decode_wallet_prepare_pay_payment_request_request(dynamic raw);
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  dco_decode_wallet_prepare_payment_by_contact_request(dynamic raw);
 
   @protected
   WalletPreparePaymentByTokenRequest
@@ -798,12 +798,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
+  AddContactRequest sse_decode_add_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  AddContactResponse sse_decode_add_contact_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   AddWalletResponse sse_decode_add_wallet_response(
     SseDeserializer deserializer,
   );
 
   @protected
   bool sse_decode_bool(SseDeserializer deserializer);
+
+  @protected
+  AddContactRequest sse_decode_box_autoadd_add_contact_request(
+    SseDeserializer deserializer,
+  );
 
   @protected
   BtcTxStatusRequest sse_decode_box_autoadd_btc_tx_status_request(
@@ -816,7 +831,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  DeleteContactRequest sse_decode_box_autoadd_delete_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  EditContactRequest sse_decode_box_autoadd_edit_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GetContactRequest sse_decode_box_autoadd_get_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   IsValidTokenRequest sse_decode_box_autoadd_is_valid_token_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ListContactsRequest sse_decode_box_autoadd_list_contacts_request(
     SseDeserializer deserializer,
   );
 
@@ -847,11 +882,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt sse_decode_box_autoadd_u_64(SseDeserializer deserializer);
 
   @protected
-  WalletAddContactRequest sse_decode_box_autoadd_wallet_add_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   WalletCancelPaymentRequestRequest
   sse_decode_box_autoadd_wallet_cancel_payment_request_request(
     SseDeserializer deserializer,
@@ -860,17 +890,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletCheckReceivedPaymentRequest
   sse_decode_box_autoadd_wallet_check_received_payment_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletDeleteContactRequest
-  sse_decode_box_autoadd_wallet_delete_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletEditContactRequest sse_decode_box_autoadd_wallet_edit_contact_request(
     SseDeserializer deserializer,
   );
 
@@ -891,11 +910,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  WalletGetContactRequest sse_decode_box_autoadd_wallet_get_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   WalletGetPaymentRequestRequest
   sse_decode_box_autoadd_wallet_get_payment_request_request(
     SseDeserializer deserializer,
@@ -904,11 +918,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletIdForMnemonicAndNetworkRequest
   sse_decode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletListContactsRequest sse_decode_box_autoadd_wallet_list_contacts_request(
     SseDeserializer deserializer,
   );
 
@@ -935,6 +944,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletPaymentByContactRequest
+  sse_decode_box_autoadd_wallet_payment_by_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletPaymentByTokenRequest
   sse_decode_box_autoadd_wallet_payment_by_token_request(
     SseDeserializer deserializer,
@@ -948,6 +963,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   sse_decode_box_autoadd_wallet_prepare_pay_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  sse_decode_box_autoadd_wallet_prepare_payment_by_contact_request(
     SseDeserializer deserializer,
   );
 
@@ -1058,10 +1079,40 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  DeleteContactRequest sse_decode_delete_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  DeleteContactResponse sse_decode_delete_contact_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  EditContactRequest sse_decode_edit_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  EditContactResponse sse_decode_edit_contact_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   double sse_decode_f_32(SseDeserializer deserializer);
 
   @protected
   FeesByMonth sse_decode_fees_by_month(SseDeserializer deserializer);
+
+  @protected
+  GetContactRequest sse_decode_get_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  GetContactResponse sse_decode_get_contact_response(
+    SseDeserializer deserializer,
+  );
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
@@ -1089,6 +1140,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   List<Contact> sse_decode_list_contact(SseDeserializer deserializer);
+
+  @protected
+  ListContactsRequest sse_decode_list_contacts_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ListContactsResponse sse_decode_list_contacts_response(
+    SseDeserializer deserializer,
+  );
 
   @protected
   List<FeesByMonth> sse_decode_list_fees_by_month(SseDeserializer deserializer);
@@ -1285,16 +1346,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt sse_decode_usize(SseDeserializer deserializer);
 
   @protected
-  WalletAddContactRequest sse_decode_wallet_add_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletAddContactResponse sse_decode_wallet_add_contact_response(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   WalletBalanceResponse sse_decode_wallet_balance_response(
     SseDeserializer deserializer,
   );
@@ -1327,16 +1378,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  WalletDeleteContactRequest sse_decode_wallet_delete_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletDeleteContactResponse sse_decode_wallet_delete_contact_response(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   WalletDevModeDetailedBalanceEntry
   sse_decode_wallet_dev_mode_detailed_balance_entry(
     SseDeserializer deserializer,
@@ -1345,16 +1386,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletDevModeDetailedBalanceResponse
   sse_decode_wallet_dev_mode_detailed_balance_response(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletEditContactRequest sse_decode_wallet_edit_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletEditContactResponse sse_decode_wallet_edit_contact_response(
     SseDeserializer deserializer,
   );
 
@@ -1396,16 +1427,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletFfiConfig sse_decode_wallet_ffi_config(SseDeserializer deserializer);
 
   @protected
-  WalletGetContactRequest sse_decode_wallet_get_contact_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletGetContactResponse sse_decode_wallet_get_contact_response(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   WalletGetPaymentRequestRequest sse_decode_wallet_get_payment_request_request(
     SseDeserializer deserializer,
   );
@@ -1428,16 +1449,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   WalletInfoResponse sse_decode_wallet_info_response(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletListContactsRequest sse_decode_wallet_list_contacts_request(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  WalletListContactsResponse sse_decode_wallet_list_contacts_response(
     SseDeserializer deserializer,
   );
 
@@ -1494,6 +1505,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   WalletPayRequest sse_decode_wallet_pay_request(SseDeserializer deserializer);
 
   @protected
+  WalletPaymentByContactRequest sse_decode_wallet_payment_by_contact_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletPaymentByTokenRequest sse_decode_wallet_payment_by_token_request(
     SseDeserializer deserializer,
   );
@@ -1517,6 +1533,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   sse_decode_wallet_prepare_pay_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePaymentByContactRequest
+  sse_decode_wallet_prepare_payment_by_contact_request(
     SseDeserializer deserializer,
   );
 
@@ -1726,6 +1748,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
+  void sse_encode_add_contact_request(
+    AddContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_add_contact_response(
+    AddContactResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_add_wallet_response(
     AddWalletResponse self,
     SseSerializer serializer,
@@ -1733,6 +1767,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_bool(bool self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_add_contact_request(
+    AddContactRequest self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_box_autoadd_btc_tx_status_request(
@@ -1747,8 +1787,32 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_delete_contact_request(
+    DeleteContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_edit_contact_request(
+    EditContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_get_contact_request(
+    GetContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_is_valid_token_request(
     IsValidTokenRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_list_contacts_request(
+    ListContactsRequest self,
     SseSerializer serializer,
   );
 
@@ -1786,12 +1850,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_box_autoadd_u_64(BigInt self, SseSerializer serializer);
 
   @protected
-  void sse_encode_box_autoadd_wallet_add_contact_request(
-    WalletAddContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_box_autoadd_wallet_cancel_payment_request_request(
     WalletCancelPaymentRequestRequest self,
     SseSerializer serializer,
@@ -1800,18 +1858,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_check_received_payment_request(
     WalletCheckReceivedPaymentRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_box_autoadd_wallet_delete_contact_request(
-    WalletDeleteContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_box_autoadd_wallet_edit_contact_request(
-    WalletEditContactRequest self,
     SseSerializer serializer,
   );
 
@@ -1834,12 +1880,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_box_autoadd_wallet_get_contact_request(
-    WalletGetContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_box_autoadd_wallet_get_payment_request_request(
     WalletGetPaymentRequestRequest self,
     SseSerializer serializer,
@@ -1848,12 +1888,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_id_for_mnemonic_and_network_request(
     WalletIdForMnemonicAndNetworkRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_box_autoadd_wallet_list_contacts_request(
-    WalletListContactsRequest self,
     SseSerializer serializer,
   );
 
@@ -1882,6 +1916,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_wallet_payment_by_contact_request(
+    WalletPaymentByContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_wallet_payment_by_token_request(
     WalletPaymentByTokenRequest self,
     SseSerializer serializer,
@@ -1896,6 +1936,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_prepare_pay_payment_request_request(
     WalletPreparePayPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_wallet_prepare_payment_by_contact_request(
+    WalletPreparePaymentByContactRequest self,
     SseSerializer serializer,
   );
 
@@ -2017,10 +2063,46 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_delete_contact_request(
+    DeleteContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_delete_contact_response(
+    DeleteContactResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_edit_contact_request(
+    EditContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_edit_contact_response(
+    EditContactResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_f_32(double self, SseSerializer serializer);
 
   @protected
   void sse_encode_fees_by_month(FeesByMonth self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_get_contact_request(
+    GetContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_get_contact_response(
+    GetContactResponse self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);
@@ -2051,6 +2133,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_list_contact(List<Contact> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_contacts_request(
+    ListContactsRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_contacts_response(
+    ListContactsResponse self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_list_fees_by_month(
@@ -2311,18 +2405,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_usize(BigInt self, SseSerializer serializer);
 
   @protected
-  void sse_encode_wallet_add_contact_request(
-    WalletAddContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_add_contact_response(
-    WalletAddContactResponse self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_wallet_balance_response(
     WalletBalanceResponse self,
     SseSerializer serializer,
@@ -2359,18 +2441,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_wallet_delete_contact_request(
-    WalletDeleteContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_delete_contact_response(
-    WalletDeleteContactResponse self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_wallet_dev_mode_detailed_balance_entry(
     WalletDevModeDetailedBalanceEntry self,
     SseSerializer serializer,
@@ -2379,18 +2449,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_dev_mode_detailed_balance_response(
     WalletDevModeDetailedBalanceResponse self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_edit_contact_request(
-    WalletEditContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_edit_contact_response(
-    WalletEditContactResponse self,
     SseSerializer serializer,
   );
 
@@ -2446,18 +2504,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_wallet_get_contact_request(
-    WalletGetContactRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_get_contact_response(
-    WalletGetContactResponse self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_wallet_get_payment_request_request(
     WalletGetPaymentRequestRequest self,
     SseSerializer serializer,
@@ -2484,18 +2530,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_info_response(
     WalletInfoResponse self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_list_contacts_request(
-    WalletListContactsRequest self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void sse_encode_wallet_list_contacts_response(
-    WalletListContactsResponse self,
     SseSerializer serializer,
   );
 
@@ -2566,6 +2600,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_wallet_payment_by_contact_request(
+    WalletPaymentByContactRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_wallet_payment_by_token_request(
     WalletPaymentByTokenRequest self,
     SseSerializer serializer,
@@ -2592,6 +2632,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_prepare_pay_payment_request_request(
     WalletPreparePayPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_prepare_payment_by_contact_request(
+    WalletPreparePaymentByContactRequest self,
     SseSerializer serializer,
   );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wallet_ffi
 description: "Wallet FFI"
-version: 0.9.7
+version: 0.9.8
 homepage:
 
 environment:


### PR DESCRIPTION
* Rework Contacts
    * Fields
        * id is now a `Uuid`
        * node_id is an `Option<NodeId>`
        * add email as an `Option<Email>`
        * name is an `Option<Name>`
        * add company as an `Option<Name>`
        * Either company, or name have to be set
        * Either node_id, or email have to be set
        * For `edit_contact`
            * All fields have to be provided
            * To delete a field, send it as `None`
            * To set a field, send it as `Some(new_value)`
    * Contacts are now on `purse` level instead of on `wallet` level and are persisted per `btc_network`
        * there is a contact book for each btc network
    * DB migration & versioning for contacts
    * It would be good to add all clowder-relays (wildcat0-n) to the wallet config
* Payment Request functions and pay by contact take a `Uuid` (the contact id) now
    * Contacts have to have a `node_id` to be eligible for `pay_to_contact` or `request_payment_from_contact`
* Expose functionality to send a private, encrypted payment to an existing contact via Nostr
    * `wallet_prepare_pay_to_contact` - taking a contact_id, amount and description
    * `wallet_pay_to_contact` - taking a payment request id
