### PR TITLE
Fix Melt URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.9.12
 
 * Fix `wallet_subscribe_to_payment_requests` holding on to it's read-lock during the whole period
+* Fix melt URL after migrate rabid (#302)
 
 # 0.9.11
 

--- a/crates/bcr-wallet-api/src/external/mint.rs
+++ b/crates/bcr-wallet-api/src/external/mint.rs
@@ -491,7 +491,7 @@ impl ClowderMintConnector for HttpClientExt {
     ) -> Result<wire_melt::MeltOnchainResponse> {
         let url = self
             .mint_url()
-            .join("v1/melt/onchain")
+            .join(TreasuryEp::MELT_ONCHAIN_V1_EXT)
             .expect("melt_onchain url error");
         debug!("HTTP call to melt_onchain on {url}");
 


### PR DESCRIPTION
After migrate rabid (before an app restart), the client had the wrong URL.

Relates to #302 