### PR TITLE
Add endpoints for sharing payment requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 * Fix Onchain Mint to not accrue swap fees (just unblind signatures and store them)
 * Add validation to disallow 0 network fee for melting
+* Add endpoints to create a shareable payment request and to pay such a request
+    * `wallet_create_shareable_remote_payment_request`
+        * takes `wallet_id`, `amount`, `description`
+        * returns a string (base58 encoded, borsh-serialized payment request)
+    * `wallet_prepare_pay_shared_payment_request`
+        * takes `wallet_id`, `payment_request` (the string from above)
+        * parses the request and prepares the given payment
+        * returns `payment_summary`
+    * `wallet_pay_shared_payment_request`
+        * takes `wallet_id`, `payment_request_id` (the string from above)
+        * executes the payment
+    * In the case of a shareable payment request, no payment request is actually persisted in the wallet
 
 # 0.9.8
 

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -501,6 +501,54 @@ impl AppState {
         Ok(tx_id)
     }
 
+    pub async fn wallet_create_shareable_remote_payment_request(
+        &self,
+        wallet_id: String,
+        amount: u64,
+        description: Option<String>,
+    ) -> Result<String> {
+        tracing::debug!(
+            "wallet_create_shareable_remote_payment_request({wallet_id}, {amount}, {description:?})"
+        );
+        let amount = cashu::Amount::from(amount);
+        let wallet = self.get_wallet(&wallet_id).await?;
+        let unit = wallet.read().await.debit_unit();
+        let payment_request = wallet
+            .read()
+            .await
+            .create_shareable_remote_payment_request(amount, unit, description)
+            .await?;
+        Ok(payment_request)
+    }
+
+    pub async fn wallet_prepare_pay_shared_payment_request(
+        &self,
+        wallet_id: String,
+        payment_req: String,
+    ) -> Result<PaymentSummary> {
+        tracing::debug!("wallet_prepare_pay_shared_payment_request({wallet_id}, {payment_req})");
+        let wallet = self.get_wallet(&wallet_id).await?;
+        let summary = wallet
+            .read()
+            .await
+            .prepare_pay_shared_payment_request(payment_req)
+            .await?;
+        Ok(summary)
+    }
+
+    pub async fn wallet_pay_shared_payment_request(
+        &self,
+        wallet_id: String,
+        rid: String,
+    ) -> Result<Uuid> {
+        tracing::debug!("wallet_pay_shared_payment_request({wallet_id}, {rid})");
+        let tstamp = chrono::Utc::now().timestamp() as u64;
+        let p_id = Uuid::from_str(&rid)?;
+        let wallet = self.get_wallet(&wallet_id).await?;
+        let (tx_id, _) = wallet.read().await.pay(p_id, &self.http_cl, tstamp).await?;
+        Ok(tx_id)
+    }
+
     pub async fn wallet_request_payment_from_contact(
         &self,
         wallet_id: String,

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -143,7 +143,16 @@ pub trait WalletApi: SendSync {
         relays: Vec<RelayUrl>,
     ) -> Result<Vec<RelayUrl>>;
     async fn delete(&self) -> Result<()>;
-    // pending payment requests
+    async fn create_shareable_remote_payment_request(
+        &self,
+        amount: Amount,
+        unit: CurrencyUnit,
+        description: Option<String>,
+    ) -> Result<String>;
+    async fn prepare_pay_shared_payment_request(
+        &self,
+        payment_req: String,
+    ) -> Result<PaymentSummary>;
     async fn request_payment_from_contact(
         &self,
         contact_id: Uuid,
@@ -626,6 +635,52 @@ impl WalletApi for super::Wallet {
                         "Could not mark payment request {p_req_id} as paid after successful payment: {e}"
                     );
                 }
+                Ok((tx_id, None))
+            }
+            WalletPaymentType::SharedPaymentRequest { node_id } => {
+                let existing_relays = self.nostr_transport.relays().to_owned();
+                let receiver_relays = self
+                    .nostr_transport
+                    .fetch_relay_list(node_id.npub(), existing_relays)
+                    .await?;
+
+                let proofs = self
+                    .debit
+                    .send_proofs(request_id, &infos, self.client.clone(), self.swap_config())
+                    .await?;
+                let (ys, proofs): (Vec<cashu::PublicKey>, Vec<cashu::Proof>) =
+                    proofs.into_iter().unzip();
+                let amount = proofs.total_amount()?;
+
+                let partial_tx = Transaction {
+                    id: Uuid::new_v4(),
+                    mint_url: to_mint_url(self.client.mint_url()),
+                    fees,
+                    direction: TransactionDirection::Outgoing,
+                    memo,
+                    tstamp: now,
+                    unit: unit.clone(),
+                    ys,
+                    amount,
+                    payment_type: PaymentType::Contact,
+                    status: TransactionStatus::Pending,
+                    payment_request_id: None,
+                    btc_tx_id: None,
+                    quote_id: None,
+                    nostr_event_id: None,
+                    contact_node_id: Some(node_id.clone()),
+                    linked_txs: vec![],
+                };
+                let tx_id = self
+                    .pay_shared_payment_request(
+                        node_id,
+                        receiver_relays,
+                        proofs,
+                        &self.nostr_transport,
+                        partial_tx,
+                    )
+                    .await?;
+
                 Ok((tx_id, None))
             }
         }
@@ -1276,6 +1331,79 @@ impl WalletApi for super::Wallet {
         }
 
         Ok(())
