### PR TITLE
Temporary Foreign-Mint-Funds Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.9.10
+
+* Store change from offline-tokens into a temporary-foreign-mint-proof-storage
+    * these foreign-mint-proofs are regularly attempted to reclaim in a job
+
 # 0.9.9
 
 * Fix Onchain Mint to not accrue swap fees (just unblind signatures and store them)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "async-utility"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34a3b57207a7a1007832416c3e4862378c8451b4e8e093e436f48c2d3d2c151"
+checksum = "188f83b9a198af8c336e505611edb00d6d2ac5c694241c5a4f9a12316938cfe9"
 dependencies = [
  "futures-util",
  "gloo-timers",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-api"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "bcr-common",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-cli"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "anyhow",
  "bcr-common",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-core"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "ammonia",
  "bcr-common",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-persistence"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "bcr-common",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "bcr-wallet-transport"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "bcr-common",
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -916,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1200,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "defmt"
@@ -1237,13 +1237,13 @@ dependencies = [
 
 [[package]]
 name = "delegate-attr"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
+checksum = "a84c9a9c129b98e707ac9a31e204c10c064dd9f949b7da362310ff1a8b137d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1278,13 +1278,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1349,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -1859,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2153,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2171,9 +2171,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -2195,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -2756,9 +2756,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2766,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2776,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2789,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
 ]
@@ -3182,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ca71a6a1a566e01ad6b3b87edcbf9bd3374c27e31978c1b4e38c9fa6412557d2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3288,9 +3288,9 @@ checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -3314,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3377,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3568,7 +3568,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -3856,9 +3856,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3936,13 +3936,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4000,9 +4000,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -4036,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -4321,7 +4321,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wallet_ffi"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "android_logger",
  "bcr-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.9.9"
+version = "0.9.10"
 edition = "2024"
 license = "MIT"
 

--- a/crates/bcr-wallet-api/src/external/mint.rs
+++ b/crates/bcr-wallet-api/src/external/mint.rs
@@ -16,7 +16,7 @@ use bcr_common::{
 };
 use bcr_wallet_core::{
     SendSync,
-    types::{MeltEstimation, MeltFeeRateEstimate},
+    types::{ClowderBeta, MeltEstimation, MeltFeeRateEstimate},
 };
 use bitcoin::secp256k1;
 use tracing::debug;
@@ -151,7 +151,7 @@ pub trait ClowderMintConnector: SendSync + std::fmt::Debug {
     ) -> MintResult<Vec<cashu::ProofState>>;
     async fn get_mint_keyset(&self, keyset_id: cashu::Id) -> MintResult<cashu::KeySet>;
     async fn get_mint_keysets(&self) -> MintResult<Vec<cashu::KeySetInfo>>;
-    async fn get_clowder_betas(&self) -> MintResult<Vec<url::Url>>;
+    async fn get_clowder_betas(&self) -> MintResult<Vec<ClowderBeta>>;
     async fn post_online_exchange(
         &self,
         alpha_proofs: Vec<Proof>,
@@ -326,10 +326,17 @@ impl ClowderMintConnector for HttpClientExt {
         self.main.get_substitute(&alpha_id).await
     }
 
-    async fn get_clowder_betas(&self) -> MintResult<Vec<url::Url>> {
+    async fn get_clowder_betas(&self) -> MintResult<Vec<ClowderBeta>> {
         debug!("Clowder client call to get_clowder_betas");
         let response = self.main.get_betas().await?;
-        Ok(response.mints.into_iter().map(|m| m.mint).collect())
+        Ok(response
+            .mints
+            .into_iter()
+            .map(|m| ClowderBeta {
+                url: m.mint,
+                clowder_id: m.node_id,
+            })
+            .collect())
     }
 
     async fn post_offline_exchange(
@@ -728,10 +735,17 @@ impl ClowderMintConnector for SentinelClient {
         self.main.get_substitute(&alpha_id).await
     }
 
-    async fn get_clowder_betas(&self) -> MintResult<Vec<url::Url>> {
+    async fn get_clowder_betas(&self) -> MintResult<Vec<ClowderBeta>> {
         debug!("Clowder client call to get_clowder_betas on sentinel");
         let response = self.main.get_betas().await?;
-        Ok(response.mints.into_iter().map(|m| m.mint).collect())
+        Ok(response
+            .mints
+            .into_iter()
+            .map(|m| ClowderBeta {
+                url: m.mint,
+                clowder_id: m.node_id,
+            })
+            .collect())
     }
 
     async fn post_offline_exchange(

--- a/crates/bcr-wallet-api/src/lib.rs
+++ b/crates/bcr-wallet-api/src/lib.rs
@@ -128,7 +128,7 @@ impl AppState {
             };
             match client.get_clowder_betas().await {
                 Ok(betas) => {
-                    w_cfg.betas = betas;
+                    w_cfg.betas = betas.into_iter().map(|b| b.url).collect();
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -983,6 +983,14 @@ impl AppState {
         Ok(cleaned_up)
     }
 
+    pub async fn wallet_reclaim_foreign_mint_proofs(&self, wallet_id: String) -> Result<u64> {
+        tracing::debug!("wallet_reclaim_foreign_mint_proofs({wallet_id})");
+        let wallet = self.get_wallet(&wallet_id).await?;
+        let wlt = wallet.read().await;
+        let reclaimed = wlt.reclaim_foreign_mint_proofs().await?;
+        Ok(reclaimed.to_u64())
+    }
+
     // Retry Nostr Messages
     pub async fn wallet_retry_nostr_messages(&self, wallet_id: String) -> Result<usize> {
         tracing::debug!("wallet_retry_nostr_messages({wallet_id})");
@@ -1153,6 +1161,22 @@ impl AppState {
                     );
                 }
             }
+            match self
+                .wallet_reclaim_foreign_mint_proofs(wallet_id.to_owned())
+                .await
+            {
+                Ok(sum) => {
+                    tracing::info!(
+                        "Reclaimed {sum} from foreign mint proofs for wallet {wallet_id}"
+                    );
+                }
+                Err(e) => {
+                    job_failed = true;
+                    tracing::error!(
+                        "Error running wallet_reclaim_foreign_mint_proofs job for wallet {wallet_id}: {e}"
+                    );
+                }
+            }
             match self.wallet_retry_nostr_messages(wallet_id.to_owned()).await {
                 Ok(retried) => {
                     tracing::info!("Retried {retried} nostr messages for wallet {wallet_id}");
@@ -1241,7 +1265,12 @@ async fn create_new_wallet(
         .into_iter()
         .map(|k| (k.id, k))
         .collect();
-    let betas = client.get_clowder_betas().await?;
+    let betas = client
+        .get_clowder_betas()
+        .await?
+        .into_iter()
+        .map(|b| b.url)
+        .collect();
     // Attempt to find debit unit in the given keysets
     let currencies = keyset_infos
         .values()

--- a/crates/bcr-wallet-api/src/pocket/debit.rs
+++ b/crates/bcr-wallet-api/src/pocket/debit.rs
@@ -13,7 +13,10 @@ use bcr_common::{
     core::swap::wallet::{PaymentPlan, prepare_payment},
     wire::{common as wire_common, melt as wire_melt, mint as wire_mint, swap as wire_swap},
 };
-use bcr_wallet_core::types::{MeltSummary, MintSummary, Seed, SendSummary, TransactionFees};
+use bcr_wallet_core::types::{
+    ForeignMintProof, ForeignMintProofReason, MeltSummary, MintSummary, Seed, SendSummary,
+    TransactionFees,
+};
 use bcr_wallet_persistence::{MeltCommitmentRecord, MintMeltRepository, PocketRepository};
 use bitcoin::secp256k1;
 use std::{
@@ -44,6 +47,12 @@ pub trait DebitPocketApi: super::PocketApi {
     ) -> Result<Amount>;
     /// Checks and cleans up spent proofs
     async fn clean_up_spent_proofs(&self, client: Arc<dyn ClowderMintConnector>) -> Result<usize>;
+    async fn fetch_foreign_mint_proofs(&self) -> Result<Vec<ForeignMintProof>>;
+    async fn delete_foreign_mint_proofs(
+        &self,
+        clowder_id: secp256k1::PublicKey,
+        ys: Vec<cdk01::PublicKey>,
+    );
     async fn prepare_onchain_melt(
         &self,
         address: String,
@@ -526,7 +535,8 @@ impl super::PocketApi for Pocket {
         proofs: Vec<cdk00::Proof>,
         keysets_info: &HashMap<cashu::Id, KeySetInfo>,
         keysets: HashMap<cashu::Id, KeySet>,
-        client: Arc<dyn ClowderMintConnector>,
+        substitute_client: Arc<dyn ClowderMintConnector>,
+        substitute_clowder_id: secp256k1::PublicKey,
         beta_provider: RandomBetaProvider,
         send_amount: Amount,
         swap_config: SwapConfig,
@@ -536,7 +546,7 @@ impl super::PocketApi for Pocket {
 
         let swap_plan: Vec<_> = prepare_swap(&proofs, keysets_info)?.into_iter().collect();
         tracing::debug!(
-            "Swapping to unlocked substitute proofs {swap_plan:?} - {change_amount} will be used for fees and/or lost."
+            "Swapping to unlocked substitute proofs {swap_plan:?} - {change_amount} will be used for fees and stored temporarily as foreign mint proofs."
         );
 
         // prepare the premints
@@ -581,7 +591,7 @@ impl super::PocketApi for Pocket {
 
         let attestation = beta_provider.attest(&proofs).await?;
         let signatures = super::committed_swap(
-            client.as_ref(),
+            substitute_client.as_ref(),
             None,
             proofs,
             blinds,
@@ -592,6 +602,8 @@ impl super::PocketApi for Pocket {
         .await?;
 
         let mut on_target: Vec<cdk00::Proof> = Vec::new();
+        let mut change_proofs: Vec<cdk00::Proof> = Vec::new();
+
         let mut sigs_by_kid: HashMap<cashu::Id, Vec<cdk00::BlindSignature>> = HashMap::new();
         for signature in signatures {
             sigs_by_kid
@@ -617,6 +629,8 @@ impl super::PocketApi for Pocket {
                     selected_amount_per_keyset += amount;
                     selected_amount += amount;
                     on_target.push(proof);
+                } else {
+                    change_proofs.push(proof);
                 }
             }
 
@@ -624,6 +638,28 @@ impl super::PocketApi for Pocket {
                 return Err(Error::Swap(format!(
                     "did not select exact payment proofs for keyset {kid}: {selected_amount_per_keyset} / {keyset_target_amount}"
                 )));
+            }
+        }
+
+        if !change_proofs.is_empty() {
+            let stored_change_amount = change_proofs.total_amount()?;
+
+            tracing::debug!(
+                "Storing {} unlocked change proofs for {stored_change_amount} for substitute {}",
+                change_proofs.len(),
+                substitute_client.mint_url()
+            );
+            for change_proof in change_proofs {
+                let fmp = ForeignMintProof {
+                    clowder_id: substitute_clowder_id,
+                    proof: change_proof,
+                    reason: ForeignMintProofReason::MintOffline,
+                };
+                if let Err(e) = self.pdb.store_foreign_mint_proof(fmp).await {
+                    tracing::error!(
+                        "Could not persist foreign mint proof for clowder_id {substitute_clowder_id}: {e}"
+                    );
+                }
             }
         }
 
@@ -794,6 +830,21 @@ impl DebitPocketApi for Pocket {
             }
         }
         Ok(cleaned_up)
+    }
+
+    async fn fetch_foreign_mint_proofs(&self) -> Result<Vec<ForeignMintProof>> {
+        let foreign_mint_proofs = self.pdb.load_foreign_mint_proofs().await?;
+        Ok(foreign_mint_proofs)
+    }
+
+    async fn delete_foreign_mint_proofs(
+        &self,
+        clowder_id: secp256k1::PublicKey,
+        ys: Vec<cdk01::PublicKey>,
+    ) {
+        if let Err(e) = self.pdb.delete_foreign_mint_proofs(clowder_id, ys).await {
+            tracing::error!("Could not delete foreign mint proof for {clowder_id}: {e}");
+        }
     }
 
     async fn prepare_onchain_melt(
@@ -1257,7 +1308,11 @@ mod tests {
     use super::*;
     use crate::{
         external::mint::{MeltQuoteResult, MockClowderMintConnector},
-        pocket::{PocketApi, debit::DebitPocketApi, test_utils::tests::test_kinfos},
+        pocket::{
+            PocketApi,
+            debit::DebitPocketApi,
+            test_utils::tests::{mock_commitment_result, test_kinfos},
+        },
     };
     use bcr_common::{core_tests, wire::mint::OnchainMintResponse};
     use bcr_wallet_persistence::{
@@ -2790,5 +2845,134 @@ mod tests {
             .unwrap();
 
         assert_eq!(cleaned, 2);
+    }
+
+    #[tokio::test]
+    async fn swap_to_unlocked_substitute_proofs_returns_payment_and_stores_change() {
+        let (info, mint_keyset) = core_tests::generate_random_ecash_keyset();
+        let kid = info.id;
+
+        let keysets_info = test_kinfos(info);
+        let keyset = bcr_wallet_core::util::to_keyset(&mint_keyset, None);
+        let keysets = HashMap::from([(kid, keyset)]);
+
+        // 24 total, 16 payment, 8 change
+        let input_proofs = core_tests::generate_random_ecash_proofs(
+            &mint_keyset,
+            &[Amount::from(8u64), Amount::from(16u64)],
+        );
+
+        let send_amount = Amount::from(16u64);
+        let expected_change_amount = Amount::from(8u64);
+
+        let substitute_keypair = secp256k1::Keypair::new_global(&mut secp256k1::rand::thread_rng());
+        let substitute_clowder_id = secp256k1::PublicKey::from_keypair(&substitute_keypair);
+        let mdb = MockMintMeltRepository::new();
+        let mut pdb = MockPocketRepository::new();
+        let mut substitute_client = MockClowderMintConnector::new();
+
+        substitute_client
+            .expect_post_swap_commitment()
+            .times(1)
+            .returning(|_, _, _, _, _| Ok(mock_commitment_result()));
+
+        let signing_keyset = mint_keyset.clone();
+        substitute_client
+            .expect_post_swap_committed()
+            .times(1)
+            .returning(move |_inputs, outputs, _commitment| {
+                let amounts = outputs
+                    .iter()
+                    .map(|output| output.amount)
+                    .collect::<Vec<_>>();
+
+                Ok(core_tests::generate_ecash_signatures(
+                    &signing_keyset,
+                    &amounts,
+                ))
+            });
+
+        // collect stored changed proofs
+        let stored_foreign_proofs = Arc::new(Mutex::new(Vec::<ForeignMintProof>::new()));
+        let stored_foreign_proofs_clone = stored_foreign_proofs.clone();
+        let expected_clowder_id = substitute_clowder_id;
+
+        pdb.expect_store_foreign_mint_proof()
+            .times(1)
+            .returning(move |foreign_proof| {
+                assert_eq!(foreign_proof.clowder_id, expected_clowder_id);
+                assert!(matches!(
+                    foreign_proof.reason,
+                    ForeignMintProofReason::MintOffline
+                ));
+                assert!(foreign_proof.proof.witness.is_none());
+
+                let y = foreign_proof
+                    .proof
+                    .y()
+                    .expect("stored change proof has valid y");
+
+                stored_foreign_proofs_clone
+                    .lock()
+                    .expect("stored proof mutex")
+                    .push(foreign_proof);
+
+                Ok(y)
+            });
+
+        let swap_config = test_swap_config();
+        let mut beta_connector = MockClowderMintConnector::new();
+        setup_attestation_mock(&mut beta_connector);
+        let beta_provider = RandomBetaProvider::new(
+            vec![Arc::new(beta_connector) as Arc<dyn crate::ClowderMintConnector>],
+            swap_config.alpha_pk,
+        )
+        .expect("can create beta provider");
+
+        let pocket = pocket(Arc::new(pdb), Arc::new(mdb));
+        let payment_proofs = pocket
+            .swap_to_unlocked_substitute_proofs(
+                input_proofs,
+                &keysets_info,
+                keysets,
+                Arc::new(substitute_client),
+                substitute_clowder_id,
+                beta_provider,
+                send_amount,
+                swap_config,
+            )
+            .await
+            .expect("swap to unlocked substitute proofs works");
+
+        assert_eq!(payment_proofs.total_amount().unwrap(), send_amount);
+        assert!(
+            payment_proofs
+                .iter()
+                .all(|proof| { proof.witness.is_none() && proof.p2pk_e.is_none() })
+        );
+
+        let stored_foreign_proofs = stored_foreign_proofs.lock().expect("stored proof mutex");
+        assert_eq!(stored_foreign_proofs.len(), 1);
+        assert_eq!(
+            stored_foreign_proofs
+                .iter()
+                .map(|entry| entry.proof.clone())
+                .collect::<Vec<_>>()
+                .total_amount()
+                .unwrap(),
+            expected_change_amount
+        );
+
+        // payment_proofs + stored_foreign_proofs = total amount
+        assert_eq!(
+            payment_proofs.total_amount().unwrap()
+                + stored_foreign_proofs
+                    .iter()
+                    .map(|fmp| fmp.proof.clone())
+                    .collect::<Vec<_>>()
+                    .total_amount()
+                    .unwrap(),
+            Amount::from(24u64)
+        );
     }
 }

--- a/crates/bcr-wallet-api/src/pocket/mod.rs
+++ b/crates/bcr-wallet-api/src/pocket/mod.rs
@@ -65,13 +65,13 @@ pub trait PocketApi: SendSync {
         &self,
         rid: Uuid,
     ) -> Result<(Amount, HashMap<cashu::PublicKey, cashu::Proof>)>;
-    /// WARN: Only used for hacky offline pay by token - will be removed
     async fn swap_to_unlocked_substitute_proofs(
         &self,
         proofs: Vec<cashu::Proof>,
         keysets_info: &HashMap<cashu::Id, KeySetInfo>,
         keysets: HashMap<cashu::Id, KeySet>,
-        client: Arc<dyn ClowderMintConnector>,
+        substitute_client: Arc<dyn ClowderMintConnector>,
+        substitute_clowder_id: secp256k1::PublicKey,
         beta_provider: RandomBetaProvider,
         send_amount: Amount,
         swap_config: SwapConfig,

--- a/crates/bcr-wallet-api/src/pocket/test_utils.rs
+++ b/crates/bcr-wallet-api/src/pocket/test_utils.rs
@@ -147,7 +147,8 @@ pub mod tests {
                 proofs: Vec<cashu::Proof>,
                 keysets_info: &HashMap<cashu::Id, KeySetInfo>,
                 keysets: HashMap<cashu::Id, cashu::KeySet>,
-                client: Arc<dyn ClowderMintConnector>,
+                substitute_client: Arc<dyn ClowderMintConnector>,
+                substitute_clowder_id: secp256k1::PublicKey,
                 beta_provider: crate::pocket::RandomBetaProvider,
                 send_amount: Amount,
                 swap_config: SwapConfig,
@@ -176,6 +177,8 @@ pub mod tests {
                 swap_config: SwapConfig,
             ) -> Result<Amount>;
             async fn clean_up_spent_proofs(&self, client: Arc<dyn ClowderMintConnector>) -> Result<usize>;
+            async fn fetch_foreign_mint_proofs(&self) -> Result<Vec<bcr_wallet_core::types::ForeignMintProof>>;
+            async fn delete_foreign_mint_proofs(&self, clowder_id: secp256k1::PublicKey, ys: Vec<cashu::PublicKey>);
             async fn prepare_onchain_melt(
                 &self,
                 address: String,

--- a/crates/bcr-wallet-api/src/wallet/api.rs
+++ b/crates/bcr-wallet-api/src/wallet/api.rs
@@ -1050,8 +1050,8 @@ impl WalletApi for super::Wallet {
         let mut beta_clients = HashMap::<url::Url, Arc<dyn ClowderMintConnector>>::new();
 
         for beta in self.client.as_ref().get_clowder_betas().await? {
-            let beta_client = (self.client_factory)(beta.clone());
-            beta_clients.insert(beta, beta_client);
+            let beta_client = (self.client_factory)(beta.url.clone());
+            beta_clients.insert(beta.url, beta_client);
         }
         self.beta_clients = beta_clients;
 
@@ -1142,15 +1142,12 @@ impl WalletApi for super::Wallet {
         Ok(summary)
     }
 
-    // This is a temporary solution for demoing the concept, which has some gaping holes
-    // The process is:
     // * Check if our alpha is offline
     // * If it is, determine the substitute
     // * Get proofs for the given amount (including the swap proof), mark them as pendingspent
     // * Do an offline-exchange from our alpha to the substitute (for all the fetched proofs)
     // * Swap the substitute proofs against the substitute beta, to the target amount
-    //   * => This means, that overlap from swapping to target is currently lost, since there's no good way to store other-mint-proofs in the Wallet for now
-    //   * => In the future, we could persist them in a special storage and, once our alpha is back online, attempt to swap them back
+    //   * Change is persisted as foreign mint proofs and attempted to be reclaimed regularly
     // * Create Token from swapped target proofs and return Token
     async fn offline_pay_by_token(
         &self,
@@ -1179,8 +1176,8 @@ impl WalletApi for super::Wallet {
             let mut beta_clients = HashMap::<url::Url, Arc<dyn ClowderMintConnector>>::new();
 
             for beta in substitute_client.as_ref().get_clowder_betas().await? {
-                let beta_client = (self.client_factory)(beta.clone());
-                beta_clients.insert(beta, beta_client);
+                let beta_client = (self.client_factory)(beta.url.clone());
+                beta_clients.insert(beta.url, beta_client);
             }
 
             let beta_provider = RandomBetaProvider::new(
@@ -1195,6 +1192,16 @@ impl WalletApi for super::Wallet {
                 .debit
                 .return_proofs_to_send_for_offline_payment(request_id)
                 .await?;
+            // TODO: just for demo - remove afterwards
+            tracing::warn!(
+                "Offline Pay by Token - Local Token: {}",
+                Token::new_bitcr(
+                    to_mint_url(self.client.mint_url()),
+                    local_proofs.clone().into_values().collect(),
+                    None,
+                    self.debit.unit(),
+                )
+            );
             tracing::debug!("Offline Pay by Token: Offline Exchange");
             // Do offline exchange
             let substitute_proofs = self
@@ -1233,6 +1240,7 @@ impl WalletApi for super::Wallet {
                     &keysets_info,
                     keysets,
                     substitute_client.clone(),
+                    substitute_clowder_id,
                     beta_provider,
                     send_amount,
                     swap_config,

--- a/crates/bcr-wallet-api/src/wallet/mod.rs
+++ b/crates/bcr-wallet-api/src/wallet/mod.rs
@@ -25,9 +25,9 @@ use bcr_wallet_core::{
     contact::Contact,
     event::{ContactPaymentPayload, EventEnvelope},
     types::{
-        ListTransactionsResult, PaymentRequest, PaymentType, Transaction, TransactionCursor,
-        TransactionFees, TransactionFilters, TransactionLinkReason, TransactionSort,
-        TransactionStatus, extract_fees_per_month,
+        ClowderBeta, ForeignMintProof, ListTransactionsResult, PaymentRequest, PaymentType,
+        Transaction, TransactionCursor, TransactionFees, TransactionFilters, TransactionLinkReason,
+        TransactionSort, TransactionStatus, extract_fees_per_month,
     },
     util::{from_mint_url, to_mint_url},
 };
@@ -590,6 +590,78 @@ impl Wallet {
         Ok(cleaned_up)
     }
 
+    pub async fn reclaim_foreign_mint_proofs(&self) -> Result<Amount> {
+        // if our mint is offline, we can't reclaim
+        if self.is_wallet_mint_offline().await? {
+            tracing::warn!(
+                "Attempting to reclaim foreign mint proofs, but wallet mint is offline - trying again on the next run."
+            );
+            return Ok(Amount::ZERO);
+        }
+        // we treat all foreign mint proofs the same - it's possible we have foreign mint proofs from our own mint in case we migrated
+        let mut all_mints = self.client.get_clowder_betas().await?;
+        all_mints.push(ClowderBeta {
+            clowder_id: self.clowder_id,
+            url: self.client.mint_url().to_owned(),
+        });
+        // get foreign mint proofs and collect by clowder id
+        let foreign_mint_proofs = self.debit.fetch_foreign_mint_proofs().await?;
+        let fmps_by_clowder_id: HashMap<secp256k1::PublicKey, Vec<ForeignMintProof>> =
+            foreign_mint_proofs
+                .into_iter()
+                .fold(HashMap::new(), |mut map, item| {
+                    map.entry(item.clowder_id).or_default().push(item);
+                    map
+                });
+
+        let mut reclaimed = Amount::ZERO;
+
+        // create tokens and attempt to reclaim
+        // if it's from our own mint, create a token and swap it to be safe
+        // if it's from another mint, create a token and do an intermint swap
+        for mint in all_mints.iter() {
+            if let Some(fmps) = fmps_by_clowder_id.get(&mint.clowder_id)
+                && !fmps.is_empty()
+            {
+                let proofs: Vec<Proof> = fmps.iter().map(|fmp| fmp.proof.clone()).collect();
+                let ys: Vec<cashu::PublicKey> = proofs
+                    .iter()
+                    .map(|proof| proof.y().expect("proof has valid y"))
+                    .collect();
+                let amount = proofs.total_amount()?;
+                let token = Token::new_bitcr(
+                    to_mint_url(&mint.url),
+                    proofs,
+                    Some(format!("Reclaimed Foreign Mint Funds from {}", mint.url)),
+                    self.debit_unit(),
+                );
+                match self
+                    .receive_token(token, Utc::now().timestamp() as u64)
+                    .await
+                {
+                    Ok(tx_id) => {
+                        tracing::info!(
+                            "Reclaimed {amount} from foreign mint proofs from {}, tx_id: {tx_id}",
+                            mint.url
+                        );
+                        reclaimed += amount;
+                        // if everything went well, delete the foreign mint proofs
+                        self.debit
+                            .delete_foreign_mint_proofs(mint.clowder_id, ys)
+                            .await;
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Could not reclaim foreign mint proofs from mint {}: {e}",
+                            mint.url
+                        );
+                    }
+                }
+            }
+        }
+        Ok(reclaimed)
+    }
+
     /// Check that the transaction can be reclaimed, then
     /// * Create a new transaction with state `Canceled`
     /// * Set the initial transaction to `Settled`
@@ -864,7 +936,7 @@ impl Wallet {
         let alpha_betas = alpha_client.get_clowder_betas().await?;
         let alpha_beta_clients: Vec<_> = alpha_betas
             .iter()
-            .map(|url| (self.client_factory)(url.clone()))
+            .map(|b| (self.client_factory)(b.url.clone()))
             .collect();
         let alpha_beta =
             crate::pocket::RandomBetaProvider::new(alpha_beta_clients, path[0].node_id)?;
@@ -1179,8 +1251,8 @@ mod tests {
         event::ContactPaymentRequestPayload,
         name::Name,
         types::{
-            MintSummary, PaymentRequestDirection, PaymentRequestState, PaymentResultCallback,
-            TimeRange, TransactionFees,
+            ClowderBeta, ForeignMintProofReason, MintSummary, PaymentRequestDirection,
+            PaymentRequestState, PaymentResultCallback, TimeRange, TransactionFees,
         },
     };
     use bcr_wallet_persistence::{
@@ -3753,7 +3825,12 @@ mod tests {
         alpha_client
             .expect_get_clowder_betas()
             .times(1)
-            .returning(move || Ok(vec![url_clone.clone()]));
+            .returning(move || {
+                Ok(vec![ClowderBeta {
+                    url: url_clone.clone(),
+                    clowder_id: test_pub_key(),
+                }])
+            });
 
         alpha_client
             .expect_get_mint_keysets()
@@ -4088,5 +4165,317 @@ mod tests {
 
         assert_eq!(res_tx_id, tx_id);
         assert!(token.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_reclaim_foreign_mint_proofs_success() {
+        let mut ctx = wallet_ctx();
+
+        let mint_url = url::Url::from_str("https://mint.example").unwrap();
+        let clowder_id = test_pub_key();
+        let tx_id = Uuid::new_v4();
+
+        let (info, _keyset, proofs) = test_keyset_and_proofs(&[Amount::from(8), Amount::from(16)]);
+
+        let keyset_infos = HashMap::from([(info.id, info.clone())]);
+
+        let expected_ys: Vec<cashu::PublicKey> = proofs
+            .iter()
+            .map(|proof| proof.y().expect("valid proof y"))
+            .collect();
+
+        let foreign_mint_proofs = vec![
+            ForeignMintProof {
+                clowder_id,
+                proof: proofs[0].clone(),
+                reason: ForeignMintProofReason::MintOffline,
+            },
+            ForeignMintProof {
+                clowder_id,
+                proof: proofs[1].clone(),
+                reason: ForeignMintProofReason::WalletOffline,
+            },
+        ];
+
+        ctx.client
+            .expect_get_clowder_betas()
+            .times(1)
+            .returning(|| Ok(vec![]));
+
+        ctx.client.expect_mint_url().return_const(mint_url.clone());
+
+        ctx.client
+            .expect_get_mint_keysets()
+            .times(1)
+            .returning(move || Ok(keyset_infos.values().cloned().collect()));
+
+        ctx.debit
+            .expect_fetch_foreign_mint_proofs()
+            .times(1)
+            .return_once(move || Ok(foreign_mint_proofs));
+
+        ctx.debit.expect_unit().returning(|| CurrencyUnit::Sat);
+
+        let received_ys = expected_ys.clone();
+
+        ctx.debit.expect_receive_proofs().times(1).return_once(
+            move |_client, received_keysets, received_proofs, _swap_config| {
+                assert!(received_keysets.contains_key(&info.id));
+                assert_eq!(received_proofs.len(), 2);
+                assert_eq!(received_proofs.total_amount().unwrap(), Amount::from(24),);
+
+                Ok((Amount::from(24), received_ys))
+            },
+        );
+
+        let deleted_ys = expected_ys.clone();
+        ctx.debit
+            .expect_delete_foreign_mint_proofs()
+            .times(1)
+            .withf(move |actual_clowder_id, actual_ys| {
+                *actual_clowder_id == clowder_id && *actual_ys == deleted_ys
+            })
+            .returning(|_, _| ());
+
+        ctx.tx_repo
+            .expect_store_tx()
+            .times(1)
+            .return_once(move |tx| {
+                assert_eq!(tx.direction, TransactionDirection::Incoming,);
+                assert_eq!(tx.amount, Amount::from(24));
+                assert_eq!(tx.fees.swap, Amount::ZERO);
+                assert_eq!(tx.unit, CurrencyUnit::Sat);
+                assert_eq!(tx.payment_type, PaymentType::Token);
+                assert_eq!(tx.status, TransactionStatus::Settled,);
+
+                Ok(tx_id)
+            });
+
+        let wlt = wallet(ctx).await;
+        let reclaimed = wlt
+            .read()
+            .await
+            .reclaim_foreign_mint_proofs()
+            .await
+            .expect("reclaim_foreign_mint_proofs works");
+        assert_eq!(reclaimed, Amount::from(24));
+    }
+
+    #[tokio::test]
+    async fn test_offline_pay_by_token() {
+        let mut ctx = wallet_ctx();
+
+        let request_id = Uuid::new_v4();
+        let tx_id = Uuid::new_v4();
+        let now = 123;
+        let send_amount = Amount::from(16u64);
+        let fees = TransactionFees {
+            swap: Amount::from(1u64),
+            ..Default::default()
+        };
+        let memo = Some("offline token payment".to_string());
+        let wallet_mint_url = url::Url::from_str("https://wallet-mint.example").unwrap();
+        let substitute_url = url::Url::from_str("https://substitute.example").unwrap();
+        let substitute_beta_url = url::Url::from_str("https://substitute-beta.example").unwrap();
+
+        let substitute_keypair = secp256k1::Keypair::new_global(&mut secp256k1::rand::thread_rng());
+        let substitute_clowder_id = secp256k1::PublicKey::from_keypair(&substitute_keypair);
+
+        // 24 total, 16 payment, 8 change
+        let (_local_info, _local_keyset, mut local_proofs) =
+            test_keyset_and_proofs(&[Amount::from(8u64), Amount::from(16u64)]);
+
+        add_test_dleqs(&mut local_proofs);
+        let local_proofs_by_y: HashMap<_, _> = local_proofs
+            .iter()
+            .cloned()
+            .map(|proof| (proof.y().unwrap(), proof))
+            .collect();
+
+        let (substitute_info, substitute_mint_keyset, mut substitute_proofs) =
+            test_keyset_and_proofs(&[Amount::from(8u64), Amount::from(16u64)]);
+        let substitute_kid = substitute_info.id;
+        add_test_dleqs(&mut substitute_proofs);
+        let unlocked_payment_proofs =
+            core_tests::generate_random_ecash_proofs(&substitute_mint_keyset, &[send_amount]);
+        assert!(
+            unlocked_payment_proofs
+                .iter()
+                .all(|proof| { proof.witness.is_none() && proof.p2pk_e.is_none() })
+        );
+
+        let expected_payment_ys: Vec<_> = unlocked_payment_proofs
+            .iter()
+            .map(|proof| proof.y().unwrap())
+            .collect();
+
+        ctx.client
+            .expect_mint_url()
+            .return_const(wallet_mint_url.clone());
+
+        ctx.debit.expect_unit().returning(|| CurrencyUnit::Sat);
+
+        let local_proofs_for_mock = local_proofs_by_y.clone();
+
+        ctx.debit
+            .expect_return_proofs_to_send_for_offline_payment()
+            .times(1)
+            .return_once(move |actual_request_id| {
+                assert_eq!(actual_request_id, request_id);
+
+                Ok((send_amount, local_proofs_for_mock))
+            });
+
+        let unlocked_payment_proofs_for_mock = unlocked_payment_proofs.clone();
+        ctx.debit
+            .expect_swap_to_unlocked_substitute_proofs()
+            .times(1)
+            .return_once(
+                move |received_substitute_proofs,
+                      received_keyset_infos,
+                      received_keysets,
+                      _substitute_client,
+                      received_clowder_id,
+                      _beta_provider,
+                      received_send_amount,
+                      received_swap_config| {
+                    assert_eq!(
+                        received_substitute_proofs.total_amount().unwrap(),
+                        Amount::from(24u64)
+                    );
+                    assert!(
+                        received_substitute_proofs
+                            .iter()
+                            .all(|proof| proof.witness.is_some())
+                    );
+                    assert_eq!(received_clowder_id, substitute_clowder_id);
+                    assert_eq!(received_send_amount, send_amount);
+                    assert_eq!(received_swap_config.alpha_pk, substitute_clowder_id);
+                    assert_eq!(received_swap_config.expiry, chrono::TimeDelta::seconds(60));
+                    assert!(received_keyset_infos.contains_key(&substitute_kid));
+                    assert!(received_keysets.contains_key(&substitute_kid));
+                    Ok(unlocked_payment_proofs_for_mock)
+                },
+            );
+
+        let expected_ys_for_tx = expected_payment_ys.clone();
+        let expected_memo_for_tx = memo.clone();
+        let expected_substitute_url_for_tx = substitute_url.clone();
+
+        ctx.tx_repo
+            .expect_store_tx()
+            .times(1)
+            .return_once(move |tx| {
+                assert_eq!(tx.mint_url, to_mint_url(&expected_substitute_url_for_tx));
+                assert_eq!(tx.direction, TransactionDirection::Outgoing);
+                assert_eq!(tx.amount, send_amount);
+                assert_eq!(tx.fees.swap, Amount::from(1u64));
+                assert_eq!(tx.fees.melt, Amount::ZERO);
+                assert_eq!(tx.fees.network, Amount::ZERO);
+                assert_eq!(tx.unit, CurrencyUnit::Sat);
+                assert_eq!(tx.tstamp, now);
+                assert_eq!(tx.memo, expected_memo_for_tx);
+                assert_eq!(tx.payment_type, PaymentType::Token);
+                assert_eq!(tx.status, TransactionStatus::Pending);
+                assert_eq!(tx.ys, expected_ys_for_tx);
+                assert!(tx.quote_id.is_none());
+                assert!(tx.payment_request_id.is_none());
+                assert!(tx.nostr_event_id.is_none());
+                assert!(tx.btc_tx_id.is_none());
+                assert!(tx.contact_node_id.is_none());
+
+                Ok(tx_id)
+            });
+
+        let mut substitute_client = MockClowderMintConnector::new();
+        let voted_substitute_url = substitute_url.clone();
+        substitute_client
+            .expect_get_alpha_substitute()
+            .times(1)
+            .return_once(move |_wallet_clowder_id| {
+                Ok(wire_clowder::ConnectedMintResponse {
+                    mint: voted_substitute_url,
+                    clowder: url::Url::from_str("https://substitute-clowder.example").unwrap(),
+                    node_id: substitute_clowder_id,
+                })
+            });
+        substitute_client
+            .expect_get_clowder_id()
+            .times(1)
+            .returning(move || Ok(substitute_clowder_id));
+
+        let beta_url_for_response = substitute_beta_url.clone();
+        substitute_client
+            .expect_get_clowder_betas()
+            .times(1)
+            .return_once(move || {
+                Ok(vec![ClowderBeta {
+                    url: beta_url_for_response,
+                    clowder_id: test_pub_key(),
+                }])
+            });
+        let exchanged_proofs_for_mock = substitute_proofs.clone();
+        substitute_client
+            .expect_post_offline_exchange()
+            .times(1)
+            .return_once(
+                move |fingerprints,
+                      hash_locks,
+                      _wallet_public_key,
+                      received_substitute_clowder_id| {
+                    assert_eq!(fingerprints.len(), 2);
+                    assert_eq!(hash_locks.len(), 2);
+                    assert_eq!(received_substitute_clowder_id, substitute_clowder_id);
+
+                    Ok(exchanged_proofs_for_mock)
+                },
+            );
+        let substitute_info_for_mock = substitute_info.clone();
+        substitute_client
+            .expect_get_mint_keysets()
+            .times(1)
+            .return_once(move || Ok(vec![substitute_info_for_mock]));
+
+        let substitute_keyset_for_mock = substitute_mint_keyset.clone();
+        substitute_client
+            .expect_get_mint_keyset()
+            .times(1)
+            .return_once(move |received_kid| {
+                assert_eq!(received_kid, substitute_kid);
+
+                Ok(bcr_wallet_core::util::to_keyset(
+                    &substitute_keyset_for_mock,
+                    None,
+                ))
+            });
+
+        let substitute_client: Arc<dyn ClowderMintConnector> = Arc::new(substitute_client);
+        let substitute_beta: Arc<dyn ClowderMintConnector> =
+            Arc::new(MockClowderMintConnector::new());
+
+        let mut wlt = wallet(ctx).await;
+        wlt = wallet_with_betas(wlt, vec![(substitute_url.clone(), substitute_client)]).await;
+        let expected_factory_url = substitute_beta_url.clone();
+        wlt.write().await.client_factory = Box::new(move |actual_url| {
+            assert_eq!(actual_url, expected_factory_url);
+            substitute_beta.clone()
+        });
+
+        let (result_tx_id, token) = wlt
+            .read()
+            .await
+            .offline_pay_by_token(request_id, CurrencyUnit::Sat, fees, memo.clone(), now)
+            .await
+            .expect("offline token payment works");
+        assert_eq!(result_tx_id, tx_id);
+        let token = token.expect("offline token payment returns a token");
+        assert_eq!(from_mint_url(&token.mint_url()), substitute_url);
+        assert_eq!(token.unit(), Some(CurrencyUnit::Sat));
+        assert_eq!(token.memo().as_deref(), memo.as_deref());
+        let token_proofs = token
+            .proofs(&[substitute_info])
+            .expect("returned token contains valid substitute proofs");
+        assert_eq!(token_proofs.total_amount().unwrap(), send_amount);
+        assert_eq!(token_proofs.len(), 1);
     }
 }

--- a/crates/bcr-wallet-cli/bob.toml
+++ b/crates/bcr-wallet-cli/bob.toml
@@ -4,8 +4,8 @@ esplora_base_urls = ["https://esplora.minibill.tech", "https://blockstream.info"
 
 [wallets.49b81beaed5cdd051ff5070906be2d8c17508ddb01436f5d6e56216d6f634c0c]
 network = "testnet"
-nostr_relays = ["wss://relay.wildcat0.clowder-dev.minibill.tech", "wss://relay.wildcat1.clowder-dev.minibill.tech"]
-mint_url = "https://mint.wildcat1.clowder-dev.minibill.tech"
+nostr_relays = ["wss://relay.wildcat0.clowder-dev.minibill.tech", "wss://relay.wildcat1.clowder-dev.minibill.tech", "wss://relay.wildcat3.clowder-dev.minibill.tech"]
+mint_url = "https://mint.wildcat3.clowder-dev.minibill.tech"
 mnemonic = "struggle toilet attitude trim obey grab alter apology across bamboo palm naive"
 
 [wallets.9b0ade58c90766fc6c4313dde1769b1146a60e0f6407919fbd41053e93c78030]

--- a/crates/bcr-wallet-core/src/types.rs
+++ b/crates/bcr-wallet-core/src/types.rs
@@ -461,6 +461,25 @@ pub struct MeltFeeRateEstimate {
     pub sat_per_vb: f32,
 }
 
+#[derive(Debug, Clone)]
+pub struct ForeignMintProof {
+    pub clowder_id: secp256k1::PublicKey,
+    pub proof: cashu::Proof,
+    pub reason: ForeignMintProofReason,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ForeignMintProofReason {
+    MintOffline,
+    WalletOffline,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClowderBeta {
+    pub url: url::Url,
+    pub clowder_id: secp256k1::PublicKey,
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/crates/bcr-wallet-persistence/src/lib.rs
+++ b/crates/bcr-wallet-persistence/src/lib.rs
@@ -10,8 +10,8 @@ use bcr_common::cashu::{self, nut00 as cdk00, nut01 as cdk01, nut07 as cdk07};
 use bcr_common::core::NodeId;
 use bcr_wallet_core::contact::Contact;
 use bcr_wallet_core::types::{
-    PaymentRequestDirection, PaymentRequestState, Transaction, TransactionLinkReason,
-    TransactionStatus,
+    ForeignMintProof, PaymentRequestDirection, PaymentRequestState, Transaction,
+    TransactionLinkReason, TransactionStatus,
 };
 use bcr_wallet_core::{
     SendSync,
@@ -80,6 +80,17 @@ pub trait PocketRepository: SendSync {
     async fn delete_commitment(&self, commitment: secp256k1::schnorr::Signature) -> Result<()>;
     async fn list_commitments(&self) -> Result<Vec<SwapCommitmentRecord>>;
     async fn delete_repo(&self) -> Result<()>;
+
+    async fn store_foreign_mint_proof(
+        &self,
+        foreign_mint_proof: ForeignMintProof,
+    ) -> Result<cdk01::PublicKey>;
+    async fn load_foreign_mint_proofs(&self) -> Result<Vec<ForeignMintProof>>;
+    async fn delete_foreign_mint_proofs(
+        &self,
+        clowder_id: secp256k1::PublicKey,
+        ys: Vec<cdk01::PublicKey>,
+    ) -> Result<()>;
 }
 
 ///////////////////////////////////////////// PurseRepository

--- a/crates/bcr-wallet-persistence/src/redb/pocket.rs
+++ b/crates/bcr-wallet-persistence/src/redb/pocket.rs
@@ -16,12 +16,120 @@ use bcr_common::wire::borsh::{
 use bcr_wallet_core::{
     borsh::{deserialize_premints, serialize_premints},
     crypto,
+    types::{ForeignMintProof, ForeignMintProofReason},
 };
 use bitcoin::secp256k1;
 use borsh::{BorshDeserialize, BorshSerialize};
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition, TableError};
 use std::{collections::HashMap, sync::Arc};
 use tokio::task::spawn_blocking;
+
+/// Foreign Mint Proof Key is a composite of the clowder_id and the proof y
+const COMPRESSED_PUBLIC_KEY_LEN: usize = 33;
+const FOREIGN_MINT_PROOF_KEY_LEN: usize = COMPRESSED_PUBLIC_KEY_LEN * 2;
+
+type ForeignMintProofKey = [u8; FOREIGN_MINT_PROOF_KEY_LEN];
+
+fn foreign_mint_proof_key(
+    clowder_id: &secp256k1::PublicKey,
+    y: &cdk01::PublicKey,
+) -> ForeignMintProofKey {
+    let mut key = [0u8; FOREIGN_MINT_PROOF_KEY_LEN];
+    key[..COMPRESSED_PUBLIC_KEY_LEN].copy_from_slice(&clowder_id.serialize());
+    key[COMPRESSED_PUBLIC_KEY_LEN..].copy_from_slice(y.to_bytes().as_slice());
+    key
+}
+
+/// StoredForeignMintProof is a versioned, encrypted, borsh-serialized foreign mint proof
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) enum StoredForeignMintProof {
+    V1(EncryptedForeignMintProofPayloadV1),
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) struct EncryptedForeignMintProofPayloadV1 {
+    pub ciphertext: Vec<u8>,
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub(super) struct StoredForeignMintProofPayloadV1 {
+    #[borsh(
+        serialize_with = "serialize_as_str",
+        deserialize_with = "deserialize_from_str"
+    )]
+    pub clowder_id: secp256k1::PublicKey,
+    pub proof: StoredProofPayloadV1,
+    pub reason: ForeignMintProofReasonV1,
+}
+
+impl From<ForeignMintProof> for StoredForeignMintProofPayloadV1 {
+    fn from(value: ForeignMintProof) -> Self {
+        Self {
+            clowder_id: value.clowder_id,
+            proof: value.proof.into(),
+            reason: value.reason.into(),
+        }
+    }
+}
+
+impl From<StoredForeignMintProofPayloadV1> for ForeignMintProof {
+    fn from(value: StoredForeignMintProofPayloadV1) -> Self {
+        Self {
+            clowder_id: value.clowder_id,
+            proof: value.proof.into(),
+            reason: value.reason.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub enum ForeignMintProofReasonV1 {
+    MintOffline,
+    WalletOffline,
+}
+
+impl From<ForeignMintProofReason> for ForeignMintProofReasonV1 {
+    fn from(value: ForeignMintProofReason) -> Self {
+        match value {
+            ForeignMintProofReason::MintOffline => ForeignMintProofReasonV1::MintOffline,
+            ForeignMintProofReason::WalletOffline => ForeignMintProofReasonV1::WalletOffline,
+        }
+    }
+}
+
+impl From<ForeignMintProofReasonV1> for ForeignMintProofReason {
+    fn from(value: ForeignMintProofReasonV1) -> Self {
+        match value {
+            ForeignMintProofReasonV1::MintOffline => ForeignMintProofReason::MintOffline,
+            ForeignMintProofReasonV1::WalletOffline => ForeignMintProofReason::WalletOffline,
+        }
+    }
+}
+
+pub(super) fn to_stored_foreign_mint_proof_v1(
+    proof: ForeignMintProof,
+    keys: bitcoin::secp256k1::Keypair,
+) -> Result<StoredForeignMintProof> {
+    let payload = StoredForeignMintProofPayloadV1::from(proof);
+    let encoded = borsh::to_vec(&payload).map_err(|e| Error::BorshSerialization(e.to_string()))?;
+    let encrypted = crypto::encrypt_ecies(&encoded, &keys.public_key())?;
+    Ok(StoredForeignMintProof::V1(
+        EncryptedForeignMintProofPayloadV1 {
+            ciphertext: encrypted,
+        },
+    ))
+}
+
+pub(super) fn from_stored_foreign_mint_proof_v1(
+    proof: StoredForeignMintProof,
+    keys: bitcoin::secp256k1::Keypair,
+) -> Result<ForeignMintProof> {
+    let StoredForeignMintProof::V1(encrypted_payload) = proof;
+    let decrypted = crypto::decrypt_ecies(&encrypted_payload.ciphertext, &keys.secret_key())?;
+    let decoded: StoredForeignMintProofPayloadV1 =
+        borsh::from_slice(&decrypted).map_err(|e| Error::BorshSerialization(e.to_string()))?;
+    Ok(decoded.into())
+}
 
 /// StoredCommitment is a versioned, encrypted, borsh-serialized commitment
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
@@ -245,11 +353,13 @@ pub struct PocketDB {
     proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
     counter_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
     commitment_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+    foreign_mint_proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
     keys: bitcoin::secp256k1::Keypair,
 }
 
 impl PocketDB {
     const PROOF_BASE_DB_NAME: &'static str = "proofs";
+    const FOREIGN_MINT_PROOF_BASE_DB_NAME: &'static str = "foreign_mint_proofs";
     const COUNTER_BASE_DB_NAME: &'static str = "counters";
     const COMMITMENT_BASE_DB_NAME: &'static str = "commitments";
 
@@ -265,6 +375,13 @@ impl PocketDB {
         format!("{wallet_id}_{unit}_{}", Self::COMMITMENT_BASE_DB_NAME)
     }
 
+    pub fn foreign_mint_proof_table_name(wallet_id: &str, unit: &CurrencyUnit) -> String {
+        format!(
+            "{wallet_id}_{unit}_{}",
+            Self::FOREIGN_MINT_PROOF_BASE_DB_NAME
+        )
+    }
+
     pub fn new(
         db: Arc<Database>,
         wallet_id: &str,
@@ -278,15 +395,20 @@ impl PocketDB {
             Box::leak(Self::counter_table_name(wallet_id, unit).into_boxed_str());
         let commitment_name: &'static str =
             Box::leak(Self::commitment_table_name(wallet_id, unit).into_boxed_str());
+        let foreign_mint_proof_name: &'static str =
+            Box::leak(Self::foreign_mint_proof_table_name(wallet_id, unit).into_boxed_str());
 
         let proof_table = TableDefinition::new(proof_name);
         let counter_table = TableDefinition::new(counter_name);
         let commitment_table = TableDefinition::new(commitment_name);
+        let foreign_mint_proof_table = TableDefinition::new(foreign_mint_proof_name);
+
         Ok(Self {
             db,
             proof_table,
             counter_table,
             commitment_table,
+            foreign_mint_proof_table,
             keys,
         })
     }
@@ -686,11 +808,78 @@ impl PocketDB {
         Ok(())
     }
 
+    fn store_foreign_mint_proof_sync(
+        db: Arc<Database>,
+        foreign_mint_proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        keys: bitcoin::secp256k1::Keypair,
+        foreign_mint_proof: ForeignMintProof,
+    ) -> Result<cdk01::PublicKey> {
+        let y = foreign_mint_proof.proof.y().expect("valid y");
+        let key = foreign_mint_proof_key(&foreign_mint_proof.clowder_id, &y);
+        let entry = to_stored_foreign_mint_proof_v1(foreign_mint_proof, keys)?;
+        let write_txn = db.begin_write()?;
+
+        {
+            let mut table = write_txn.open_table(foreign_mint_proof_table)?;
+            let serialized =
+                borsh::to_vec(&entry).map_err(|e| Error::BorshSerialization(e.to_string()))?;
+            table.insert(key.as_slice(), serialized)?;
+        }
+
+        write_txn.commit()?;
+        Ok(y)
+    }
+
+    fn load_foreign_mint_proofs_sync(
+        db: Arc<Database>,
+        foreign_mint_proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        keys: bitcoin::secp256k1::Keypair,
+    ) -> Result<Vec<ForeignMintProof>> {
+        let read_txn = db.begin_read()?;
+        match read_txn.open_table(foreign_mint_proof_table) {
+            Ok(table) => {
+                let mut res = Vec::new();
+                for item in table.range::<&[u8]>(..)? {
+                    let (_, v) = item?;
+                    let deserialized: StoredForeignMintProof =
+                        borsh::from_slice(v.value().as_slice())
+                            .map_err(|e| Error::BorshSerialization(e.to_string()))?;
+                    let fmp = from_stored_foreign_mint_proof_v1(deserialized, keys)?;
+                    res.push(fmp)
+                }
+                Ok(res)
+            }
+            Err(TableError::TableDoesNotExist(_)) => Ok(vec![]),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn delete_foreign_mint_proofs_sync(
+        db: Arc<Database>,
+        foreign_mint_proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        clowder_id: secp256k1::PublicKey,
+        ys: Vec<cdk01::PublicKey>,
+    ) -> Result<()> {
+        let write_txn = db.begin_write()?;
+
+        {
+            let mut table = write_txn.open_table(foreign_mint_proof_table)?;
+            for y in ys.iter() {
+                let key = foreign_mint_proof_key(&clowder_id, y);
+                table.remove(key.as_slice())?;
+            }
+        }
+
+        write_txn.commit()?;
+        Ok(())
+    }
+
     fn delete_repo(
         db: Arc<Database>,
         proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
         commitment_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
         counter_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
+        foreign_mint_proof_table: TableDefinition<'static, &'static [u8], Vec<u8>>,
     ) -> Result<()> {
         let write_txn = db.begin_write()?;
 
@@ -705,6 +894,10 @@ impl PocketDB {
 
             if write_txn.open_table(counter_table).is_ok() {
                 write_txn.delete_table(counter_table)?;
+            }
+
+            if write_txn.open_table(foreign_mint_proof_table).is_ok() {
+                write_txn.delete_table(foreign_mint_proof_table)?;
             }
         }
 
@@ -959,10 +1152,55 @@ impl PocketRepository for PocketDB {
         let proof_table = self.proof_table;
         let commitment_table = self.commitment_table;
         let counter_table = self.counter_table;
+        let foreign_mint_proof_table = self.foreign_mint_proof_table;
         spawn_blocking(move || {
-            Self::delete_repo(db_clone, proof_table, commitment_table, counter_table)
+            Self::delete_repo(
+                db_clone,
+                proof_table,
+                commitment_table,
+                counter_table,
+                foreign_mint_proof_table,
+            )
         })
         .await?
+    }
+
+    async fn store_foreign_mint_proof(
+        &self,
+        foreign_mint_proof: ForeignMintProof,
+    ) -> Result<cdk01::PublicKey> {
+        let db_clone = self.db.clone();
+        let table = self.foreign_mint_proof_table;
+        let keys = self.keys;
+        let y = spawn_blocking(move || {
+            Self::store_foreign_mint_proof_sync(db_clone, table, keys, foreign_mint_proof)
+        })
+        .await??;
+        Ok(y)
+    }
+
+    async fn load_foreign_mint_proofs(&self) -> Result<Vec<ForeignMintProof>> {
+        let db_clone = self.db.clone();
+        let table = self.foreign_mint_proof_table;
+        let keys = self.keys;
+        let res =
+            spawn_blocking(move || Self::load_foreign_mint_proofs_sync(db_clone, table, keys))
+                .await??;
+        Ok(res)
+    }
+
+    async fn delete_foreign_mint_proofs(
+        &self,
+        clowder_id: secp256k1::PublicKey,
+        ys: Vec<cdk01::PublicKey>,
+    ) -> Result<()> {
+        let db_clone = self.db.clone();
+        let table = self.foreign_mint_proof_table;
+        spawn_blocking(move || {
+            Self::delete_foreign_mint_proofs_sync(db_clone, table, clowder_id, ys)
+        })
+        .await??;
+        Ok(())
     }
 }
 
@@ -1175,5 +1413,168 @@ mod tests {
             .await
             .expect("delete_commitment works");
         assert!(repo.load_commitment(sig).await.is_err());
+    }
+
+    fn test_clowder_id() -> secp256k1::PublicKey {
+        let keypair = secp256k1::Keypair::new_global(&mut secp256k1::rand::thread_rng());
+
+        secp256k1::PublicKey::from_keypair(&keypair)
+    }
+
+    #[tokio::test]
+    async fn test_store_foreign_mint_proof() {
+        let repo = get_db(&wallet_id(), CurrencyUnit::Sat);
+
+        let clowder_id = test_clowder_id();
+        let proof = test_proof();
+        let expected_y = proof.y().expect("proof has valid y");
+
+        let stored_y = repo
+            .store_foreign_mint_proof(ForeignMintProof {
+                clowder_id,
+                proof: proof.clone(),
+                reason: ForeignMintProofReason::MintOffline,
+            })
+            .await
+            .expect("store_foreign_mint_proof works");
+        assert_eq!(stored_y, expected_y);
+
+        let loaded = repo
+            .load_foreign_mint_proofs()
+            .await
+            .expect("load_foreign_mint_proofs works");
+        assert_eq!(loaded.len(), 1);
+
+        let stored = &loaded[0];
+        assert_eq!(stored.clowder_id, clowder_id);
+        assert_eq!(stored.proof, proof);
+        assert!(matches!(stored.reason, ForeignMintProofReason::MintOffline));
+    }
+
+    #[tokio::test]
+    async fn test_load_foreign_mint_proofs() {
+        let repo = get_db(&wallet_id(), CurrencyUnit::Sat);
+
+        let clowder_id_a = test_clowder_id();
+        let clowder_id_b = test_clowder_id();
+
+        let proof_a1 = test_proof();
+        let proof_a2 = test_proof();
+        let proof_b1 = test_proof();
+
+        repo.store_foreign_mint_proof(ForeignMintProof {
+            clowder_id: clowder_id_a,
+            proof: proof_a1.clone(),
+            reason: ForeignMintProofReason::MintOffline,
+        })
+        .await
+        .expect("store first foreign mint proof");
+
+        repo.store_foreign_mint_proof(ForeignMintProof {
+            clowder_id: clowder_id_a,
+            proof: proof_a2.clone(),
+            reason: ForeignMintProofReason::WalletOffline,
+        })
+        .await
+        .expect("store second foreign mint proof");
+
+        repo.store_foreign_mint_proof(ForeignMintProof {
+            clowder_id: clowder_id_b,
+            proof: proof_b1.clone(),
+            reason: ForeignMintProofReason::MintOffline,
+        })
+        .await
+        .expect("store third foreign mint proof");
+
+        let loaded = repo
+            .load_foreign_mint_proofs()
+            .await
+            .expect("load_foreign_mint_proofs works");
+
+        assert_eq!(loaded.len(), 3);
+        assert!(loaded.iter().any(|entry| {
+            entry.clowder_id == clowder_id_a
+                && entry.proof == proof_a1
+                && matches!(entry.reason, ForeignMintProofReason::MintOffline)
+        }));
+        assert!(loaded.iter().any(|entry| {
+            entry.clowder_id == clowder_id_a
+                && entry.proof == proof_a2
+                && matches!(entry.reason, ForeignMintProofReason::WalletOffline)
+        }));
+        assert!(loaded.iter().any(|entry| {
+            entry.clowder_id == clowder_id_b
+                && entry.proof == proof_b1
+                && matches!(entry.reason, ForeignMintProofReason::MintOffline)
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_delete_foreign_mint_proof() {
+        let repo = get_db(&wallet_id(), CurrencyUnit::Sat);
+
+        let clowder_id_a = test_clowder_id();
+        let clowder_id_b = test_clowder_id();
+
+        let proof = test_proof();
+        let y = proof.y().unwrap();
+        let proof_2 = test_proof();
+        let y_2 = proof_2.y().unwrap();
+
+        repo.store_foreign_mint_proof(ForeignMintProof {
+            clowder_id: clowder_id_a,
+            proof: proof.clone(),
+            reason: ForeignMintProofReason::MintOffline,
+        })
+        .await
+        .expect("store proof for first clowder");
+
+        repo.store_foreign_mint_proof(ForeignMintProof {
+            clowder_id: clowder_id_a,
+            proof: proof_2.clone(),
+            reason: ForeignMintProofReason::MintOffline,
+        })
+        .await
+        .expect("store proof_2 for first clowder");
+
+        repo.store_foreign_mint_proof(ForeignMintProof {
+            clowder_id: clowder_id_b,
+            proof: proof.clone(),
+            reason: ForeignMintProofReason::WalletOffline,
+        })
+        .await
+        .expect("store proof for second clowder");
+
+        let loaded = repo
+            .load_foreign_mint_proofs()
+            .await
+            .expect("load before delete");
+        assert_eq!(loaded.len(), 3);
+
+        repo.delete_foreign_mint_proofs(clowder_id_a, vec![y, y_2])
+            .await
+            .expect("delete_foreign_mint_proofs works");
+
+        let loaded = repo
+            .load_foreign_mint_proofs()
+            .await
+            .expect("load after delete");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].clowder_id, clowder_id_b);
+        assert_eq!(loaded[0].proof, proof);
+        assert!(matches!(
+            loaded[0].reason,
+            ForeignMintProofReason::WalletOffline
+        ));
+
+        repo.delete_foreign_mint_proofs(clowder_id_b, vec![y])
+            .await
+            .expect("delete remaining foreign mint proof");
+
+        let loaded = repo
+            .load_foreign_mint_proofs()
+            .await
+            .expect("load after deleting all records");
+        assert!(loaded.is_empty());
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wallet_ffi
 description: "Wallet FFI"
-version: 0.9.9
+version: 0.9.10
 homepage:
 
 environment:


### PR DESCRIPTION
* Up to 0.9.10
* Store change from offline-tokens into a temporary-foreign-mint-proof-storage
  * these foreign-mint-proofs are regularly attempted to reclaim in a job
