### PR TITLE
Separate Fees into multiple Fee Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 * Expose functionality to send a private, encrypted payment to an existing contact via Nostr
     * `wallet_prepare_pay_to_contact` - taking a contact_id, amount and description
     * `wallet_pay_to_contact` - taking a payment request id
+* Separate `fees` in `Transaction` and `PaymentSummary` to contain different types of fees
+    * `swap` - swap fee
+    * `network` - network fee (e.g. bitcoin miner fee)
+    * `melt` - melt fee
 
 # 0.9.7
 

--- a/crates/bcr-wallet-api/src/pocket/debit.rs
+++ b/crates/bcr-wallet-api/src/pocket/debit.rs
@@ -821,7 +821,7 @@ impl DebitPocketApi for Pocket {
 
         // inputs need to cover amount + network_fee + melt_fee
         let full_amount = amount + network_fee + melt_fee;
-        let (_, send_ref) = self
+        let (send_summary, send_ref) = self
             .compute_send_costs(Amount::from(full_amount), keysets_info)
             .await?;
 
@@ -885,7 +885,7 @@ impl DebitPocketApi for Pocket {
         summary.fees = TransactionFees {
             network: cashu::Amount::from(network_fee),
             melt: cashu::Amount::from(melt_fee),
-            ..Default::default()
+            swap: send_summary.fees.swap,
         };
         let melt_ref = MeltReference {
             rid: summary.request_id,

--- a/crates/bcr-wallet-api/src/pocket/debit.rs
+++ b/crates/bcr-wallet-api/src/pocket/debit.rs
@@ -13,7 +13,7 @@ use bcr_common::{
     core::swap::wallet::{PaymentPlan, prepare_payment},
     wire::{common as wire_common, melt as wire_melt, mint as wire_mint, swap as wire_swap},
 };
-use bcr_wallet_core::types::{MeltSummary, MintSummary, Seed, SendSummary};
+use bcr_wallet_core::types::{MeltSummary, MintSummary, Seed, SendSummary, TransactionFees};
 use bcr_wallet_persistence::{MeltCommitmentRecord, MintMeltRepository, PocketRepository};
 use bitcoin::secp256k1;
 use std::{
@@ -263,7 +263,10 @@ impl Pocket {
                 let mut pocket_summary = SendSummary::new();
                 pocket_summary.amount = target_amount;
                 pocket_summary.unit = self.unit.clone();
-                pocket_summary.swap_fees = estimated_fee;
+                pocket_summary.fees = TransactionFees {
+                    swap: estimated_fee,
+                    ..Default::default()
+                };
                 let SplitTarget::Value(target_amount) = target else {
                     return Err(Error::InvalidSplitTarget);
                 };
@@ -876,12 +879,14 @@ impl DebitPocketApi for Pocket {
             }
         };
 
-        let fee = Amount::from(network_fee + melt_fee);
-
         let mut summary = MeltSummary::new();
         summary.amount = Amount::from(amount);
         summary.expiry = expiry;
-        summary.fees = fee;
+        summary.fees = TransactionFees {
+            network: cashu::Amount::from(network_fee),
+            melt: cashu::Amount::from(melt_fee),
+            ..Default::default()
+        };
         let melt_ref = MeltReference {
             rid: summary.request_id,
             quote_id,
@@ -2476,7 +2481,7 @@ mod tests {
             } => {
                 assert_eq!(inputs.len(), amounts.len());
                 assert_eq!(target, Amount::from(41u64));
-                assert_eq!(summary.swap_fees, estimated_fee);
+                assert_eq!(summary.fees.swap, estimated_fee);
             }
             SendPlan::Ready { .. } => panic!("expected swap send plan"),
         }
@@ -2524,7 +2529,7 @@ mod tests {
             } => {
                 assert_eq!(inputs.len(), amounts.len());
                 assert_eq!(target, Amount::from(23u64));
-                assert_eq!(summary.swap_fees, estimated_fee);
+                assert_eq!(summary.fees.swap, estimated_fee);
             }
             SendPlan::Ready { .. } => panic!("expected swap send plan"),
         }
@@ -2799,7 +2804,9 @@ mod tests {
 
         assert_eq!(summary.amount, Amount::from(amount));
         assert_eq!(summary.expiry, expiry);
-        assert_eq!(summary.fees, Amount::from(network_fee + melt_fee));
+        assert_eq!(summary.fees.network, Amount::from(network_fee));
+        assert_eq!(summary.fees.melt, Amount::from(melt_fee));
+        assert_eq!(summary.fees.swap, Amount::ZERO);
 
         let current_melt = pocket.current_melt.lock().unwrap();
         let melt_ref = current_melt.as_ref().unwrap();

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -544,7 +544,9 @@ impl WalletApi for super::Wallet {
                     .await?;
                 let (ys, proofs): (Vec<cashu::PublicKey>, Vec<cashu::Proof>) =
                     proofs.into_iter().unzip();
-                let amount = proofs.total_amount()?;
+                let mut amount = proofs.total_amount()?;
+                // the proofs are for amount + network_fee + melt_fee, so we need to subtract them
+                amount = amount - fees.network - fees.melt;
 
                 let partial_tx = Transaction {
                     id: Uuid::new_v4(),

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -25,7 +25,7 @@ use bcr_wallet_core::{
     types::{
         MeltEstimation, PaymentRequest, PaymentRequestDirection, PaymentRequestState,
         PaymentResultCallback, PaymentType, PendingPaymentSubscriptionCallback, Transaction,
-        TransactionStatus,
+        TransactionFees, TransactionStatus,
     },
     util::{from_mint_url, to_mint_url},
 };
@@ -132,7 +132,7 @@ pub trait WalletApi: SendSync {
         &self,
         request_id: Uuid,
         unit: CurrencyUnit,
-        fees: Amount,
+        fees: TransactionFees,
         memo: Option<String>,
         now: u64,
     ) -> Result<(Uuid, Option<Token>)>;
@@ -573,8 +573,7 @@ impl WalletApi for super::Wallet {
                 payment_request_id,
             } => {
                 self.refresh_contact_relays(&contact_id).await;
-                let Ok(Some(contact)) = self.contact_repo.get_contact(contact_id).await
-                else {
+                let Ok(Some(contact)) = self.contact_repo.get_contact(contact_id).await else {
                     return Err(Error::ContactNotFound(contact_id.to_string()));
                 };
                 if contact.node_id.is_none() {
@@ -657,7 +656,10 @@ impl WalletApi for super::Wallet {
             let tx = Transaction {
                 id: Uuid::new_v4(),
                 mint_url: to_mint_url(self.client.mint_url()),
-                fees: mint_result.fee,
+                fees: TransactionFees {
+                    swap: mint_result.fee, // when minting, we only accrue swap fees
+                    ..Default::default()
+                },
                 direction: TransactionDirection::Incoming,
                 memo: None,
                 status: TransactionStatus::Settled,
@@ -701,7 +703,7 @@ impl WalletApi for super::Wallet {
             let tx = Transaction {
                 id: Uuid::new_v4(),
                 mint_url: to_mint_url(self.client.mint_url()),
-                fees: cashu::Amount::ZERO,
+                fees: TransactionFees::default(),
                 direction: TransactionDirection::Incoming,
                 memo: Some("Mint protest resolved".to_string()),
                 tstamp: now.timestamp() as u64,
@@ -745,7 +747,7 @@ impl WalletApi for super::Wallet {
             let tx = Transaction {
                 id: Uuid::new_v4(),
                 mint_url: to_mint_url(self.client.mint_url()),
-                fees: cashu::Amount::ZERO,
+                fees: TransactionFees::default(),
                 direction: TransactionDirection::Incoming,
                 memo: Some("Swap protest resolved".to_string()),
                 tstamp: now.timestamp() as u64,
@@ -779,7 +781,7 @@ impl WalletApi for super::Wallet {
             let tx = Transaction {
                 id: Uuid::new_v4(),
                 mint_url: to_mint_url(self.client.mint_url()),
-                fees: cashu::Amount::ZERO,
+                fees: TransactionFees::default(),
                 direction: TransactionDirection::Outgoing,
                 memo: Some("Melt protest resolved".to_string()),
                 tstamp: now.timestamp() as u64,
@@ -1112,7 +1114,7 @@ impl WalletApi for super::Wallet {
         &self,
         request_id: Uuid,
         unit: CurrencyUnit,
-        fees: Amount,
+        fees: TransactionFees,
         memo: Option<String>,
         now: u64,
     ) -> Result<(Uuid, Option<Token>)> {

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -26,8 +26,8 @@ use bcr_wallet_core::{
     event::{ContactPaymentPayload, EventEnvelope},
     types::{
         ListTransactionsResult, PaymentRequest, PaymentType, Transaction, TransactionCursor,
-        TransactionFilters, TransactionLinkReason, TransactionSort, TransactionStatus,
-        extract_fees_per_month,
+        TransactionFees, TransactionFilters, TransactionLinkReason, TransactionSort,
+        TransactionStatus, extract_fees_per_month,
     },
     util::{from_mint_url, to_mint_url},
 };
@@ -627,7 +627,10 @@ impl Wallet {
                 id: Uuid::new_v4(),
                 mint_url: tx.mint_url.clone(),
                 direction: TransactionDirection::Incoming, // incoming, since we're getting back the funds
-                fees: fee,
+                fees: TransactionFees {
+                    swap: fee,
+                    ..Default::default()
+                },
                 amount: tx.amount,
                 memo: tx.memo.clone(),
                 tstamp: Utc::now().timestamp() as u64,
@@ -762,7 +765,10 @@ impl Wallet {
             id: Uuid::new_v4(),
             mint_url: to_mint_url(self.client.mint_url()),
             direction: TransactionDirection::Incoming,
-            fees: fee,
+            fees: TransactionFees {
+                swap: fee,
+                ..Default::default()
+            },
             amount: initial_amount,
             memo,
             tstamp,
@@ -1123,7 +1129,7 @@ mod tests {
         name::Name,
         types::{
             MintSummary, PaymentRequestDirection, PaymentRequestState, PaymentResultCallback,
-            TimeRange,
+            TimeRange, TransactionFees,
         },
     };
     use bcr_wallet_persistence::{
@@ -1291,7 +1297,7 @@ mod tests {
             id: Uuid::new_v4(),
             mint_url: cashu::MintUrl::from_str("https://mint.example").unwrap(),
             direction: TransactionDirection::Outgoing,
-            fees: Amount::ZERO,
+            fees: TransactionFees::default(),
             amount,
             memo: None,
             payment_type: PaymentType::Token,
@@ -1320,7 +1326,7 @@ mod tests {
             id: Uuid::new_v4(),
             mint_url: cashu::MintUrl::from_str("https://mint.example").unwrap(),
             direction,
-            fees: Amount::ZERO,
+            fees: TransactionFees::default(),
             amount: Amount::from(amount),
             memo: None,
             status,
@@ -1824,7 +1830,7 @@ mod tests {
             .offline_pay_by_token(
                 Uuid::new_v4(),
                 CurrencyUnit::Sat,
-                cashu::Amount::ZERO,
+                TransactionFees::default(),
                 None,
                 123,
             )
@@ -1871,7 +1877,7 @@ mod tests {
         *wlt.read().await.current_payment.lock().await = Some(PayReference {
             request_id: pid,
             unit: CurrencyUnit::Sat,
-            fees: cashu::Amount::ZERO,
+            fees: TransactionFees::default(),
             ptype: WalletPaymentType::Token,
             memo: Some("memo".to_string()),
         });
@@ -1910,7 +1916,7 @@ mod tests {
         *wlt.read().await.current_payment.lock().await = Some(PayReference {
             request_id: prepared_pid,
             unit: CurrencyUnit::Sat,
-            fees: cashu::Amount::ZERO,
+            fees: TransactionFees::default(),
             ptype: WalletPaymentType::Token,
             memo: None,
         });
@@ -1960,7 +1966,9 @@ mod tests {
         ctx.tx_repo.expect_store_tx().times(1).returning(move |tx| {
             assert_eq!(tx.direction, TransactionDirection::Outgoing);
             assert_eq!(tx.amount, Amount::ZERO);
-            assert_eq!(tx.fees, Amount::ZERO);
+            assert_eq!(tx.fees.swap, Amount::ZERO);
+            assert_eq!(tx.fees.melt, Amount::ZERO);
+            assert_eq!(tx.fees.network, Amount::ZERO);
             assert_eq!(tx.unit, CurrencyUnit::Sat);
             assert_eq!(tx.tstamp, 123);
             assert_eq!(tx.memo, Some("melt memo".to_string()));
@@ -1974,7 +1982,7 @@ mod tests {
         *wlt.read().await.current_payment.lock().await = Some(PayReference {
             request_id: pid,
             unit: CurrencyUnit::Sat,
-            fees: cashu::Amount::ZERO,
+            fees: TransactionFees::default(),
             ptype: WalletPaymentType::OnChain,
             memo: Some("melt memo".to_string()),
         });
@@ -2022,7 +2030,9 @@ mod tests {
         ctx.tx_repo.expect_store_tx().times(1).returning(move |tx| {
             assert_eq!(tx.direction, TransactionDirection::Outgoing);
             assert_eq!(tx.amount, Amount::ZERO);
-            assert_eq!(tx.fees, Amount::ZERO);
+            assert_eq!(tx.fees.swap, Amount::ZERO);
+            assert_eq!(tx.fees.melt, Amount::ZERO);
+            assert_eq!(tx.fees.network, Amount::ZERO);
             assert_eq!(tx.unit, CurrencyUnit::Sat);
             assert_eq!(tx.tstamp, 123);
             assert_eq!(tx.memo, Some("cdk18 memo".to_string()));
@@ -2048,7 +2058,7 @@ mod tests {
         *wlt.read().await.current_payment.lock().await = Some(PayReference {
             request_id: pid,
             unit: CurrencyUnit::Sat,
-            fees: cashu::Amount::ZERO,
+            fees: TransactionFees::default(),
             ptype: WalletPaymentType::Cdk18 {
                 transport,
                 id: Some("payment-id".to_string()),
@@ -2125,7 +2135,9 @@ mod tests {
         ctx.tx_repo.expect_store_tx().times(1).returning(move |tx| {
             assert_eq!(tx.direction, TransactionDirection::Outgoing);
             assert_eq!(tx.amount, Amount::ZERO);
-            assert_eq!(tx.fees, Amount::ZERO);
+            assert_eq!(tx.fees.swap, Amount::ZERO);
+            assert_eq!(tx.fees.melt, Amount::ZERO);
+            assert_eq!(tx.fees.network, Amount::ZERO);
             assert_eq!(tx.unit, CurrencyUnit::Sat);
             assert_eq!(tx.tstamp, 123);
             assert_eq!(tx.memo, Some("contact memo".to_string()));
@@ -2141,7 +2153,7 @@ mod tests {
         *wlt.read().await.current_payment.lock().await = Some(PayReference {
             request_id: pid,
             unit: CurrencyUnit::Sat,
-            fees: cashu::Amount::ZERO,
+            fees: TransactionFees::default(),
             ptype: WalletPaymentType::Contact {
                 contact_id: Uuid::new_v4(),
                 payment_request_id: None,
@@ -3283,7 +3295,9 @@ mod tests {
         ctx.tx_repo.expect_store_tx().times(1).returning(move |tx| {
             assert_eq!(tx.direction, TransactionDirection::Incoming);
             assert_eq!(tx.amount, Amount::ZERO);
-            assert_eq!(tx.fees, Amount::ZERO);
+            assert_eq!(tx.fees.swap, Amount::ZERO);
+            assert_eq!(tx.fees.melt, Amount::ZERO);
+            assert_eq!(tx.fees.network, Amount::ZERO);
             assert_eq!(tx.unit, CurrencyUnit::Sat);
             assert_eq!(tx.tstamp, 123);
             assert_eq!(tx.memo, Some("memo".to_string()));
@@ -3628,7 +3642,9 @@ mod tests {
             .return_once(move |tx| {
                 assert_eq!(tx.direction, TransactionDirection::Incoming);
                 assert_eq!(tx.amount, Amount::from(24));
-                assert_eq!(tx.fees, Amount::ZERO);
+                assert_eq!(tx.fees.swap, Amount::ZERO);
+                assert_eq!(tx.fees.melt, Amount::ZERO);
+                assert_eq!(tx.fees.network, Amount::ZERO);
                 assert_eq!(tx.unit, CurrencyUnit::Sat);
                 assert_eq!(tx.tstamp, 123);
                 assert_eq!(tx.memo, Some("token memo".to_string()));

--- a/crates/bcr-wallet-api/src/wallet/types.rs
+++ b/crates/bcr-wallet-api/src/wallet/types.rs
@@ -1,8 +1,9 @@
 use bcr_common::{
-    cashu::{self, Amount, CurrencyUnit},
+    cashu::{self, CurrencyUnit},
     core::NodeId,
     wire::common as wire_common,
 };
+use bcr_wallet_core::types::TransactionFees;
 use bitcoin::secp256k1;
 use nostr::types::RelayUrl;
 use uuid::Uuid;
@@ -29,7 +30,7 @@ pub enum WalletPaymentType {
 pub struct PayReference {
     pub request_id: Uuid,
     pub unit: CurrencyUnit,
-    pub fees: Amount,
+    pub fees: TransactionFees,
     pub ptype: WalletPaymentType,
     pub memo: Option<String>,
 }

--- a/crates/bcr-wallet-api/src/wallet/util.rs
+++ b/crates/bcr-wallet-api/src/wallet/util.rs
@@ -196,7 +196,7 @@ mod tests {
     };
     use bcr_wallet_core::{
         name::Name,
-        types::{PaymentType, TransactionStatus},
+        types::{PaymentType, TransactionFees, TransactionStatus},
         util::to_mint_url,
     };
     use std::str::FromStr;
@@ -334,7 +334,7 @@ mod tests {
         Transaction {
             id: Uuid::new_v4(),
             mint_url: to_mint_url(&url::Url::from_str("https://mint.example").unwrap()),
-            fees: cashu::Amount::from(0),
+            fees: TransactionFees::default(),
             direction,
             memo: None,
             tstamp: 5,

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -1,18 +1,17 @@
-use std::sync::Arc;
-
+use crate::WalletSettings;
 use anyhow::Result;
+use bcr_common::cashu;
 use bcr_wallet_api::{AppState, config::CreateWalletConfig};
 use bcr_wallet_core::types::{
     PaymentRequestDirection, PaymentResultCallback, PendingPaymentSubscriptionCallback,
-    TransactionFilters, TransactionSort,
+    TransactionFees, TransactionFilters, TransactionSort,
 };
 use chrono::{DateTime, Utc};
+use std::sync::Arc;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use uuid::Uuid;
-
-use crate::WalletSettings;
 
 pub async fn cmd_info(app_state: &AppState) -> Result<String> {
     let mut res = String::new();
@@ -100,8 +99,8 @@ pub async fn cmd_info(app_state: &AppState) -> Result<String> {
                     .collect::<Vec<_>>()
                     .join(", ");
                 res.push_str(&format!(
-                    "\t\tId: {} \t Amount: {:8} {} \t Fees: {}  \t Status: {:?} \t {} \tType: {:<10} \t {:?} \t Memo: {} \t BTC TxID/Quote ID: {} \t Contact: {} \t Payment Request ID: {} \t Links: {}",
-                    tx.id, tx.amount, tx.unit, tx.fees,  tx.status, format_timestamp(tx.tstamp), format!("{:?}", tx.payment_type), tx.direction, tx.memo.clone().unwrap_or_default(), quote_or_btc_tx_id, tx.contact_node_id.as_ref().map(|n| n.to_string()).unwrap_or_default(), tx.payment_request_id.map(|id| id.to_string()).unwrap_or_default(), tx_links
+                    "\t\tId: {} \t Amount: {:8} {} \t {}  \t Status: {:?} \t {} \tType: {:<10} \t {:?} \t Memo: {} \t BTC TxID/Quote ID: {} \t Contact: {} \t Payment Request ID: {} \t Links: {}",
+                    tx.id, tx.amount, tx.unit, format_fees(tx.fees),  tx.status, format_timestamp(tx.tstamp), format!("{:?}", tx.payment_type), tx.direction, tx.memo.clone().unwrap_or_default(), quote_or_btc_tx_id, tx.contact_node_id.as_ref().map(|n| n.to_string()).unwrap_or_default(), tx.payment_request_id.map(|id| id.to_string()).unwrap_or_default(), tx_links
                 ));
                 push_break(&mut res);
             }
@@ -262,8 +261,10 @@ pub async fn cmd_pay_by_token(
         .await?;
 
     info!(
-        "Payment Summary: Amount: {}, Unit: {}, Fees: {}",
-        payment_summary.amount, payment_summary.unit, payment_summary.fees,
+        "Payment Summary: Amount: {}, Unit: {}, {}",
+        payment_summary.amount,
+        payment_summary.unit,
+        format_fees(payment_summary.fees),
     );
     let result = app_state
         .wallet_pay_by_token(id.to_owned(), payment_summary.request_id.to_string())
@@ -275,8 +276,10 @@ pub async fn cmd_pay_by_token(
     push_break(&mut res);
     res.push_str(&format!("Payment Summary: {}", payment_summary.request_id));
     res.push_str(&format!(
-        "Unit: {}, Amount: {}, Fees: {}",
-        payment_summary.unit, payment_summary.amount, payment_summary.fees
+        "Unit: {}, Amount: {}, {}",
+        payment_summary.unit,
+        payment_summary.amount,
+        format_fees(payment_summary.fees)
     ));
     push_break(&mut res);
     res.push_str(&format!("Transaction ID: {}", result.tx_id));
@@ -301,8 +304,10 @@ pub async fn cmd_pay_to_contact(
         .await?;
 
     info!(
-        "Payment Summary: Amount: {}, Unit: {}, Fees: {}",
-        payment_summary.amount, payment_summary.unit, payment_summary.fees,
+        "Payment Summary: Amount: {}, Unit: {}, {}",
+        payment_summary.amount,
+        payment_summary.unit,
+        format_fees(payment_summary.fees),
     );
     let result = app_state
         .wallet_pay_to_contact(id.to_owned(), payment_summary.request_id.to_string())
@@ -316,8 +321,10 @@ pub async fn cmd_pay_to_contact(
     push_break(&mut res);
     res.push_str(&format!("Payment Summary: {}", payment_summary.request_id));
     res.push_str(&format!(
-        "Unit: {}, Amount: {}, Fees: {}",
-        payment_summary.unit, payment_summary.amount, payment_summary.fees
+        "Unit: {}, Amount: {}, {}",
+        payment_summary.unit,
+        payment_summary.amount,
+        format_fees(payment_summary.fees)
     ));
     push_break(&mut res);
     res.push_str(&format!("Transaction ID: {}", result));
@@ -337,8 +344,10 @@ pub async fn cmd_send_payment(
         .await?;
 
     info!(
-        "Payment Summary: Amount: {}, Unit: {}, Fees: {}",
-        payment_summary.amount, payment_summary.unit, payment_summary.fees,
+        "Payment Summary: Amount: {}, Unit: {}, {}",
+        payment_summary.amount,
+        payment_summary.unit,
+        format_fees(payment_summary.fees),
     );
 
     let tx_id = app_state
@@ -353,8 +362,10 @@ pub async fn cmd_send_payment(
     push_break(&mut res);
     res.push_str(&format!("Payment Summary: {}", payment_summary.request_id));
     res.push_str(&format!(
-        "Unit: {}, Amount: {}, Fees: {}",
-        payment_summary.unit, payment_summary.amount, payment_summary.fees
+        "Unit: {}, Amount: {}, {}",
+        payment_summary.unit,
+        payment_summary.amount,
+        format_fees(payment_summary.fees)
     ));
     push_break(&mut res);
     res.push_str(&format!("Transaction ID: {tx_id}"));
@@ -430,8 +441,10 @@ pub async fn cmd_melt(
         .await?;
 
     info!(
-        "Melt Summary: Amount: {}, Unit: {}, Fees: {}",
-        &melt_summary.amount, &melt_summary.unit, &melt_summary.fees
+        "Melt Summary: Amount: {}, Unit: {}, {}",
+        &melt_summary.amount,
+        &melt_summary.unit,
+        &format_fees(melt_summary.fees)
     );
 
     let tx_id = app_state
@@ -888,8 +901,10 @@ pub async fn cmd_pay_pr(
         .wallet_prepare_pay_payment_request(id.to_owned(), payment_req_id.to_owned())
         .await?;
     info!(
-        "Payment Summary: Amount: {}, Unit: {}, Fees: {}",
-        payment_summary.amount, payment_summary.unit, payment_summary.fees,
+        "Payment Summary: Amount: {}, Unit: {}, {}",
+        payment_summary.amount,
+        payment_summary.unit,
+        format_fees(payment_summary.fees),
     );
     let result = app_state
         .wallet_pay_payment_request(id.to_owned(), payment_summary.request_id.to_string())
@@ -900,8 +915,10 @@ pub async fn cmd_pay_pr(
         "Pay Payment Request {payment_req_id} for {name}, Wallet ID: {id}.\n"
     ));
     res.push_str(&format!(
-        "Unit: {}, Amount: {}, Fees: {}",
-        payment_summary.unit, payment_summary.amount, payment_summary.fees
+        "Unit: {}, Amount: {}, {}",
+        payment_summary.unit,
+        payment_summary.amount,
+        format_fees(payment_summary.fees)
     ));
     push_break(&mut res);
     res.push_str(&format!("Transaction ID: {}", result));
@@ -990,4 +1007,22 @@ fn format_timestamp(ts: u64) -> String {
     let datetime: DateTime<Utc> = DateTime::from_timestamp(ts as i64, 0).expect("valid timestamp");
 
     datetime.format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+fn format_fees(fees: TransactionFees) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if fees.swap > cashu::Amount::ZERO {
+        parts.push(format!("swap = {}", fees.swap));
+    }
+    if fees.network > cashu::Amount::ZERO {
+        parts.push(format!("network = {}", fees.network));
+    }
+    if fees.melt > cashu::Amount::ZERO {
+        parts.push(format!("melt = {}", fees.melt));
+    }
+    if parts.is_empty() {
+        "Fees: 0".to_string()
+    } else {
+        format!("Fees: {}", parts.join(", "))
+    }
 }

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -24,8 +24,7 @@ pub struct SendSummary {
     pub request_id: Uuid,
     pub amount: Amount,
     pub unit: CurrencyUnit,
-    pub swap_fees: Amount,
-    pub send_fees: Amount,
+    pub fees: TransactionFees,
 }
 
 impl SendSummary {
@@ -56,7 +55,7 @@ pub struct MeltSummary {
     pub request_id: Uuid,
     pub amount: Amount,
     pub unit: CurrencyUnit,
-    pub fees: Amount,
+    pub fees: TransactionFees,
     pub reserved_fees: Amount,
     pub expiry: u64,
 }
@@ -170,7 +169,7 @@ pub struct Transaction {
     pub mint_url: MintUrl,
     pub ys: Vec<cashu::PublicKey>,
     pub amount: cashu::Amount,
-    pub fees: cashu::Amount,
+    pub fees: TransactionFees,
     pub unit: CurrencyUnit,
     pub tstamp: u64,
     pub direction: TransactionDirection,
@@ -183,6 +182,19 @@ pub struct Transaction {
     pub contact_node_id: Option<NodeId>,
     pub payment_request_id: Option<Uuid>,
     pub linked_txs: Vec<TransactionLink>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TransactionFees {
+    pub swap: cashu::Amount,
+    pub network: cashu::Amount,
+    pub melt: cashu::Amount,
+}
+
+impl TransactionFees {
+    pub fn sum(&self) -> cashu::Amount {
+        self.swap + self.network + self.melt
+    }
 }
 
 /// A link to another transaction with a reason, e.g. linking a payment transaction with a reclaim of the payment
@@ -213,7 +225,7 @@ pub struct PaymentSummary {
     pub request_id: Uuid,
     pub unit: CurrencyUnit,
     pub amount: Amount,
-    pub fees: Amount,
+    pub fees: TransactionFees,
     pub reserved_fees: Amount,
     pub expiry: u64,
     pub ptype: PaymentType,
@@ -234,7 +246,7 @@ impl std::convert::From<SendSummary> for PaymentSummary {
             request_id: value.request_id,
             unit: value.unit,
             amount: value.amount,
-            fees: value.send_fees + value.swap_fees,
+            fees: value.fees,
             reserved_fees: Amount::ZERO,
             expiry: 0,
             ptype: PaymentType::Token,
@@ -387,12 +399,12 @@ pub struct ListTransactionsResult {
 pub struct FeesByMonth {
     pub year: i32,
     pub month: u32,
-    pub fees: Amount,
+    pub fees: TransactionFees,
 }
 
 // Sums up fees per month for a given set of transactions
 pub fn extract_fees_per_month(transactions: &[Transaction]) -> Vec<FeesByMonth> {
-    let mut fees_by_month: BTreeMap<(i32, u32), Amount> = BTreeMap::new();
+    let mut fees_by_month: BTreeMap<(i32, u32), TransactionFees> = BTreeMap::new();
 
     for tx in transactions {
         let Some(dt) = DateTime::<Utc>::from_timestamp(tx.tstamp as i64, 0) else {
@@ -404,7 +416,11 @@ pub fn extract_fees_per_month(transactions: &[Transaction]) -> Vec<FeesByMonth> 
 
         fees_by_month
             .entry((year, month))
-            .and_modify(|fees| *fees += tx.fees)
+            .and_modify(|fees| {
+                fees.swap += tx.fees.swap;
+                fees.network += tx.fees.network;
+                fees.melt += tx.fees.melt;
+            })
             .or_insert(tx.fees);
     }
 
@@ -464,7 +480,11 @@ mod tests {
             mint_url: cashu::MintUrl::from_str("https://mint.example").unwrap(),
             direction: TransactionDirection::Incoming,
             amount: Amount::from(0),
-            fees: fee,
+            fees: TransactionFees {
+                swap: fee,
+                network: cashu::Amount::ZERO,
+                melt: cashu::Amount::ZERO,
+            },
             unit: CurrencyUnit::Sat,
             ys: vec![],
             tstamp: timestamp,
@@ -497,10 +517,10 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].year, 2025);
         assert_eq!(result[0].month, 3);
-        assert_eq!(result[0].fees, Amount::from(5));
+        assert_eq!(result[0].fees.swap, Amount::from(5));
         assert_eq!(result[1].year, 2025);
         assert_eq!(result[1].month, 2);
-        assert_eq!(result[1].fees, Amount::from(30));
+        assert_eq!(result[1].fees.swap, Amount::from(30));
     }
 
     #[test]

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -465,7 +465,7 @@ pub async fn wallet_prepare_melt(
             request_id: payment_summary.request_id.to_string(),
             unit: payment_summary.unit.to_string(),
             amount: u64::from(payment_summary.amount),
-            fees: u64::from(payment_summary.fees),
+            fees: payment_summary.fees.into(),
             reserved_fees: u64::from(payment_summary.reserved_fees),
             expiry: payment_summary.expiry,
             ptype: PaymentType::from(bcr_wallet_core::types::PaymentType::from(
@@ -511,7 +511,7 @@ pub async fn wallet_prepare_payment(
             request_id: payment_summary.request_id.to_string(),
             unit: payment_summary.unit.to_string(),
             amount: u64::from(payment_summary.amount),
-            fees: u64::from(payment_summary.fees),
+            fees: payment_summary.fees.into(),
             reserved_fees: u64::from(payment_summary.reserved_fees),
             expiry: payment_summary.expiry,
             ptype: PaymentType::from(bcr_wallet_core::types::PaymentType::from(
@@ -543,7 +543,7 @@ pub async fn wallet_prepare_pay_by_token(
             request_id: payment_summary.request_id.to_string(),
             unit: payment_summary.unit.to_string(),
             amount: u64::from(payment_summary.amount),
-            fees: u64::from(payment_summary.fees),
+            fees: payment_summary.fees.into(),
             reserved_fees: u64::from(payment_summary.reserved_fees),
             expiry: payment_summary.expiry,
             ptype: PaymentType::from(bcr_wallet_core::types::PaymentType::from(
@@ -806,7 +806,7 @@ pub async fn wallet_prepare_pay_to_contact(
             request_id: payment_summary.request_id.to_string(),
             unit: payment_summary.unit.to_string(),
             amount: u64::from(payment_summary.amount),
-            fees: u64::from(payment_summary.fees),
+            fees: payment_summary.fees.into(),
             reserved_fees: u64::from(payment_summary.reserved_fees),
             expiry: payment_summary.expiry,
             ptype: PaymentType::from(bcr_wallet_core::types::PaymentType::from(
@@ -891,7 +891,7 @@ pub async fn wallet_prepare_pay_payment_request(
             request_id: payment_summary.request_id.to_string(),
             unit: payment_summary.unit.to_string(),
             amount: u64::from(payment_summary.amount),
-            fees: u64::from(payment_summary.fees),
+            fees: payment_summary.fees.into(),
             reserved_fees: u64::from(payment_summary.reserved_fees),
             expiry: payment_summary.expiry,
             ptype: PaymentType::from(bcr_wallet_core::types::PaymentType::from(
@@ -1521,7 +1521,7 @@ impl From<bcr_wallet_core::contact::Contact> for Contact {
 pub struct Transaction {
     pub id: String,
     pub amount: u64,
-    pub fees: u64,
+    pub fees: TransactionFees,
     pub unit: String,
     pub tstamp: u64,
     pub direction: TransactionDirection,
@@ -1533,6 +1533,23 @@ pub struct Transaction {
     pub contact_node_id: Option<String>,
     pub payment_request_id: Option<String>,
     pub linked_txs: Vec<TransactionLink>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransactionFees {
+    pub swap: u64,
+    pub network: u64,
+    pub melt: u64,
+}
+
+impl From<bcr_wallet_core::types::TransactionFees> for TransactionFees {
+    fn from(value: bcr_wallet_core::types::TransactionFees) -> Self {
+        Self {
+            swap: u64::from(value.swap),
+            network: u64::from(value.network),
+            melt: u64::from(value.melt),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1701,11 +1718,11 @@ impl From<bcr_wallet_core::types::TransactionCursor> for TransactionCursor {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct FeesByMonth {
     pub year: i32,
     pub month: u32,
-    pub fees: u64,
+    pub fees: TransactionFees,
 }
 
 impl From<bcr_wallet_core::types::FeesByMonth> for FeesByMonth {
@@ -1713,7 +1730,7 @@ impl From<bcr_wallet_core::types::FeesByMonth> for FeesByMonth {
         FeesByMonth {
             year: value.year,
             month: value.month,
-            fees: u64::from(value.fees),
+            fees: value.fees.into(),
         }
     }
 }
@@ -1723,7 +1740,7 @@ impl From<bcr_wallet_core::types::Transaction> for Transaction {
         Self {
             id: value.id.to_string(),
             amount: u64::from(value.amount),
-            fees: u64::from(value.fees),
+            fees: value.fees.into(),
             unit: value.unit.to_string(),
             tstamp: value.tstamp,
             direction: TransactionDirection::from(value.direction),
@@ -1912,7 +1929,7 @@ pub struct PaymentSummary {
     pub request_id: String,
     pub unit: String,
     pub amount: u64,
-    pub fees: u64,
+    pub fees: TransactionFees,
     pub reserved_fees: u64,
     pub expiry: u64,
     pub ptype: PaymentType,

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -2946,7 +2946,7 @@ impl SseDecode for crate::api::FeesByMonth {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_year = <i32>::sse_decode(deserializer);
         let mut var_month = <u32>::sse_decode(deserializer);
-        let mut var_fees = <u64>::sse_decode(deserializer);
+        let mut var_fees = <crate::api::TransactionFees>::sse_decode(deserializer);
         return crate::api::FeesByMonth {
             year: var_year,
             month: var_month,
@@ -3384,7 +3384,7 @@ impl SseDecode for crate::api::PaymentSummary {
         let mut var_requestId = <String>::sse_decode(deserializer);
         let mut var_unit = <String>::sse_decode(deserializer);
         let mut var_amount = <u64>::sse_decode(deserializer);
-        let mut var_fees = <u64>::sse_decode(deserializer);
+        let mut var_fees = <crate::api::TransactionFees>::sse_decode(deserializer);
         let mut var_reservedFees = <u64>::sse_decode(deserializer);
         let mut var_expiry = <u64>::sse_decode(deserializer);
         let mut var_ptype = <crate::api::PaymentType>::sse_decode(deserializer);
@@ -3507,7 +3507,7 @@ impl SseDecode for crate::api::Transaction {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_id = <String>::sse_decode(deserializer);
         let mut var_amount = <u64>::sse_decode(deserializer);
-        let mut var_fees = <u64>::sse_decode(deserializer);
+        let mut var_fees = <crate::api::TransactionFees>::sse_decode(deserializer);
         let mut var_unit = <String>::sse_decode(deserializer);
         let mut var_tstamp = <u64>::sse_decode(deserializer);
         let mut var_direction = <crate::api::TransactionDirection>::sse_decode(deserializer);
@@ -3562,6 +3562,20 @@ impl SseDecode for crate::api::TransactionDirection {
             0 => crate::api::TransactionDirection::Incoming,
             1 => crate::api::TransactionDirection::Outgoing,
             _ => unreachable!("Invalid variant for TransactionDirection: {}", inner),
+        };
+    }
+}
+
+impl SseDecode for crate::api::TransactionFees {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_swap = <u64>::sse_decode(deserializer);
+        let mut var_network = <u64>::sse_decode(deserializer);
+        let mut var_melt = <u64>::sse_decode(deserializer);
+        return crate::api::TransactionFees {
+            swap: var_swap,
+            network: var_network,
+            melt: var_melt,
         };
     }
 }
@@ -5487,6 +5501,25 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::TransactionDirection>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::TransactionFees {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.swap.into_into_dart().into_dart(),
+            self.network.into_into_dart().into_dart(),
+            self.melt.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for crate::api::TransactionFees {}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::TransactionFees>
+    for crate::api::TransactionFees
+{
+    fn into_into_dart(self) -> crate::api::TransactionFees {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::TransactionFilters {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -7198,7 +7231,7 @@ impl SseEncode for crate::api::FeesByMonth {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i32>::sse_encode(self.year, serializer);
         <u32>::sse_encode(self.month, serializer);
-        <u64>::sse_encode(self.fees, serializer);
+        <crate::api::TransactionFees>::sse_encode(self.fees, serializer);
     }
 }
 
@@ -7556,7 +7589,7 @@ impl SseEncode for crate::api::PaymentSummary {
         <String>::sse_encode(self.request_id, serializer);
         <String>::sse_encode(self.unit, serializer);
         <u64>::sse_encode(self.amount, serializer);
-        <u64>::sse_encode(self.fees, serializer);
+        <crate::api::TransactionFees>::sse_encode(self.fees, serializer);
         <u64>::sse_encode(self.reserved_fees, serializer);
         <u64>::sse_encode(self.expiry, serializer);
         <crate::api::PaymentType>::sse_encode(self.ptype, serializer);
@@ -7658,7 +7691,7 @@ impl SseEncode for crate::api::Transaction {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.id, serializer);
         <u64>::sse_encode(self.amount, serializer);
-        <u64>::sse_encode(self.fees, serializer);
+        <crate::api::TransactionFees>::sse_encode(self.fees, serializer);
         <String>::sse_encode(self.unit, serializer);
         <u64>::sse_encode(self.tstamp, serializer);
         <crate::api::TransactionDirection>::sse_encode(self.direction, serializer);
@@ -7696,6 +7729,15 @@ impl SseEncode for crate::api::TransactionDirection {
             },
             serializer,
         );
+    }
+}
+
+impl SseEncode for crate::api::TransactionFees {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u64>::sse_encode(self.swap, serializer);
+        <u64>::sse_encode(self.network, serializer);
+        <u64>::sse_encode(self.melt, serializer);
     }
 }
 

--- a/crates/bcr-wallet-persistence/src/error.rs
+++ b/crates/bcr-wallet-persistence/src/error.rs
@@ -75,4 +75,6 @@ pub enum Error {
     InvalidTransactionId(String),
     #[error("Invalid Quote Id {0}")]
     InvalidQuoteId(String),
+    #[error("Invalid Transaction Data Version {0}")]
+    InvalidTransactionData(String),
 }

--- a/crates/bcr-wallet-persistence/src/redb/migration/migration_0003.rs
+++ b/crates/bcr-wallet-persistence/src/redb/migration/migration_0003.rs
@@ -7,7 +7,7 @@ use bcr_common::{
     cdk_common::wallet::TransactionDirection,
     core::NodeId,
 };
-use bcr_wallet_core::types::{PaymentType, Transaction, TransactionStatus};
+use bcr_wallet_core::types::{PaymentType, Transaction, TransactionFees, TransactionStatus};
 use nostr::event::EventId;
 use redb::{ReadableTable, TableDefinition};
 use std::{collections::HashMap, str::FromStr};
@@ -101,18 +101,39 @@ impl TryFrom<TransactionEntry> for Transaction {
     type Error = Error;
 
     fn try_from(entry: TransactionEntry) -> Result<Self> {
+        let pt = get_payment_type(&entry.metadata);
+        let fees = match pt {
+            PaymentType::OnChain => {
+                // melt
+                if entry.direction == TransactionDirection::Outgoing {
+                    TransactionFees {
+                        melt: entry.fee,
+                        ..Default::default()
+                    }
+                } else {
+                    TransactionFees {
+                        swap: entry.fee,
+                        ..Default::default()
+                    }
+                }
+            }
+            _ => TransactionFees {
+                swap: entry.fee,
+                ..Default::default()
+            },
+        };
         Ok(Transaction {
             id: Uuid::new_v4(),
             mint_url: entry.mint_url,
             direction: entry.direction,
             amount: entry.amount,
-            fees: entry.fee,
+            fees,
             unit: entry.unit,
             ys: entry.ys,
             tstamp: entry.timestamp,
             memo: entry.memo,
             status: get_transaction_status(&entry.metadata),
-            payment_type: get_payment_type(&entry.metadata),
+            payment_type: pt,
             quote_id: entry
                 .quote_id
                 .map(|qid| Uuid::from_str(&qid))
@@ -254,7 +275,9 @@ mod tests {
             let (key, value) = item.expect("read transaction entry");
             let envelope: StoredTransaction = borsh::from_slice(value.value().as_slice())
                 .expect("deserialize transaction envelope");
-            let StoredTransaction::V1(payload) = envelope;
+            let StoredTransaction::V1(payload) = envelope else {
+                panic!("invalid version")
+            };
             transactions.push((key.value().to_vec(), payload));
         }
         transactions

--- a/crates/bcr-wallet-persistence/src/redb/migration/migration_0004.rs
+++ b/crates/bcr-wallet-persistence/src/redb/migration/migration_0004.rs
@@ -1,0 +1,66 @@
+use crate::{
+    error::{Error, Result},
+    redb::{migration::WalletStorageNamespace, transaction::StoredTransaction},
+};
+use bcr_wallet_core::types::Transaction;
+use redb::{ReadableTable, TableDefinition};
+
+///////////////////////////////////////////////////////////////// MIGRATION 0004
+const MIGRATION_0004_TX_FEES: &str = "0004_tx_fees";
+
+pub(super) fn migration_name_for_wallet(wallet_id: &str) -> String {
+    format!("{}_{}", MIGRATION_0004_TX_FEES, wallet_id)
+}
+
+pub(super) fn migration_0004_tx_fees(
+    txn: &redb::WriteTransaction,
+    namespace: &WalletStorageNamespace,
+) -> Result<()> {
+    tracing::info!("Migrating transaction fees..");
+    migrate_transaction_fees(txn, &namespace.transaction_table)?;
+    tracing::info!("Migrated transaction fees.");
+
+    Ok(())
+}
+
+// Fetch v1 transactions
+// transform to v2
+// put in V2 envelope
+// Store new transactions
+fn migrate_transaction_fees(txn: &redb::WriteTransaction, table_name: &str) -> Result<()> {
+    let table_def: TableDefinition<&[u8], Vec<u8>> = TableDefinition::new(table_name);
+
+    let mut table = match txn.open_table(table_def) {
+        Ok(table) => table,
+        Err(redb::TableError::TableDoesNotExist(_)) => {
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut migrated_transactions: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    for item in table.iter()? {
+        let (_, v) = item?;
+
+        let deserialized: StoredTransaction = borsh::from_slice(v.value().as_slice())
+            .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+        let StoredTransaction::V1(old_tx) = deserialized else {
+            continue;
+        };
+        let new_tx: Transaction = old_tx.try_into()?;
+        let new_tx_id = new_tx.id;
+        let stored_tx_v2 = StoredTransaction::V2(new_tx.into());
+
+        let migrated_tx_bytes =
+            borsh::to_vec(&stored_tx_v2).map_err(|e| Error::BorshSerialization(e.to_string()))?;
+
+        migrated_transactions.push((new_tx_id.as_bytes().to_vec(), migrated_tx_bytes));
+    }
+
+    // Add new entries
+    for (id, new_transaction) in migrated_transactions.iter() {
+        table.insert(id.as_slice(), new_transaction)?;
+    }
+
+    Ok(())
+}

--- a/crates/bcr-wallet-persistence/src/redb/migration/mod.rs
+++ b/crates/bcr-wallet-persistence/src/redb/migration/mod.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 mod migration_0001;
 mod migration_0002;
 mod migration_0003;
+mod migration_0004;
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct AppliedMigration {
@@ -82,6 +83,18 @@ fn migrate_wallet_sync(db: Arc<Database>, namespace: WalletStorageNamespace) -> 
         migration_0003::migration_0003_tx_rework(&write_txn, &namespace)?;
         mark_migration_applied(&write_txn, &migration_0003_id_for_wallet)?;
         tracing::info!("Applied Migration 0003 for wallet {}", &namespace.wallet_id);
+    }
+
+    let migration_0004_id_for_wallet =
+        migration_0004::migration_name_for_wallet(&namespace.wallet_id);
+    if !applied.contains(&migration_0004_id_for_wallet) {
+        tracing::info!(
+            "Applying Migration 0004 for wallet {}",
+            &namespace.wallet_id
+        );
+        migration_0004::migration_0004_tx_fees(&write_txn, &namespace)?;
+        mark_migration_applied(&write_txn, &migration_0004_id_for_wallet)?;
+        tracing::info!("Applied Migration 0004 for wallet {}", &namespace.wallet_id);
     }
 
     write_txn.commit()?;

--- a/crates/bcr-wallet-persistence/src/redb/transaction.rs
+++ b/crates/bcr-wallet-persistence/src/redb/transaction.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub(super) enum StoredTransaction {
     V1(StoredTransactionPayloadV1),
+    V2(StoredTransactionPayloadV2),
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
@@ -82,7 +83,7 @@ impl From<bcr_wallet_core::types::Transaction> for StoredTransactionPayloadV1 {
             mint_url: value.mint_url,
             ys: value.ys,
             amount: value.amount,
-            fees: value.fees,
+            fees: value.fees.sum(),
             unit: value.unit,
             tstamp: value.tstamp,
             direction: value.direction,
@@ -102,12 +103,32 @@ impl From<bcr_wallet_core::types::Transaction> for StoredTransactionPayloadV1 {
 impl TryFrom<StoredTransactionPayloadV1> for bcr_wallet_core::types::Transaction {
     type Error = Error;
     fn try_from(value: StoredTransactionPayloadV1) -> Result<Self> {
+        // melt is melt fee, otherwise swap fee
+        let fees = match value.payment_type {
+            PaymentType::OnChain => {
+                if value.direction == TransactionDirection::Outgoing {
+                    bcr_wallet_core::types::TransactionFees {
+                        melt: value.fees,
+                        ..Default::default()
+                    }
+                } else {
+                    bcr_wallet_core::types::TransactionFees {
+                        swap: value.fees,
+                        ..Default::default()
+                    }
+                }
+            }
+            _ => bcr_wallet_core::types::TransactionFees {
+                swap: value.fees,
+                ..Default::default()
+            },
+        };
         Ok(Self {
             id: value.id,
             mint_url: value.mint_url,
             ys: value.ys,
             amount: value.amount,
-            fees: value.fees,
+            fees,
             unit: value.unit,
             tstamp: value.tstamp,
             direction: value.direction,
@@ -129,6 +150,151 @@ impl TryFrom<StoredTransactionPayloadV1> for bcr_wallet_core::types::Transaction
             payment_request_id: value.payment_request_id,
             linked_txs: value.linked_txs.into_iter().map(|ltx| ltx.into()).collect(),
         })
+    }
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct StoredTransactionPayloadV2 {
+    pub id: Uuid,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub mint_url: MintUrl,
+    #[borsh(
+        serialize_with = "serialize_vec_of_strs",
+        deserialize_with = "deserialize_vec_of_strs"
+    )]
+    pub ys: Vec<cashu::PublicKey>,
+    #[borsh(
+        serialize_with = "serialize_cashu_amount",
+        deserialize_with = "deserialize_cashu_amount"
+    )]
+    pub amount: cashu::Amount,
+    pub fees: TransactionFeesV1,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub unit: CurrencyUnit,
+    pub tstamp: u64,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub direction: TransactionDirection,
+    pub memo: Option<String>,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub payment_type: PaymentType,
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub status: TransactionStatus,
+    pub btc_tx_id: Option<String>,
+    pub quote_id: Option<Uuid>,
+    pub nostr_event_id: Option<String>,
+    pub contact_node_id: Option<NodeId>,
+    pub payment_request_id: Option<Uuid>,
+    pub linked_txs: Vec<TransactionLink>,
+}
+
+impl From<bcr_wallet_core::types::Transaction> for StoredTransactionPayloadV2 {
+    fn from(value: bcr_wallet_core::types::Transaction) -> Self {
+        Self {
+            id: value.id,
+            mint_url: value.mint_url,
+            ys: value.ys,
+            amount: value.amount,
+            fees: value.fees.into(),
+            unit: value.unit,
+            tstamp: value.tstamp,
+            direction: value.direction,
+            memo: value.memo,
+            payment_type: value.payment_type,
+            status: value.status,
+            btc_tx_id: value.btc_tx_id.map(|bid| bid.to_string()),
+            quote_id: value.quote_id,
+            nostr_event_id: value.nostr_event_id.map(|nei| nei.to_string()),
+            contact_node_id: value.contact_node_id,
+            payment_request_id: value.payment_request_id,
+            linked_txs: value.linked_txs.into_iter().map(|ltx| ltx.into()).collect(),
+        }
+    }
+}
+
+impl TryFrom<StoredTransactionPayloadV2> for bcr_wallet_core::types::Transaction {
+    type Error = Error;
+    fn try_from(value: StoredTransactionPayloadV2) -> Result<Self> {
+        Ok(Self {
+            id: value.id,
+            mint_url: value.mint_url,
+            ys: value.ys,
+            amount: value.amount,
+            fees: value.fees.into(),
+            unit: value.unit,
+            tstamp: value.tstamp,
+            direction: value.direction,
+            memo: value.memo,
+            payment_type: value.payment_type,
+            status: value.status,
+            btc_tx_id: value
+                .btc_tx_id
+                .map(|bid| bitcoin::Txid::from_str(&bid))
+                .transpose()
+                .map_err(|e| Error::InvalidBtcTxId(e.to_string()))?,
+            quote_id: value.quote_id,
+            nostr_event_id: value
+                .nostr_event_id
+                .map(|nei| EventId::from_str(&nei))
+                .transpose()
+                .map_err(|e| Error::InvalidNostrEventId(e.to_string()))?,
+            contact_node_id: value.contact_node_id,
+            payment_request_id: value.payment_request_id,
+            linked_txs: value.linked_txs.into_iter().map(|ltx| ltx.into()).collect(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct TransactionFeesV1 {
+    #[borsh(
+        serialize_with = "serialize_cashu_amount",
+        deserialize_with = "deserialize_cashu_amount"
+    )]
+    pub swap: cashu::Amount,
+    #[borsh(
+        serialize_with = "serialize_cashu_amount",
+        deserialize_with = "deserialize_cashu_amount"
+    )]
+    pub network: cashu::Amount,
+    #[borsh(
+        serialize_with = "serialize_cashu_amount",
+        deserialize_with = "deserialize_cashu_amount"
+    )]
+    pub melt: cashu::Amount,
+}
+
+impl From<bcr_wallet_core::types::TransactionFees> for TransactionFeesV1 {
+    fn from(value: bcr_wallet_core::types::TransactionFees) -> Self {
+        Self {
+            swap: value.swap,
+            network: value.network,
+            melt: value.melt,
+        }
+    }
+}
+
+impl From<TransactionFeesV1> for bcr_wallet_core::types::TransactionFees {
+    fn from(value: TransactionFeesV1) -> Self {
+        Self {
+            swap: value.swap,
+            network: value.network,
+            melt: value.melt,
+        }
     }
 }
 
@@ -211,7 +377,7 @@ impl TransactionDB {
         tx: Transaction,
     ) -> Result<Uuid> {
         let id = tx.id;
-        let entry = StoredTransaction::V1(tx.into());
+        let entry = StoredTransaction::V2(tx.into());
         let write_txn = db.begin_write()?;
 
         {
@@ -241,7 +407,7 @@ impl TransactionDB {
                         let deserialized: StoredTransaction =
                             borsh::from_slice(e.value().as_slice())
                                 .map_err(|e| Error::BorshSerialization(e.to_string()))?;
-                        let StoredTransaction::V1(tx) = deserialized;
+                        let tx = stored_tx_data(deserialized)?;
                         Ok(Some(tx.try_into()?))
                     }
                     None => Ok(None),
@@ -287,7 +453,7 @@ impl TransactionDB {
                     let deserialized: StoredTransaction =
                         borsh::from_slice(v.value().as_slice())
                             .map_err(|e| Error::BorshSerialization(e.to_string()))?;
-                    let StoredTransaction::V1(tx) = deserialized;
+                    let tx = stored_tx_data(deserialized)?;
                     res.push(tx.try_into()?);
                 }
                 Ok(res)
@@ -311,11 +477,11 @@ impl TransactionDB {
             if let Some(old_value) = old_value {
                 let deserialized: StoredTransaction = borsh::from_slice(&old_value)
                     .map_err(|e| Error::BorshSerialization(e.to_string()))?;
-                let StoredTransaction::V1(mut tx) = deserialized;
+                let mut tx = stored_tx_data(deserialized)?;
                 let old = tx.status;
                 tx.status = status;
 
-                let serialized = borsh::to_vec(&StoredTransaction::V1(tx))
+                let serialized = borsh::to_vec(&StoredTransaction::V2(tx))
                     .map_err(|e| Error::BorshSerialization(e.to_string()))?;
                 table.insert(tx_id.as_bytes().as_slice(), serialized)?;
                 Some(old)
@@ -342,12 +508,12 @@ impl TransactionDB {
             if let Some(old_value) = old_value {
                 let deserialized: StoredTransaction = borsh::from_slice(&old_value)
                     .map_err(|e| Error::BorshSerialization(e.to_string()))?;
-                let StoredTransaction::V1(mut tx) = deserialized;
+                let mut tx = stored_tx_data(deserialized)?;
 
                 let old = tx.memo.clone();
                 tx.memo = new_memo;
 
-                let serialized = borsh::to_vec(&StoredTransaction::V1(tx))
+                let serialized = borsh::to_vec(&StoredTransaction::V2(tx))
                     .map_err(|e| Error::BorshSerialization(e.to_string()))?;
                 table.insert(tx_id.as_bytes().as_slice(), serialized)?;
                 old
@@ -382,11 +548,11 @@ impl TransactionDB {
 
             let deserialized_1: StoredTransaction = borsh::from_slice(&entry_1)
                 .map_err(|e| Error::BorshSerialization(e.to_string()))?;
-            let StoredTransaction::V1(mut tx_1) = deserialized_1;
+            let mut tx_1 = stored_tx_data(deserialized_1)?;
 
             let deserialized_2: StoredTransaction = borsh::from_slice(&entry_2)
                 .map_err(|e| Error::BorshSerialization(e.to_string()))?;
-            let StoredTransaction::V1(mut tx_2) = deserialized_2;
+            let mut tx_2 = stored_tx_data(deserialized_2)?;
 
             let link_1_to_2 = TransactionLink {
                 tx_id: tx_id_2,
@@ -401,11 +567,11 @@ impl TransactionDB {
             tx_1.linked_txs.push(link_1_to_2);
             tx_2.linked_txs.push(link_2_to_1);
 
-            let serialized_1 = borsh::to_vec(&StoredTransaction::V1(tx_1))
+            let serialized_1 = borsh::to_vec(&StoredTransaction::V2(tx_1))
                 .map_err(|e| Error::BorshSerialization(e.to_string()))?;
             table.insert(tx_id_1.as_bytes().as_slice(), serialized_1)?;
 
-            let serialized_2 = borsh::to_vec(&StoredTransaction::V1(tx_2))
+            let serialized_2 = borsh::to_vec(&StoredTransaction::V2(tx_2))
                 .map_err(|e| Error::BorshSerialization(e.to_string()))?;
             table.insert(tx_id_2.as_bytes().as_slice(), serialized_2)?;
         }
@@ -497,6 +663,14 @@ impl TransactionRepository for TransactionDB {
     }
 }
 
+// after migrations, everything has to be v2
+fn stored_tx_data(stored_tx: StoredTransaction) -> Result<StoredTransactionPayloadV2> {
+    match stored_tx {
+        StoredTransaction::V1(_) => Err(Error::InvalidTransactionData("v1".to_string())),
+        StoredTransaction::V2(data) => Ok(data),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -527,7 +701,12 @@ mod tests {
             mint_url,
             direction: TransactionDirection::Outgoing,
             amount: Amount::from(42u64),
-            fees: Amount::ZERO,
+            fees: TransactionFeesV1 {
+                swap: Amount::ZERO,
+                network: Amount::ZERO,
+                melt: Amount::ZERO,
+            }
+            .into(),
             unit: CurrencyUnit::Sat,
             ys: vec![cashu::PublicKey::from(test_pub_key())],
             tstamp: Utc::now().timestamp() as u64,

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `get_app_state`, `init_logging`, `init_panic_hook`, `new`, `reset_runtime`, `start_jobs`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `PaymentRequestState`, `WalletCleanLocalDbResponse`, `WalletRuntime`, `WalletsNamesResponse`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
 
 Future<void> initWalletFfi({required WalletFfiConfig conf}) =>
     RustLib.instance.api.crateApiInitWalletFfi(conf: conf);
@@ -569,7 +569,7 @@ class EditContactResponse {
 class FeesByMonth {
   final int year;
   final int month;
-  final BigInt fees;
+  final TransactionFees fees;
 
   const FeesByMonth({
     required this.year,
@@ -840,7 +840,7 @@ class PaymentSummary {
   final String requestId;
   final String unit;
   final BigInt amount;
-  final BigInt fees;
+  final TransactionFees fees;
   final BigInt reservedFees;
   final BigInt expiry;
   final PaymentType ptype;
@@ -993,7 +993,7 @@ class TimeRange {
 class Transaction {
   final String id;
   final BigInt amount;
-  final BigInt fees;
+  final TransactionFees fees;
   final String unit;
   final BigInt tstamp;
   final TransactionDirection direction;
@@ -1095,6 +1095,30 @@ enum TransactionDirection {
 
   static Future<TransactionDirection> default_() =>
       RustLib.instance.api.crateApiTransactionDirectionDefault();
+}
+
+class TransactionFees {
+  final BigInt swap;
+  final BigInt network;
+  final BigInt melt;
+
+  const TransactionFees({
+    required this.swap,
+    required this.network,
+    required this.melt,
+  });
+
+  @override
+  int get hashCode => swap.hashCode ^ network.hashCode ^ melt.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TransactionFees &&
+          runtimeType == other.runtimeType &&
+          swap == other.swap &&
+          network == other.network &&
+          melt == other.melt;
 }
 
 class TransactionFilters {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -3344,7 +3344,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return FeesByMonth(
       year: dco_decode_i_32(arr[0]),
       month: dco_decode_u_32(arr[1]),
-      fees: dco_decode_u_64(arr[2]),
+      fees: dco_decode_transaction_fees(arr[2]),
     );
   }
 
@@ -3656,7 +3656,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       requestId: dco_decode_String(arr[0]),
       unit: dco_decode_String(arr[1]),
       amount: dco_decode_u_64(arr[2]),
-      fees: dco_decode_u_64(arr[3]),
+      fees: dco_decode_transaction_fees(arr[3]),
       reservedFees: dco_decode_u_64(arr[4]),
       expiry: dco_decode_u_64(arr[5]),
       ptype: dco_decode_payment_type(arr[6]),
@@ -3755,7 +3755,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return Transaction(
       id: dco_decode_String(arr[0]),
       amount: dco_decode_u_64(arr[1]),
-      fees: dco_decode_u_64(arr[2]),
+      fees: dco_decode_transaction_fees(arr[2]),
       unit: dco_decode_String(arr[3]),
       tstamp: dco_decode_u_64(arr[4]),
       direction: dco_decode_transaction_direction(arr[5]),
@@ -3788,6 +3788,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TransactionDirection dco_decode_transaction_direction(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return TransactionDirection.values[raw as int];
+  }
+
+  @protected
+  TransactionFees dco_decode_transaction_fees(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return TransactionFees(
+      swap: dco_decode_u_64(arr[0]),
+      network: dco_decode_u_64(arr[1]),
+      melt: dco_decode_u_64(arr[2]),
+    );
   }
 
   @protected
@@ -5386,7 +5399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_year = sse_decode_i_32(deserializer);
     var var_month = sse_decode_u_32(deserializer);
-    var var_fees = sse_decode_u_64(deserializer);
+    var var_fees = sse_decode_transaction_fees(deserializer);
     return FeesByMonth(year: var_year, month: var_month, fees: var_fees);
   }
 
@@ -5820,7 +5833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_requestId = sse_decode_String(deserializer);
     var var_unit = sse_decode_String(deserializer);
     var var_amount = sse_decode_u_64(deserializer);
-    var var_fees = sse_decode_u_64(deserializer);
+    var var_fees = sse_decode_transaction_fees(deserializer);
     var var_reservedFees = sse_decode_u_64(deserializer);
     var var_expiry = sse_decode_u_64(deserializer);
     var var_ptype = sse_decode_payment_type(deserializer);
@@ -5918,7 +5931,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_id = sse_decode_String(deserializer);
     var var_amount = sse_decode_u_64(deserializer);
-    var var_fees = sse_decode_u_64(deserializer);
+    var var_fees = sse_decode_transaction_fees(deserializer);
     var var_unit = sse_decode_String(deserializer);
     var var_tstamp = sse_decode_u_64(deserializer);
     var var_direction = sse_decode_transaction_direction(deserializer);
@@ -5972,6 +5985,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_32(deserializer);
     return TransactionDirection.values[inner];
+  }
+
+  @protected
+  TransactionFees sse_decode_transaction_fees(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_swap = sse_decode_u_64(deserializer);
+    var var_network = sse_decode_u_64(deserializer);
+    var var_melt = sse_decode_u_64(deserializer);
+    return TransactionFees(
+      swap: var_swap,
+      network: var_network,
+      melt: var_melt,
+    );
   }
 
   @protected
@@ -7573,7 +7599,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.year, serializer);
     sse_encode_u_32(self.month, serializer);
-    sse_encode_u_64(self.fees, serializer);
+    sse_encode_transaction_fees(self.fees, serializer);
   }
 
   @protected
@@ -7967,7 +7993,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.requestId, serializer);
     sse_encode_String(self.unit, serializer);
     sse_encode_u_64(self.amount, serializer);
-    sse_encode_u_64(self.fees, serializer);
+    sse_encode_transaction_fees(self.fees, serializer);
     sse_encode_u_64(self.reservedFees, serializer);
     sse_encode_u_64(self.expiry, serializer);
     sse_encode_payment_type(self.ptype, serializer);
@@ -8054,7 +8080,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.id, serializer);
     sse_encode_u_64(self.amount, serializer);
-    sse_encode_u_64(self.fees, serializer);
+    sse_encode_transaction_fees(self.fees, serializer);
     sse_encode_String(self.unit, serializer);
     sse_encode_u_64(self.tstamp, serializer);
     sse_encode_transaction_direction(self.direction, serializer);
@@ -8087,6 +8113,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_transaction_fees(
+    TransactionFees self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_64(self.swap, serializer);
+    sse_encode_u_64(self.network, serializer);
+    sse_encode_u_64(self.melt, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -449,6 +449,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   TransactionDirection dco_decode_transaction_direction(dynamic raw);
 
   @protected
+  TransactionFees dco_decode_transaction_fees(dynamic raw);
+
+  @protected
   TransactionFilters dco_decode_transaction_filters(dynamic raw);
 
   @protected
@@ -1305,6 +1308,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   TransactionDirection sse_decode_transaction_direction(
     SseDeserializer deserializer,
   );
+
+  @protected
+  TransactionFees sse_decode_transaction_fees(SseDeserializer deserializer);
 
   @protected
   TransactionFilters sse_decode_transaction_filters(
@@ -2351,6 +2357,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_transaction_direction(
     TransactionDirection self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_transaction_fees(
+    TransactionFees self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -451,6 +451,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   TransactionDirection dco_decode_transaction_direction(dynamic raw);
 
   @protected
+  TransactionFees dco_decode_transaction_fees(dynamic raw);
+
+  @protected
   TransactionFilters dco_decode_transaction_filters(dynamic raw);
 
   @protected
@@ -1307,6 +1310,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   TransactionDirection sse_decode_transaction_direction(
     SseDeserializer deserializer,
   );
+
+  @protected
+  TransactionFees sse_decode_transaction_fees(SseDeserializer deserializer);
 
   @protected
   TransactionFilters sse_decode_transaction_filters(
@@ -2353,6 +2359,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_transaction_direction(
     TransactionDirection self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_transaction_fees(
+    TransactionFees self,
     SseSerializer serializer,
   );
 


### PR DESCRIPTION
* Separate `fees` in `Transaction` and `PaymentSummary` to contain different types of fees
    * `swap` - swap fee
    * `network` - network fee (e.g. bitcoin miner fee)
    * `melt` - melt fee