+    }
+
+    async fn create_shareable_remote_payment_request(
+        &self,
+        amount: Amount,
+        unit: CurrencyUnit,
+        description: Option<String>,
+    ) -> Result<String> {
+        let payload = ContactPaymentRequestPayload::new(
+            self.node_id(),
+            amount,
+            unit.clone(),
+            description.clone(),
+            None,
+            to_mint_url(self.client.mint_url()),
+        );
+        let event: EventEnvelope =
+            bcr_wallet_core::event::Event::new_contact_payment_request(payload).try_into()?;
+        let encoded_payload = base58::encode(&borsh::to_vec(&event)?);
+        Ok(encoded_payload)
+    }
+
+    async fn prepare_pay_shared_payment_request(
+        &self,
+        payment_req: String,
+    ) -> Result<PaymentSummary> {
+        let infos = self.get_wallet_mint_keyset_infos().await?;
+
+        if let Ok(decoded_event) = base58::decode(&payment_req)
+            && let Ok(deserialized_event) = borsh::from_slice::<EventEnvelope>(&decoded_event)
+        {
+            match deserialized_event.event_type {
+                bcr_wallet_core::event::EventType::ContactPaymentRequest => {
+                    if let Ok(deserialized_payload) =
+                        borsh::from_slice::<ContactPaymentRequestPayload>(&deserialized_event.data)
+                    {
+                        if deserialized_payload.unit != self.debit.unit() {
+                            return Err(Error::InvalidCurrencyUnit(
+                                deserialized_payload.unit.to_string(),
+                            ));
+                        }
+                        if deserialized_payload.sender.network() != self.network() {
+                            return Err(Error::InvalidNetwork(
+                                self.network(),
+                                deserialized_payload.sender.network(),
+                            ));
+                        }
+                        let s_summary = self
+                            .debit
+                            .prepare_send(deserialized_payload.amount, &infos)
+                            .await?;
+                        let mut summary = PaymentSummary::from(s_summary);
+                        summary.ptype = PaymentType::Contact;
+                        let pref = PayReference {
+                            request_id: summary.request_id,
+                            unit: summary.unit.clone(),
+                            fees: summary.fees,
+                            ptype: WalletPaymentType::SharedPaymentRequest {
+                                node_id: deserialized_payload.sender,
+                            },
+                            memo: deserialized_payload.memo,
+                        };
+                        *self.current_payment.lock().await = Some(pref);
+                        Ok(summary)
+                    } else {
+                        Err(Error::UnknownPaymentRequest(payment_req))
+                    }
+                }
+                _ => Err(Error::UnknownPaymentRequest(payment_req)),
+            }
+        } else {
+            Err(Error::UnknownPaymentRequest(payment_req))
+        }
     }
 
     async fn request_payment_from_contact(

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -41,7 +41,11 @@ use bitcoin::{
     secp256k1,
 };
 use chrono::Utc;
-use nostr::event::EventId;
+use nostr::{
+    event::EventId,
+    nips::nip19::{Nip19Profile, ToBech32},
+    types::RelayUrl,
+};
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 use tokio::sync::{Mutex, RwLock, broadcast};
 use tokio_util::sync::CancellationToken;
@@ -986,6 +990,53 @@ impl Wallet {
         let Some(target) = target else {
             return Err(Error::ContactMustHaveNodeId(contact.id.to_string()));
         };
+
+        let event_id = match nostr_cl
+            .send_private_msg(target.clone(), payload.clone())
+            .await
+        {
+            Ok(event_id) => event_id,
+            Err(e) => {
+                tracing::error!("Failed to send contact payment, queuing for retry: {e}");
+                match e {
+                    bcr_wallet_transport::error::Error::NostrSendPrivateMsg(event_id) => {
+                        self.nostr_transport
+                            .queue_retry_message(Some(target), payload)
+                            .await?;
+                        event_id
+                    }
+                    e => return Err(e.into()),
+                }
+            }
+        };
+        partial_tx.nostr_event_id = Some(event_id);
+        let txid = self.tx_repo.store_tx(partial_tx).await?;
+        Ok(txid)
+    }
+
+    async fn pay_shared_payment_request(
+        &self,
+        node_id: NodeId,
+        relays: Vec<RelayUrl>,
+        proofs: Vec<cashu::Proof>,
+        nostr_cl: &Arc<dyn TransportApi>,
+        mut partial_tx: Transaction,
+    ) -> Result<Uuid> {
+        let payload = ContactPaymentPayload {
+            payment_request_id: None,
+            sender: self.node_id(),
+            proofs,
+            memo: partial_tx.memo.clone(),
+            unit: partial_tx.unit.clone(),
+            mint: to_mint_url(self.client.mint_url()),
+            created_at: Utc::now().timestamp() as u64,
+        };
+        let event: EventEnvelope =
+            bcr_wallet_core::event::Event::new_contact_payment(payload).try_into()?;
+        let payload = base58::encode(&borsh::to_vec(&event)?);
+        let target = Nip19Profile::new(node_id.npub(), relays.clone())
+            .to_bech32()
+            .map_err(|_| Error::Unsupported(node_id.to_string()))?;
 
         let event_id = match nostr_cl
             .send_private_msg(target.clone(), payload.clone())
@@ -3827,5 +3878,215 @@ mod tests {
         assert_eq!(res[0].amount, Amount::from(8));
 
         assert!(res[0].witness.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_create_shareable_remote_payment_request_can_be_prepared() {
+        let mut ctx = wallet_ctx();
+        let relays = vec![RelayUrl::from_str("wss://relay.example.com").unwrap()];
+
+        ctx.debit
+            .expect_unit()
+            .times(1)
+            .returning(|| CurrencyUnit::Sat);
+
+        ctx.client
+            .expect_mint_url()
+            .times(1)
+            .return_const(url::Url::from_str("https://mint.example").unwrap());
+
+        ctx.nostr_transport
+            .expect_relays()
+            .times(1)
+            .return_const(relays);
+
+        ctx.client
+            .expect_get_mint_keysets()
+            .times(1)
+            .returning(|| Ok(vec![]));
+
+        ctx.debit
+            .expect_prepare_send()
+            .times(1)
+            .returning(|amount, _infos| {
+                assert_eq!(amount, Amount::from(42));
+                Ok(Default::default())
+            });
+
+        let wlt = wallet(ctx).await;
+
+        let shared_request = wlt
+            .read()
+            .await
+            .create_shareable_remote_payment_request(
+                Amount::from(42),
+                CurrencyUnit::Sat,
+                Some("shared request memo".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert!(!shared_request.is_empty());
+
+        let summary = wlt
+            .read()
+            .await
+            .prepare_pay_shared_payment_request(shared_request)
+            .await
+            .unwrap();
+
+        assert_eq!(summary.ptype, PaymentType::Contact);
+    }
+
+    #[tokio::test]
+    async fn test_prepare_pay_shared_payment_request_sets_payment_reference() {
+        let mut ctx = wallet_ctx();
+        let relays = vec![RelayUrl::from_str("wss://relay.example.com").unwrap()];
+        let expected_node_id = NodeId::new(test_pub_key(), bitcoin::Network::Testnet);
+
+        ctx.debit
+            .expect_unit()
+            .times(1)
+            .returning(|| CurrencyUnit::Sat);
+
+        ctx.nostr_transport
+            .expect_relays()
+            .times(1)
+            .return_const(relays);
+
+        ctx.client
+            .expect_mint_url()
+            .times(1)
+            .return_const(url::Url::from_str("https://mint.example").unwrap());
+
+        ctx.client
+            .expect_get_mint_keysets()
+            .times(1)
+            .returning(|| Ok(vec![]));
+
+        ctx.debit
+            .expect_prepare_send()
+            .times(1)
+            .returning(|amount, _infos| {
+                assert_eq!(amount, Amount::from(42));
+                Ok(Default::default())
+            });
+
+        let wlt = wallet(ctx).await;
+
+        let shared_request = wlt
+            .read()
+            .await
+            .create_shareable_remote_payment_request(
+                Amount::from(42),
+                CurrencyUnit::Sat,
+                Some("shared request memo".to_string()),
+            )
+            .await
+            .unwrap();
+
+        let summary = wlt
+            .read()
+            .await
+            .prepare_pay_shared_payment_request(shared_request)
+            .await
+            .unwrap();
+
+        assert_eq!(summary.ptype, PaymentType::Contact);
+
+        let wallet_guard = wlt.read().await;
+        let payment_guard = wallet_guard.current_payment.lock().await;
+        let payment = payment_guard.as_ref().expect("payment reference is set");
+
+        assert_eq!(payment.unit, CurrencyUnit::Sat);
+        assert_eq!(payment.memo, Some("shared request memo".to_string()));
+
+        match &payment.ptype {
+            WalletPaymentType::SharedPaymentRequest { node_id } => {
+                assert_eq!(node_id, &expected_node_id);
+            }
+            other => panic!("unexpected payment type: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pay_shared_payment_request() {
+        let mut ctx = wallet_ctx();
+
+        let pid = Uuid::new_v4();
+        let tx_id = Uuid::new_v4();
+        let receiver_node_id = node_id(NODE_ID_1);
+        let expected_receiver_node_id = receiver_node_id.clone();
+        let relays = vec![RelayUrl::from_str("wss://relay.example.com").unwrap()];
+
+        ctx.client
+            .expect_get_mint_keysets()
+            .times(1)
+            .returning(|| Ok(vec![]));
+
+        ctx.client
+            .expect_mint_url()
+            .times(2)
+            .return_const(url::Url::from_str("https://mint.example").unwrap());
+
+        ctx.nostr_transport
+            .expect_relays()
+            .return_const(vec![RelayUrl::from_str("wss://test.example.com").unwrap()]);
+
+        let relays_clone = relays.clone();
+        ctx.nostr_transport
+            .expect_fetch_relay_list()
+            .times(1)
+            .returning(move |_, _| Ok(relays_clone.clone()));
+
+        ctx.debit
+            .expect_unit()
+            .times(1)
+            .returning(|| CurrencyUnit::Sat);
+
+        ctx.debit
+            .expect_send_proofs()
+            .times(1)
+            .returning(|_rid, _infos, _client, _swap| Ok(HashMap::default()));
+
+        ctx.nostr_transport
+            .expect_send_private_msg()
+            .times(1)
+            .returning(|_, _| Ok(EventId::all_zeros()));
+
+        ctx.tx_repo.expect_store_tx().times(1).returning(move |tx| {
+            assert_eq!(tx.direction, TransactionDirection::Outgoing);
+            assert_eq!(tx.amount, Amount::ZERO);
+            assert_eq!(tx.fees.swap, Amount::ZERO);
+            assert_eq!(tx.fees.melt, Amount::ZERO);
+            assert_eq!(tx.fees.network, Amount::ZERO);
+            assert_eq!(tx.unit, CurrencyUnit::Sat);
+            assert_eq!(tx.tstamp, 123);
+            assert_eq!(tx.memo, Some("shared request memo".to_string()));
+            assert_eq!(tx.payment_type, PaymentType::Contact);
+            assert_eq!(tx.status, TransactionStatus::Pending);
+            assert_eq!(tx.contact_node_id, Some(expected_receiver_node_id.clone()));
+            assert!(tx.payment_request_id.is_none());
+            assert_eq!(tx.nostr_event_id, Some(EventId::all_zeros()));
+            Ok(tx_id)
+        });
+
+        let wlt = wallet(ctx).await;
+
+        *wlt.read().await.current_payment.lock().await = Some(PayReference {
+            request_id: pid,
+            unit: CurrencyUnit::Sat,
+            fees: TransactionFees::default(),
+            ptype: WalletPaymentType::SharedPaymentRequest {
+                node_id: receiver_node_id,
+            },
+            memo: Some("shared request memo".to_string()),
+        });
+
+        let http_cl = reqwest::Client::new();
+        let (res_tx_id, token) = wlt.read().await.pay(pid, &http_cl, 123).await.unwrap();
+
+        assert_eq!(res_tx_id, tx_id);
+        assert!(token.is_none());
     }
 }

--- a/crates/bcr-wallet-api/src/wallet/types.rs
+++ b/crates/bcr-wallet-api/src/wallet/types.rs
@@ -14,6 +14,7 @@ pub struct SwapConfig {
     pub alpha_pk: secp256k1::PublicKey,
 }
 
+#[derive(Debug, Clone)]
 pub enum WalletPaymentType {
     Cdk18 {
         transport: cashu::Transport,
@@ -24,6 +25,9 @@ pub enum WalletPaymentType {
     Contact {
         contact_id: Uuid,
         payment_request_id: Option<Uuid>,
+    },
+    SharedPaymentRequest {
+        node_id: NodeId,
     },
 }
 

--- a/crates/bcr-wallet-cli/src/command.rs
+++ b/crates/bcr-wallet-cli/src/command.rs
@@ -773,6 +773,63 @@ pub async fn cmd_list_contacts(
     Ok(res)
 }
 
+pub async fn cmd_create_shareable_payment_request(
+    app_state: &AppState,
+    name: &str,
+    id: &str,
+    amount: u64,
+) -> Result<String> {
+    let mut res = String::new();
+    let req = app_state
+        .wallet_create_shareable_remote_payment_request(id.to_owned(), amount, None)
+        .await?;
+    push_break(&mut res);
+    push_break(&mut res);
+    res.push_str(&format!(
+        "Create Shareable Payment Request for {amount} for {name}:\n"
+    ));
+    res.push_str("Payment Request: ");
+    res.push_str(&req);
+    push_break(&mut res);
+    Ok(res)
+}
+
+pub async fn cmd_pay_shared_payment_request(
+    app_state: &AppState,
+    name: &str,
+    id: &str,
+    payment_request: &str,
+) -> Result<String> {
+    let mut res = String::new();
+    let payment_summary = app_state
+        .wallet_prepare_pay_shared_payment_request(id.to_owned(), payment_request.to_owned())
+        .await?;
+    info!(
+        "Payment Summary: Amount: {}, Unit: {}, {}",
+        payment_summary.amount,
+        payment_summary.unit,
+        format_fees(payment_summary.fees),
+    );
+    push_break(&mut res);
+    push_break(&mut res);
+    let result = app_state
+        .wallet_pay_shared_payment_request(id.to_owned(), payment_summary.request_id.to_string())
+        .await?;
+    res.push_str(&format!(
+        "Pay Shared Payment Request {payment_request} for {name}, Wallet ID: {id}.\n"
+    ));
+    res.push_str(&format!(
+        "Unit: {}, Amount: {}, {}",
+        payment_summary.unit,
+        payment_summary.amount,
+        format_fees(payment_summary.fees)
+    ));
+    push_break(&mut res);
+    res.push_str(&format!("Transaction ID: {}", result));
+    push_break(&mut res);
+    Ok(res)
+}
+
 pub async fn cmd_request_payment_from_contact(
     app_state: &AppState,
     name: &str,

--- a/crates/bcr-wallet-cli/src/main.rs
+++ b/crates/bcr-wallet-cli/src/main.rs
@@ -154,6 +154,10 @@ enum Commands {
         network: bitcoin::Network,
         search_term: Option<String>,
     },
+    #[command(name = "create_shareable_payment_req")]
+    CreateShareablePaymentRequest { id: String, amount: u64 },
+    #[command(name = "pay_shared_payment_req")]
+    PaySharedPaymentRequest { id: String, payment_req: String },
     #[command(name = "req_payment_from_contact")]
     RequestPaymentFromContact {
         id: String,
@@ -499,6 +503,22 @@ async fn main() -> Result<()> {
                 "List Contacts for {}: {}",
                 cli.wallet,
                 command::cmd_list_contacts(&app_state, &cli.wallet, network, &search_term).await?
+            );
+        }
+        Commands::CreateShareablePaymentRequest { id, amount } => {
+            info!(
+                "Create Shareable Payment Request for {}: {}",
+                cli.wallet,
+                command::cmd_create_shareable_payment_request(&app_state, &cli.wallet, &id, amount)
+                    .await?
+            );
+        }
+        Commands::PaySharedPaymentRequest { id, payment_req } => {
+            info!(
+                "Pay Shared Payment Request for {}: {}",
+                cli.wallet,
+                command::cmd_pay_shared_payment_request(&app_state, &cli.wallet, &id, &payment_req)
+                    .await?
             );
         }
         Commands::RequestPaymentFromContact {

--- a/crates/bcr-wallet-ffi/src/api/mod.rs
+++ b/crates/bcr-wallet-ffi/src/api/mod.rs
@@ -879,6 +879,53 @@ pub async fn wallet_get_payment_request(
 }
 
 #[frb]
+pub async fn wallet_create_shareable_remote_payment_request(
+    req: WalletCreateShareableRemotePaymentRequest,
+) -> Result<WalletCreateShareableRemotePaymentResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let payment_request = app_state
+        .wallet_create_shareable_remote_payment_request(req.wallet_id, req.amount, req.description)
+        .await?;
+    Ok(WalletCreateShareableRemotePaymentResponse { payment_request })
+}
+
+#[frb]
+pub async fn wallet_prepare_pay_shared_payment_request(
+    req: WalletPreparePaySharedPaymentRequestRequest,
+) -> Result<WalletPreparePaymentResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let payment_summary = app_state
+        .wallet_prepare_pay_shared_payment_request(req.wallet_id, req.payment_request)
+        .await?;
+    Ok(WalletPreparePaymentResponse {
+        payment_summary: PaymentSummary {
+            request_id: payment_summary.request_id.to_string(),
+            unit: payment_summary.unit.to_string(),
+            amount: u64::from(payment_summary.amount),
+            fees: payment_summary.fees.into(),
+            reserved_fees: u64::from(payment_summary.reserved_fees),
+            expiry: payment_summary.expiry,
+            ptype: PaymentType::from(bcr_wallet_core::types::PaymentType::from(
+                payment_summary.ptype,
+            )),
+        },
+    })
+}
+
+#[frb]
+pub async fn wallet_pay_shared_payment_request(
+    req: WalletPayRequest,
+) -> Result<WalletTransactionIdResponse, WalletError> {
+    let app_state = get_app_state().await;
+    let res = app_state
+        .wallet_pay_shared_payment_request(req.wallet_id, req.rid)
+        .await?;
+    Ok(WalletTransactionIdResponse {
+        tx_id: res.to_string(),
+    })
+}
+
+#[frb]
 pub async fn wallet_prepare_pay_payment_request(
     req: WalletPreparePayPaymentRequestRequest,
 ) -> Result<WalletPreparePaymentResponse, WalletError> {
@@ -1879,6 +1926,18 @@ pub struct WalletPreparePaymentReqRequest {
 }
 
 #[derive(Debug, Clone)]
+pub struct WalletCreateShareableRemotePaymentRequest {
+    pub wallet_id: String,
+    pub amount: u64,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletCreateShareableRemotePaymentResponse {
+    pub payment_request: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct WalletPreparePaymentReqResponse {
     pub payment_request: Cdk18PaymentRequest,
 }
@@ -2196,6 +2255,12 @@ pub struct WalletGetPaymentRequestRequest {
 #[derive(Debug, Clone)]
 pub struct WalletGetPaymentRequestResponse {
     pub payment_request: PaymentRequest,
+}
+
+#[derive(Debug, Clone)]
+pub struct WalletPreparePaySharedPaymentRequestRequest {
+    pub wallet_id: String,
+    pub payment_request: String,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/bcr-wallet-ffi/src/frb_generated.rs
+++ b/crates/bcr-wallet-ffi/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1690913843;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1834494998;
 
 // Section: executor
 
@@ -775,6 +775,46 @@ let api_result_callback = decode_DartFn_Inputs_wallet_maybe_transaction_id_respo
                          let output_ok = crate::api::wallet_check_received_payment(api_req, api_result_callback).await?;   Ok(output_ok)
                     })().await)
                 } })
+}
+fn wire__crate__api__wallet_create_shareable_remote_payment_request_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_create_shareable_remote_payment_request",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::WalletCreateShareableRemotePaymentRequest>::sse_decode(
+                &mut deserializer,
+            );
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::wallet_create_shareable_remote_payment_request(api_req)
+                                .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
 }
 fn wire__crate__api__wallet_delete_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
@@ -1890,6 +1930,43 @@ fn wire__crate__api__wallet_pay_payment_request_impl(
         },
     )
 }
+fn wire__crate__api__wallet_pay_shared_payment_request_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_pay_shared_payment_request",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::WalletPayRequest>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::wallet_pay_shared_payment_request(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet_pay_to_contact_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2030,6 +2107,45 @@ fn wire__crate__api__wallet_prepare_pay_payment_request_impl(
                     (move || async move {
                         let output_ok =
                             crate::api::wallet_prepare_pay_payment_request(api_req).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet_prepare_pay_shared_payment_request_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "wallet_prepare_pay_shared_payment_request",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_req = <crate::api::WalletPreparePaySharedPaymentRequestRequest>::sse_decode(
+                &mut deserializer,
+            );
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::WalletError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::wallet_prepare_pay_shared_payment_request(api_req).await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -3746,6 +3862,30 @@ impl SseDecode for crate::api::WalletCheckReceivedPaymentRequest {
     }
 }
 
+impl SseDecode for crate::api::WalletCreateShareableRemotePaymentRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_walletId = <String>::sse_decode(deserializer);
+        let mut var_amount = <u64>::sse_decode(deserializer);
+        let mut var_description = <Option<String>>::sse_decode(deserializer);
+        return crate::api::WalletCreateShareableRemotePaymentRequest {
+            wallet_id: var_walletId,
+            amount: var_amount,
+            description: var_description,
+        };
+    }
+}
+
+impl SseDecode for crate::api::WalletCreateShareableRemotePaymentResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_paymentRequest = <String>::sse_decode(deserializer);
+        return crate::api::WalletCreateShareableRemotePaymentResponse {
+            payment_request: var_paymentRequest,
+        };
+    }
+}
+
 impl SseDecode for crate::api::WalletCurrencyUnitResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4241,6 +4381,18 @@ impl SseDecode for crate::api::WalletPreparePayPaymentRequestRequest {
     }
 }
 
+impl SseDecode for crate::api::WalletPreparePaySharedPaymentRequestRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_walletId = <String>::sse_decode(deserializer);
+        let mut var_paymentRequest = <String>::sse_decode(deserializer);
+        return crate::api::WalletPreparePaySharedPaymentRequestRequest {
+            wallet_id: var_walletId,
+            payment_request: var_paymentRequest,
+        };
+    }
+}
+
 impl SseDecode for crate::api::WalletPreparePaymentByContactRequest {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4620,92 +4772,110 @@ fn pde_ffi_dispatcher_primary_impl(
         21 => {
             wire__crate__api__wallet_check_received_payment_impl(port, ptr, rust_vec_len, data_len)
         }
-        22 => wire__crate__api__wallet_delete_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__wallet_dev_mode_get_detailed_balance_impl(
+        22 => wire__crate__api__wallet_create_shareable_remote_payment_request_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        24 => {
+        23 => wire__crate__api__wallet_delete_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__wallet_dev_mode_get_detailed_balance_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        25 => {
             wire__crate__api__wallet_edit_transaction_memo_impl(port, ptr, rust_vec_len, data_len)
         }
-        25 => wire__crate__api__wallet_error_bad_request_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__wallet_error_internal_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__wallet_error_network_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__wallet_error_not_found_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__wallet_error_unavailable_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__wallet_estimate_melt_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__wallet_get_balance_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__wallet_get_currency_unit_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__wallet_get_ids_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__wallet_get_info_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__wallet_get_mint_url_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__wallet_get_name_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__wallet_get_node_id_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__wallet_get_payment_request_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__wallet_get_status_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__wallet_get_transaction_ids_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__wallet_get_transactions_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__wallet_id_for_mnemonic_and_network_impl(
+        26 => wire__crate__api__wallet_error_bad_request_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__wallet_error_internal_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__wallet_error_network_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__wallet_error_not_found_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__wallet_error_unavailable_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__wallet_estimate_melt_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__wallet_get_balance_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__wallet_get_currency_unit_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__wallet_get_ids_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__wallet_get_info_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__wallet_get_mint_url_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__wallet_get_name_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__wallet_get_node_id_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__wallet_get_payment_request_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__wallet_get_status_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__wallet_get_transaction_ids_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__wallet_get_transactions_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__wallet_id_for_mnemonic_and_network_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => {
+        44 => {
             wire__crate__api__wallet_list_payment_requests_impl(port, ptr, rust_vec_len, data_len)
         }
-        44 => wire__crate__api__wallet_load_transaction_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__wallet_melt_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__wallet_migrate_rabid_impl(port, ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__wallet_mint_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__wallet_mint_is_offline_impl(port, ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__wallet_mint_is_rabid_impl(port, ptr, rust_vec_len, data_len),
-        50 => wire__crate__api__wallet_pay_impl(port, ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__wallet_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
-        52 => wire__crate__api__wallet_pay_payment_request_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__wallet_pay_to_contact_impl(port, ptr, rust_vec_len, data_len),
-        54 => wire__crate__api__wallet_prepare_melt_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__wallet_prepare_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__wallet_prepare_pay_payment_request_impl(
+        45 => wire__crate__api__wallet_load_transaction_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__wallet_melt_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__wallet_migrate_rabid_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__wallet_mint_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__wallet_mint_is_offline_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__wallet_mint_is_rabid_impl(port, ptr, rust_vec_len, data_len),
+        51 => wire__crate__api__wallet_pay_impl(port, ptr, rust_vec_len, data_len),
+        52 => wire__crate__api__wallet_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
+        53 => wire__crate__api__wallet_pay_payment_request_impl(port, ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__wallet_pay_shared_payment_request_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        57 => {
+        55 => wire__crate__api__wallet_pay_to_contact_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__wallet_prepare_melt_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__wallet_prepare_pay_by_token_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__wallet_prepare_pay_payment_request_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        59 => wire__crate__api__wallet_prepare_pay_shared_payment_request_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        60 => {
             wire__crate__api__wallet_prepare_pay_to_contact_impl(port, ptr, rust_vec_len, data_len)
         }
-        58 => wire__crate__api__wallet_prepare_payment_impl(port, ptr, rust_vec_len, data_len),
-        59 => {
+        61 => wire__crate__api__wallet_prepare_payment_impl(port, ptr, rust_vec_len, data_len),
+        62 => {
             wire__crate__api__wallet_prepare_payment_request_impl(port, ptr, rust_vec_len, data_len)
         }
-        60 => wire__crate__api__wallet_protest_melt_impl(port, ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__wallet_protest_mint_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__wallet_protest_swap_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__wallet_receive_impl(port, ptr, rust_vec_len, data_len),
-        64 => wire__crate__api__wallet_reclaim_transaction_impl(port, ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__wallet_recover_pending_stale_proofs_impl(
+        63 => wire__crate__api__wallet_protest_melt_impl(port, ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__wallet_protest_mint_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__wallet_protest_swap_impl(port, ptr, rust_vec_len, data_len),
+        66 => wire__crate__api__wallet_receive_impl(port, ptr, rust_vec_len, data_len),
+        67 => wire__crate__api__wallet_reclaim_transaction_impl(port, ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__wallet_recover_pending_stale_proofs_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        66 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
-        68 => {
+        69 => wire__crate__api__wallet_refresh_transaction_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__wallet_refresh_transactions_impl(port, ptr, rust_vec_len, data_len),
+        71 => {
             wire__crate__api__wallet_reject_payment_request_impl(port, ptr, rust_vec_len, data_len)
         }
-        69 => wire__crate__api__wallet_request_payment_from_contact_impl(
+        72 => wire__crate__api__wallet_request_payment_from_contact_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        70 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
-        71 => wire__crate__api__wallet_set_dev_mode_impl(port, ptr, rust_vec_len, data_len),
-        72 => wire__crate__api__wallet_subscribe_to_payment_requests_impl(
+        73 => wire__crate__api__wallet_restore_impl(port, ptr, rust_vec_len, data_len),
+        74 => wire__crate__api__wallet_set_dev_mode_impl(port, ptr, rust_vec_len, data_len),
+        75 => wire__crate__api__wallet_subscribe_to_payment_requests_impl(
             port,
             ptr,
             rust_vec_len,
@@ -5721,6 +5891,45 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletCheckReceivedPaymentReq
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletCreateShareableRemotePaymentRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.wallet_id.into_into_dart().into_dart(),
+            self.amount.into_into_dart().into_dart(),
+            self.description.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletCreateShareableRemotePaymentRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletCreateShareableRemotePaymentRequest>
+    for crate::api::WalletCreateShareableRemotePaymentRequest
+{
+    fn into_into_dart(self) -> crate::api::WalletCreateShareableRemotePaymentRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletCreateShareableRemotePaymentResponse {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.payment_request.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletCreateShareableRemotePaymentResponse
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletCreateShareableRemotePaymentResponse>
+    for crate::api::WalletCreateShareableRemotePaymentResponse
+{
+    fn into_into_dart(self) -> crate::api::WalletCreateShareableRemotePaymentResponse {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::WalletCurrencyUnitResponse {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [self.unit.into_into_dart().into_dart()].into_dart()
@@ -6456,6 +6665,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletPreparePayPaymentReques
     for crate::api::WalletPreparePayPaymentRequestRequest
 {
     fn into_into_dart(self) -> crate::api::WalletPreparePayPaymentRequestRequest {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::WalletPreparePaySharedPaymentRequestRequest {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.wallet_id.into_into_dart().into_dart(),
+            self.payment_request.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::WalletPreparePaySharedPaymentRequestRequest
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::WalletPreparePaySharedPaymentRequestRequest>
+    for crate::api::WalletPreparePaySharedPaymentRequestRequest
+{
+    fn into_into_dart(self) -> crate::api::WalletPreparePaySharedPaymentRequestRequest {
         self
     }
 }
@@ -7895,6 +8125,22 @@ impl SseEncode for crate::api::WalletCheckReceivedPaymentRequest {
     }
 }
 
+impl SseEncode for crate::api::WalletCreateShareableRemotePaymentRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.wallet_id, serializer);
+        <u64>::sse_encode(self.amount, serializer);
+        <Option<String>>::sse_encode(self.description, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletCreateShareableRemotePaymentResponse {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.payment_request, serializer);
+    }
+}
+
 impl SseEncode for crate::api::WalletCurrencyUnitResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -8258,6 +8504,14 @@ impl SseEncode for crate::api::WalletPreparePayPaymentRequestRequest {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.wallet_id, serializer);
         <String>::sse_encode(self.payment_request_id, serializer);
+    }
+}
+
+impl SseEncode for crate::api::WalletPreparePaySharedPaymentRequestRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.wallet_id, serializer);
+        <String>::sse_encode(self.payment_request, serializer);
     }
 }
 

--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `get_app_state`, `init_logging`, `init_panic_hook`, `new`, `reset_runtime`, `start_jobs`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `PaymentRequestState`, `WalletCleanLocalDbResponse`, `WalletRuntime`, `WalletsNamesResponse`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
 
 Future<void> initWalletFfi({required WalletFfiConfig conf}) =>
     RustLib.instance.api.crateApiInitWalletFfi(conf: conf);
@@ -178,6 +178,22 @@ Future<WalletListPaymentRequestsResponse> walletListPaymentRequests({
 Future<WalletGetPaymentRequestResponse> walletGetPaymentRequest({
   required WalletGetPaymentRequestRequest req,
 }) => RustLib.instance.api.crateApiWalletGetPaymentRequest(req: req);
+
+Future<WalletCreateShareableRemotePaymentResponse>
+walletCreateShareableRemotePaymentRequest({
+  required WalletCreateShareableRemotePaymentRequest req,
+}) => RustLib.instance.api.crateApiWalletCreateShareableRemotePaymentRequest(
+  req: req,
+);
+
+Future<WalletPreparePaymentResponse> walletPreparePaySharedPaymentRequest({
+  required WalletPreparePaySharedPaymentRequestRequest req,
+}) =>
+    RustLib.instance.api.crateApiWalletPreparePaySharedPaymentRequest(req: req);
+
+Future<WalletTransactionIdResponse> walletPaySharedPaymentRequest({
+  required WalletPayRequest req,
+}) => RustLib.instance.api.crateApiWalletPaySharedPaymentRequest(req: req);
 
 Future<WalletPreparePaymentResponse> walletPreparePayPaymentRequest({
   required WalletPreparePayPaymentRequestRequest req,
@@ -1303,6 +1319,49 @@ class WalletCheckReceivedPaymentRequest {
           pId == other.pId;
 }
 
+class WalletCreateShareableRemotePaymentRequest {
+  final String walletId;
+  final BigInt amount;
+  final String? description;
+
+  const WalletCreateShareableRemotePaymentRequest({
+    required this.walletId,
+    required this.amount,
+    this.description,
+  });
+
+  @override
+  int get hashCode =>
+      walletId.hashCode ^ amount.hashCode ^ description.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletCreateShareableRemotePaymentRequest &&
+          runtimeType == other.runtimeType &&
+          walletId == other.walletId &&
+          amount == other.amount &&
+          description == other.description;
+}
+
+class WalletCreateShareableRemotePaymentResponse {
+  final String paymentRequest;
+
+  const WalletCreateShareableRemotePaymentResponse({
+    required this.paymentRequest,
+  });
+
+  @override
+  int get hashCode => paymentRequest.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletCreateShareableRemotePaymentResponse &&
+          runtimeType == other.runtimeType &&
+          paymentRequest == other.paymentRequest;
+}
+
 class WalletCurrencyUnitResponse {
   final String unit;
 
@@ -2110,6 +2169,27 @@ class WalletPreparePayPaymentRequestRequest {
           runtimeType == other.runtimeType &&
           walletId == other.walletId &&
           paymentRequestId == other.paymentRequestId;
+}
+
+class WalletPreparePaySharedPaymentRequestRequest {
+  final String walletId;
+  final String paymentRequest;
+
+  const WalletPreparePaySharedPaymentRequestRequest({
+    required this.walletId,
+    required this.paymentRequest,
+  });
+
+  @override
+  int get hashCode => walletId.hashCode ^ paymentRequest.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WalletPreparePaySharedPaymentRequestRequest &&
+          runtimeType == other.runtimeType &&
+          walletId == other.walletId &&
+          paymentRequest == other.paymentRequest;
 }
 
 class WalletPreparePaymentByContactRequest {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -66,7 +66,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 1690913843;
+  int get rustContentHash => -1834494998;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -147,6 +147,11 @@ abstract class RustLibApi extends BaseApi {
     required WalletCheckReceivedPaymentRequest req,
     required FutureOr<void> Function(WalletMaybeTransactionIdResponse)
     resultCallback,
+  });
+
+  Future<WalletCreateShareableRemotePaymentResponse>
+  crateApiWalletCreateShareableRemotePaymentRequest({
+    required WalletCreateShareableRemotePaymentRequest req,
   });
 
   Future<void> crateApiWalletDelete({required WalletRequest req});
@@ -264,6 +269,10 @@ abstract class RustLibApi extends BaseApi {
     required WalletPayRequest req,
   });
 
+  Future<WalletTransactionIdResponse> crateApiWalletPaySharedPaymentRequest({
+    required WalletPayRequest req,
+  });
+
   Future<WalletTransactionIdResponse> crateApiWalletPayToContact({
     required WalletPaymentByContactRequest req,
   });
@@ -278,6 +287,11 @@ abstract class RustLibApi extends BaseApi {
 
   Future<WalletPreparePaymentResponse> crateApiWalletPreparePayPaymentRequest({
     required WalletPreparePayPaymentRequestRequest req,
+  });
+
+  Future<WalletPreparePaymentResponse>
+  crateApiWalletPreparePaySharedPaymentRequest({
+    required WalletPreparePaySharedPaymentRequestRequest req,
   });
 
   Future<WalletPreparePaymentResponse> crateApiWalletPreparePayToContact({
@@ -1014,6 +1028,45 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<WalletCreateShareableRemotePaymentResponse>
+  crateApiWalletCreateShareableRemotePaymentRequest({
+    required WalletCreateShareableRemotePaymentRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_create_shareable_remote_payment_request(
+            req,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 22,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_wallet_create_shareable_remote_payment_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletCreateShareableRemotePaymentRequestConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletCreateShareableRemotePaymentRequestConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_create_shareable_remote_payment_request",
+        argNames: ["req"],
+      );
+
+  @override
   Future<void> crateApiWalletDelete({required WalletRequest req}) {
     return handler.executeNormal(
       NormalTask(
@@ -1023,7 +1076,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 23,
             port: port_,
           );
         },
@@ -1052,7 +1105,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 24,
             port: port_,
           );
         },
@@ -1089,7 +1142,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1124,7 +1177,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1155,7 +1208,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1186,7 +1239,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1218,7 +1271,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1253,7 +1306,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1286,7 +1339,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1316,7 +1369,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1346,7 +1399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1376,7 +1429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1406,7 +1459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1436,7 +1489,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1466,7 +1519,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1496,7 +1549,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -1529,7 +1582,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1559,7 +1612,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1589,7 +1642,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1625,7 +1678,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1662,7 +1715,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1699,7 +1752,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1732,7 +1785,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -1765,7 +1818,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -1792,7 +1845,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -1822,7 +1875,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -1852,7 +1905,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -1885,7 +1938,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -1915,7 +1968,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -1948,7 +2001,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -1978,7 +2031,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2000,6 +2053,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<WalletTransactionIdResponse> crateApiWalletPaySharedPaymentRequest({
+    required WalletPayRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_pay_request(req, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 54,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_wallet_transaction_id_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletPaySharedPaymentRequestConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletPaySharedPaymentRequestConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_pay_shared_payment_request",
+        argNames: ["req"],
+      );
+
+  @override
   Future<WalletTransactionIdResponse> crateApiWalletPayToContact({
     required WalletPaymentByContactRequest req,
   }) {
@@ -2014,7 +2100,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2046,7 +2132,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2079,7 +2165,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2115,7 +2201,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2137,6 +2223,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<WalletPreparePaymentResponse>
+  crateApiWalletPreparePaySharedPaymentRequest({
+    required WalletPreparePaySharedPaymentRequestRequest req,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_box_autoadd_wallet_prepare_pay_shared_payment_request_request(
+            req,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 59,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_wallet_prepare_payment_response,
+          decodeErrorData: sse_decode_wallet_error,
+        ),
+        constMeta: kCrateApiWalletPreparePaySharedPaymentRequestConstMeta,
+        argValues: [req],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletPreparePaySharedPaymentRequestConstMeta =>
+      const TaskConstMeta(
+        debugName: "wallet_prepare_pay_shared_payment_request",
+        argNames: ["req"],
+      );
+
+  @override
   Future<WalletPreparePaymentResponse> crateApiWalletPreparePayToContact({
     required WalletPreparePaymentByContactRequest req,
   }) {
@@ -2151,7 +2274,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2187,7 +2310,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2223,7 +2346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2256,7 +2379,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 63,
             port: port_,
           );
         },
@@ -2286,7 +2409,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 64,
             port: port_,
           );
         },
@@ -2316,7 +2439,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 65,
             port: port_,
           );
         },
@@ -2346,7 +2469,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 66,
             port: port_,
           );
         },
@@ -2379,7 +2502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 67,
             port: port_,
           );
         },
@@ -2411,7 +2534,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 68,
             port: port_,
           );
         },
@@ -2448,7 +2571,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 69,
             port: port_,
           );
         },
@@ -2481,7 +2604,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 70,
             port: port_,
           );
         },
@@ -2518,7 +2641,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 71,
             port: port_,
           );
         },
@@ -2555,7 +2678,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 72,
             port: port_,
           );
         },
@@ -2589,7 +2712,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 73,
             port: port_,
           );
         },
@@ -2619,7 +2742,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 74,
             port: port_,
           );
         },
@@ -2658,7 +2781,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 75,
             port: port_,
           );
         },
@@ -2993,6 +3116,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  dco_decode_box_autoadd_wallet_create_shareable_remote_payment_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_wallet_create_shareable_remote_payment_request(raw);
+  }
+
+  @protected
   WalletEditTransactionMemoRequest
   dco_decode_box_autoadd_wallet_edit_transaction_memo_request(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -3084,6 +3216,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_wallet_prepare_pay_payment_request_request(raw);
+  }
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_prepare_pay_shared_payment_request_request(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_wallet_prepare_pay_shared_payment_request_request(raw);
   }
 
   @protected
@@ -3948,6 +4089,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  dco_decode_wallet_create_shareable_remote_payment_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return WalletCreateShareableRemotePaymentRequest(
+      walletId: dco_decode_String(arr[0]),
+      amount: dco_decode_u_64(arr[1]),
+      description: dco_decode_opt_String(arr[2]),
+    );
+  }
+
+  @protected
+  WalletCreateShareableRemotePaymentResponse
+  dco_decode_wallet_create_shareable_remote_payment_response(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return WalletCreateShareableRemotePaymentResponse(
+      paymentRequest: dco_decode_String(arr[0]),
+    );
+  }
+
+  @protected
   WalletCurrencyUnitResponse dco_decode_wallet_currency_unit_response(
     dynamic raw,
   ) {
@@ -4376,6 +4543,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return WalletPreparePayPaymentRequestRequest(
       walletId: dco_decode_String(arr[0]),
       paymentRequestId: dco_decode_String(arr[1]),
+    );
+  }
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  dco_decode_wallet_prepare_pay_shared_payment_request_request(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return WalletPreparePaySharedPaymentRequestRequest(
+      walletId: dco_decode_String(arr[0]),
+      paymentRequest: dco_decode_String(arr[1]),
     );
   }
 
@@ -4998,6 +5178,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  sse_decode_box_autoadd_wallet_create_shareable_remote_payment_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_wallet_create_shareable_remote_payment_request(
+      deserializer,
+    ));
+  }
+
+  @protected
   WalletEditTransactionMemoRequest
   sse_decode_box_autoadd_wallet_edit_transaction_memo_request(
     SseDeserializer deserializer,
@@ -5109,6 +5300,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_wallet_prepare_pay_payment_request_request(
+      deserializer,
+    ));
+  }
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_prepare_pay_shared_payment_request_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_wallet_prepare_pay_shared_payment_request_request(
       deserializer,
     ));
   }
@@ -6153,6 +6355,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  sse_decode_wallet_create_shareable_remote_payment_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_walletId = sse_decode_String(deserializer);
+    var var_amount = sse_decode_u_64(deserializer);
+    var var_description = sse_decode_opt_String(deserializer);
+    return WalletCreateShareableRemotePaymentRequest(
+      walletId: var_walletId,
+      amount: var_amount,
+      description: var_description,
+    );
+  }
+
+  @protected
+  WalletCreateShareableRemotePaymentResponse
+  sse_decode_wallet_create_shareable_remote_payment_response(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_paymentRequest = sse_decode_String(deserializer);
+    return WalletCreateShareableRemotePaymentResponse(
+      paymentRequest: var_paymentRequest,
+    );
+  }
+
+  @protected
   WalletCurrencyUnitResponse sse_decode_wallet_currency_unit_response(
     SseDeserializer deserializer,
   ) {
@@ -6580,6 +6810,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return WalletPreparePayPaymentRequestRequest(
       walletId: var_walletId,
       paymentRequestId: var_paymentRequestId,
+    );
+  }
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  sse_decode_wallet_prepare_pay_shared_payment_request_request(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_walletId = sse_decode_String(deserializer);
+    var var_paymentRequest = sse_decode_String(deserializer);
+    return WalletPreparePaySharedPaymentRequestRequest(
+      walletId: var_walletId,
+      paymentRequest: var_paymentRequest,
     );
   }
 
@@ -7228,6 +7472,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_wallet_create_shareable_remote_payment_request(
+    WalletCreateShareableRemotePaymentRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_wallet_create_shareable_remote_payment_request(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_wallet_edit_transaction_memo_request(
     WalletEditTransactionMemoRequest self,
     SseSerializer serializer,
@@ -7342,6 +7595,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_wallet_prepare_pay_payment_request_request(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_wallet_prepare_pay_shared_payment_request_request(
+    WalletPreparePaySharedPaymentRequestRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_wallet_prepare_pay_shared_payment_request_request(
+      self,
+      serializer,
+    );
   }
 
   @protected
@@ -8264,6 +8529,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_wallet_create_shareable_remote_payment_request(
+    WalletCreateShareableRemotePaymentRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.walletId, serializer);
+    sse_encode_u_64(self.amount, serializer);
+    sse_encode_opt_String(self.description, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_create_shareable_remote_payment_response(
+    WalletCreateShareableRemotePaymentResponse self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.paymentRequest, serializer);
+  }
+
+  @protected
   void sse_encode_wallet_currency_unit_response(
     WalletCurrencyUnitResponse self,
     SseSerializer serializer,
@@ -8613,6 +8898,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.walletId, serializer);
     sse_encode_String(self.paymentRequestId, serializer);
+  }
+
+  @protected
+  void sse_encode_wallet_prepare_pay_shared_payment_request_request(
+    WalletPreparePaySharedPaymentRequestRequest self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.walletId, serializer);
+    sse_encode_String(self.paymentRequest, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -136,6 +136,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_box_autoadd_wallet_check_received_payment_request(dynamic raw);
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  dco_decode_box_autoadd_wallet_create_shareable_remote_payment_request(
+    dynamic raw,
+  );
+
+  @protected
   WalletEditTransactionMemoRequest
   dco_decode_box_autoadd_wallet_edit_transaction_memo_request(dynamic raw);
 
@@ -187,6 +193,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   dco_decode_box_autoadd_wallet_prepare_pay_payment_request_request(
+    dynamic raw,
+  );
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_prepare_pay_shared_payment_request_request(
     dynamic raw,
   );
 
@@ -504,6 +516,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_wallet_check_received_payment_request(dynamic raw);
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  dco_decode_wallet_create_shareable_remote_payment_request(dynamic raw);
+
+  @protected
+  WalletCreateShareableRemotePaymentResponse
+  dco_decode_wallet_create_shareable_remote_payment_response(dynamic raw);
+
+  @protected
   WalletCurrencyUnitResponse dco_decode_wallet_currency_unit_response(
     dynamic raw,
   );
@@ -638,6 +658,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   dco_decode_wallet_prepare_pay_payment_request_request(dynamic raw);
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  dco_decode_wallet_prepare_pay_shared_payment_request_request(dynamic raw);
 
   @protected
   WalletPreparePaymentByContactRequest
@@ -895,6 +919,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  sse_decode_box_autoadd_wallet_create_shareable_remote_payment_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletEditTransactionMemoRequest
   sse_decode_box_autoadd_wallet_edit_transaction_memo_request(
     SseDeserializer deserializer,
@@ -964,6 +994,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   sse_decode_box_autoadd_wallet_prepare_pay_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_prepare_pay_shared_payment_request_request(
     SseDeserializer deserializer,
   );
 
@@ -1377,6 +1413,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  sse_decode_wallet_create_shareable_remote_payment_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletCreateShareableRemotePaymentResponse
+  sse_decode_wallet_create_shareable_remote_payment_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletCurrencyUnitResponse sse_decode_wallet_currency_unit_response(
     SseDeserializer deserializer,
   );
@@ -1537,6 +1585,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   sse_decode_wallet_prepare_pay_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  sse_decode_wallet_prepare_pay_shared_payment_request_request(
     SseDeserializer deserializer,
   );
 
@@ -1866,6 +1920,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_wallet_create_shareable_remote_payment_request(
+    WalletCreateShareableRemotePaymentRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_wallet_edit_transaction_memo_request(
     WalletEditTransactionMemoRequest self,
     SseSerializer serializer,
@@ -1940,6 +2000,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_prepare_pay_payment_request_request(
     WalletPreparePayPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_wallet_prepare_pay_shared_payment_request_request(
+    WalletPreparePaySharedPaymentRequestRequest self,
     SseSerializer serializer,
   );
 
@@ -2445,6 +2511,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_wallet_create_shareable_remote_payment_request(
+    WalletCreateShareableRemotePaymentRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_create_shareable_remote_payment_response(
+    WalletCreateShareableRemotePaymentResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_wallet_currency_unit_response(
     WalletCurrencyUnitResponse self,
     SseSerializer serializer,
@@ -2642,6 +2720,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_prepare_pay_payment_request_request(
     WalletPreparePayPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_prepare_pay_shared_payment_request_request(
+    WalletPreparePaySharedPaymentRequestRequest self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -138,6 +138,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_box_autoadd_wallet_check_received_payment_request(dynamic raw);
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  dco_decode_box_autoadd_wallet_create_shareable_remote_payment_request(
+    dynamic raw,
+  );
+
+  @protected
   WalletEditTransactionMemoRequest
   dco_decode_box_autoadd_wallet_edit_transaction_memo_request(dynamic raw);
 
@@ -189,6 +195,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   dco_decode_box_autoadd_wallet_prepare_pay_payment_request_request(
+    dynamic raw,
+  );
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  dco_decode_box_autoadd_wallet_prepare_pay_shared_payment_request_request(
     dynamic raw,
   );
 
@@ -506,6 +518,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   dco_decode_wallet_check_received_payment_request(dynamic raw);
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  dco_decode_wallet_create_shareable_remote_payment_request(dynamic raw);
+
+  @protected
+  WalletCreateShareableRemotePaymentResponse
+  dco_decode_wallet_create_shareable_remote_payment_response(dynamic raw);
+
+  @protected
   WalletCurrencyUnitResponse dco_decode_wallet_currency_unit_response(
     dynamic raw,
   );
@@ -640,6 +660,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   dco_decode_wallet_prepare_pay_payment_request_request(dynamic raw);
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  dco_decode_wallet_prepare_pay_shared_payment_request_request(dynamic raw);
 
   @protected
   WalletPreparePaymentByContactRequest
@@ -897,6 +921,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  sse_decode_box_autoadd_wallet_create_shareable_remote_payment_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletEditTransactionMemoRequest
   sse_decode_box_autoadd_wallet_edit_transaction_memo_request(
     SseDeserializer deserializer,
@@ -966,6 +996,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   sse_decode_box_autoadd_wallet_prepare_pay_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  sse_decode_box_autoadd_wallet_prepare_pay_shared_payment_request_request(
     SseDeserializer deserializer,
   );
 
@@ -1379,6 +1415,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  WalletCreateShareableRemotePaymentRequest
+  sse_decode_wallet_create_shareable_remote_payment_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletCreateShareableRemotePaymentResponse
+  sse_decode_wallet_create_shareable_remote_payment_response(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   WalletCurrencyUnitResponse sse_decode_wallet_currency_unit_response(
     SseDeserializer deserializer,
   );
@@ -1539,6 +1587,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   WalletPreparePayPaymentRequestRequest
   sse_decode_wallet_prepare_pay_payment_request_request(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  WalletPreparePaySharedPaymentRequestRequest
+  sse_decode_wallet_prepare_pay_shared_payment_request_request(
     SseDeserializer deserializer,
   );
 
@@ -1868,6 +1922,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_box_autoadd_wallet_create_shareable_remote_payment_request(
+    WalletCreateShareableRemotePaymentRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_box_autoadd_wallet_edit_transaction_memo_request(
     WalletEditTransactionMemoRequest self,
     SseSerializer serializer,
@@ -1942,6 +2002,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_wallet_prepare_pay_payment_request_request(
     WalletPreparePayPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_wallet_prepare_pay_shared_payment_request_request(
+    WalletPreparePaySharedPaymentRequestRequest self,
     SseSerializer serializer,
   );
 
@@ -2447,6 +2513,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_wallet_create_shareable_remote_payment_request(
+    WalletCreateShareableRemotePaymentRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_create_shareable_remote_payment_response(
+    WalletCreateShareableRemotePaymentResponse self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_wallet_currency_unit_response(
     WalletCurrencyUnitResponse self,
     SseSerializer serializer,
@@ -2644,6 +2722,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_wallet_prepare_pay_payment_request_request(
     WalletPreparePayPaymentRequestRequest self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_wallet_prepare_pay_shared_payment_request_request(
+    WalletPreparePaySharedPaymentRequestRequest self,
     SseSerializer serializer,
   );
 


### PR DESCRIPTION
* Add endpoints to create a shareable payment request and to pay such a request
    * `wallet_create_shareable_remote_payment_request`
        * takes `wallet_id`, `amount`, `description`
        * returns a string (base58 encoded, borsh-serialized payment request)
    * `wallet_prepare_pay_shared_payment_request`
        * takes `wallet_id`, `payment_request` (the string from above)
        * parses the request and prepares the given payment
        * returns `payment_summary`
    * `wallet_pay_shared_payment_request`
        * takes `wallet_id`, `payment_request_id` (the string from above)
        * executes the payment
    * In the case of a shareable payment request, no payment request is actually persisted in the wallet